### PR TITLE
Add IActionDispatcherProvider type

### DIFF
--- a/src/base/actions/action-dispatcher.ts
+++ b/src/base/actions/action-dispatcher.ts
@@ -111,3 +111,5 @@ export interface PostponedAction {
     resolve: () => void
     reject: (reason: any) => void
 }
+
+export type IActionDispatcherProvider = () => Promise<IActionDispatcher>;


### PR DESCRIPTION
The IActionDispatcherProvider type has been missing, however, it is available in the DI container. Thus, to make it easier for clients to obtain the action dispatcher via a provider, this change adds and exports the corresponding type.

Signed-off-by: Philip Langer <planger@eclipsesource.com>