### PR TITLE
Add support for a command palette (#34)

### DIFF
--- a/css/command-palette.css
+++ b/css/command-palette.css
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+.command-palette {
+    transition: opacity 0.3s linear;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+}
+
+.command-palette-suggestions {
+    background: white;
+    z-index: 1000;
+    overflow: auto;
+    box-sizing: border-box;
+    border: 1px solid rgba(60, 60, 60, 0.6);
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+}
+
+.command-palette-suggestions * {
+    font: inherit;
+}
+
+.command-palette-suggestions > div {
+    padding: 0 4px;
+}
+
+.command-palette-suggestions .group {
+    background: #eee;
+}
+
+.command-palette-suggestions > div:hover:not(.group),
+.command-palette-suggestions > div.selected {
+    cursor: pointer;
+}
+
+.command-palette-suggestions > div:hover:not(.group) {
+    background: #e0e0e0;
+}
+.command-palette-suggestions > div.selected {
+    background: #bbdefb;
+}

--- a/examples/classdiagram/src/di.config.ts
+++ b/examples/classdiagram/src/di.config.ts
@@ -21,7 +21,8 @@ import {
     viewportModule, hoverModule, HtmlRootView, PreRenderedView, exportModule, expandModule,
     fadeModule, ExpandButtonView, buttonModule, edgeEditModule, SRoutingHandleView, PreRenderedElement,
     HtmlRoot, SGraph, configureModelElement, SLabel, SCompartment, SEdge, SButton, SRoutingHandle,
-    edgeLayoutModule, updateModule, graphModule, routingModule, modelSourceModule
+    edgeLayoutModule, updateModule, graphModule, routingModule, modelSourceModule, commandPaletteModule,
+    RevealNamedElementActionProvider
 } from "../../../src";
 import { ClassNodeView, IconView} from "./views";
 import { PopupModelProvider } from "./popup";
@@ -30,6 +31,7 @@ import { Icon, ClassNode } from "./model";
 
 export default (useWebsocket: boolean, containerId: string) => {
     require("../../../css/sprotty.css");
+    require("../../../css/command-palette.css");
     require("../css/diagram.css");
     const classDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => {
         if (useWebsocket)
@@ -39,6 +41,7 @@ export default (useWebsocket: boolean, containerId: string) => {
         rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
         rebind(TYPES.LogLevel).toConstantValue(LogLevel.log);
         bind(TYPES.IPopupModelProvider).to(PopupModelProvider);
+        bind(TYPES.ICommandPaletteActionProvider).to(RevealNamedElementActionProvider);
         const context = { bind, unbind, isBound, rebind };
         configureModelElement(context, 'graph', SGraph, SGraphView);
         configureModelElement(context, 'node:class', ClassNode, ClassNodeView);
@@ -64,6 +67,6 @@ export default (useWebsocket: boolean, containerId: string) => {
     container.load(defaultModule, selectModule, moveModule, boundsModule, undoRedoModule,
         viewportModule, fadeModule, hoverModule, exportModule, expandModule, buttonModule,
         updateModule, graphModule, routingModule, edgeEditModule, edgeLayoutModule,
-        modelSourceModule, classDiagramModule);
+        modelSourceModule, commandPaletteModule, classDiagramModule);
     return container;
 };

--- a/examples/classdiagram/src/model.ts
+++ b/examples/classdiagram/src/model.ts
@@ -16,14 +16,15 @@
 
 import {
     SShapeElement, Expandable, boundsFeature, expandFeature, fadeFeature, layoutContainerFeature,
-    layoutableChildFeature, RectangularNode
+    layoutableChildFeature, RectangularNode, Nameable, nameFeature
 } from "../../../src";
 
-export class ClassNode extends RectangularNode implements Expandable {
+export class ClassNode extends RectangularNode implements Expandable, Nameable {
     expanded: boolean = false;
+    name: string = '';
 
     hasFeature(feature: symbol) {
-        return feature === expandFeature || super.hasFeature(feature);
+        return feature === expandFeature || feature === nameFeature || super.hasFeature(feature);
     }
 }
 

--- a/examples/classdiagram/src/model.ts
+++ b/examples/classdiagram/src/model.ts
@@ -16,12 +16,22 @@
 
 import {
     SShapeElement, Expandable, boundsFeature, expandFeature, fadeFeature, layoutContainerFeature,
-    layoutableChildFeature, RectangularNode, Nameable, nameFeature
+    layoutableChildFeature, RectangularNode, Nameable, nameFeature, SLabel
 } from "../../../src";
 
 export class ClassNode extends RectangularNode implements Expandable, Nameable {
     expanded: boolean = false;
-    name: string = '';
+
+    get name() {
+        const headerComp = this.children.find(element => element.type === 'comp:header');
+        if (headerComp) {
+            const label = headerComp.children.find(element => element.type === 'label:heading');
+            if (label && label instanceof SLabel) {
+                return label.text;
+            }
+        }
+        return this.id;
+    }
 
     hasFeature(feature: symbol) {
         return feature === expandFeature || feature === nameFeature || super.hasFeature(feature);

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "inversify": "^4.3.0",
     "snabbdom": "^0.7.0",
     "snabbdom-jsx": "^0.4.2",
-    "snabbdom-virtualize": "^0.7.0"
+    "snabbdom-virtualize": "^0.7.0",
+    "autocompleter": "^4.0.2"
   },
   "devDependencies": {
     "@types/chai": "^4.0.1",

--- a/src/base/di.config.ts
+++ b/src/base/di.config.ts
@@ -37,7 +37,7 @@ import { configureCommand, CommandActionHandlerInitializer } from "./commands/c
 import { CssClassDecorator } from "./views/css-class-decorator";
 import { ToolManager, DefaultToolsEnablingKeyListener, ToolManagerActionHandlerInitializer } from "./tool-manager/tool-manager";
 import { SetModelCommand } from "./features/set-model";
-import { UIExtensionRegistry, UIExtensionActionHandlerInitializer } from "./ui-extensions/ui-extension-registry";
+import { UIExtensionRegistry, SetUIExtensionVisibilityCommand } from "./ui-extensions/ui-extension-registry";
 
 const defaultContainerModule = new ContainerModule((bind, _unbind, isBound) => {
     // Logging ---------------------------------------------
@@ -144,7 +144,7 @@ const defaultContainerModule = new ContainerModule((bind, _unbind, isBound) => {
 
     // UIExtension registry initialization ------------------------------------
     bind(TYPES.UIExtensionRegistry).to(UIExtensionRegistry).inSingletonScope();
-    bind(TYPES.IActionHandlerInitializer).to(UIExtensionActionHandlerInitializer);
+    configureCommand({ bind, isBound }, SetUIExtensionVisibilityCommand);
 });
 
 export default defaultContainerModule;

--- a/src/base/di.config.ts
+++ b/src/base/di.config.ts
@@ -37,6 +37,7 @@ import { configureCommand, CommandActionHandlerInitializer } from "./commands/c
 import { CssClassDecorator } from "./views/css-class-decorator";
 import { ToolManager, DefaultToolsEnablingKeyListener, ToolManagerActionHandlerInitializer } from "./tool-manager/tool-manager";
 import { SetModelCommand } from "./features/set-model";
+import { UIExtensionRegistry, UIExtensionActionHandlerInitializer } from "./ui-extensions/ui-extension-registry";
 
 const defaultContainerModule = new ContainerModule((bind, _unbind, isBound) => {
     // Logging ---------------------------------------------
@@ -140,6 +141,10 @@ const defaultContainerModule = new ContainerModule((bind, _unbind, isBound) => {
     bind(TYPES.IToolManager).to(ToolManager).inSingletonScope();
     bind(TYPES.KeyListener).to(DefaultToolsEnablingKeyListener);
     bind(TYPES.IActionHandlerInitializer).to(ToolManagerActionHandlerInitializer);
+
+    // UIExtension registry initialization ------------------------------------
+    bind(TYPES.UIExtensionRegistry).to(UIExtensionRegistry).inSingletonScope();
+    bind(TYPES.IActionHandlerInitializer).to(UIExtensionActionHandlerInitializer);
 });
 
 export default defaultContainerModule;

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -56,5 +56,7 @@ export const TYPES = {
     IVNodeDecorator: Symbol('IVNodeDecorator'),
     IToolManager: Symbol('IToolManager'),
     IUIExtension: Symbol('IUIExtension'),
-    UIExtensionRegistry: Symbol('UIExtensionRegistry')
+    UIExtensionRegistry: Symbol('UIExtensionRegistry'),
+    ICommandPaletteActionProviderRegistry: Symbol('ICommandPaletteActionProviderRegistry'),
+    ICommandPaletteActionProvider: Symbol('ICommandPaletteActionProvider')
 };

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -54,5 +54,7 @@ export const TYPES = {
     ViewRegistration: Symbol('ViewRegistration'),
     ViewRegistry: Symbol('ViewRegistry'),
     IVNodeDecorator: Symbol('IVNodeDecorator'),
-    IToolManager: Symbol('IToolManager')
+    IToolManager: Symbol('IToolManager'),
+    IUIExtension: Symbol('IUIExtension'),
+    UIExtensionRegistry: Symbol('UIExtensionRegistry')
 };

--- a/src/base/ui-extensions/ui-extension-registry.ts
+++ b/src/base/ui-extensions/ui-extension-registry.ts
@@ -1,0 +1,112 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { inject, injectable, multiInject, optional } from "inversify";
+import { InstanceRegistry } from "../../utils/registry";
+import { Action } from "../actions/action";
+import { ActionHandlerRegistry, IActionHandler, IActionHandlerInitializer } from "../actions/action-handler";
+import { CommandExecutionContext, CommandResult, ICommand, SystemCommand } from "../commands/command";
+import { TYPES } from "../types";
+import { IUIExtension } from "./ui-extension";
+
+/**
+ * Action requesting to show the UI extension with the specified `id`.
+ */
+export class ShowUIExtensionAction implements Action {
+    static KIND = "showUIExtension";
+    readonly kind = ShowUIExtensionAction.KIND;
+    constructor(public readonly extensionId: string) { }
+}
+
+/**
+ * Action requesting to hide the UI extension with the specified `id`.
+ */
+export class HideUIExtensionAction implements Action {
+    static KIND = "hideUIExtension";
+    readonly kind = HideUIExtensionAction.KIND;
+    constructor(public readonly extensionId: string) { }
+}
+
+/**
+ * The registry maintaining UI extensions registered via `TYPES.IUIExtension`.
+ */
+@injectable()
+export class UIExtensionRegistry extends InstanceRegistry<IUIExtension>  {
+    constructor(@multiInject(TYPES.IUIExtension) @optional() extensions: (IUIExtension)[] = []) {
+        super();
+        extensions.forEach((extension) => this.register(extension.id, extension));
+    }
+}
+
+/**
+ * Initalizer and handler for actions related to UI extensions.
+ */
+@injectable()
+export class UIExtensionActionHandlerInitializer implements IActionHandlerInitializer, IActionHandler {
+
+    @inject(TYPES.UIExtensionRegistry) protected readonly registry: UIExtensionRegistry;
+
+    initialize(registry: ActionHandlerRegistry): void {
+        registry.register(ShowUIExtensionAction.KIND, this);
+        registry.register(HideUIExtensionAction.KIND, this);
+    }
+
+    handle(action: Action): void | ICommand | Action {
+        if (action instanceof ShowUIExtensionAction) {
+            return new UIExtensionActionCommand((context) => {
+                this.withExtension(action.extensionId, (extension) => {
+                    extension.show(context);
+                });
+            });
+        } else if (action instanceof HideUIExtensionAction) {
+            return new UIExtensionActionCommand((context) => {
+                this.withExtension(action.extensionId, (extension) => {
+                    extension.hide();
+                });
+            });
+        }
+    }
+
+    protected withExtension(extensionId: string, func: (extension: IUIExtension) => void) {
+        const extension = this.registry.get(extensionId);
+        if (extension) {
+            func(extension);
+        }
+    }
+}
+
+/**
+ * A system command that doesn't change the model but just performs a specified `effect`.
+ */
+@injectable()
+export class UIExtensionActionCommand extends SystemCommand {
+
+    constructor(readonly effect: (context: CommandExecutionContext) => void) {
+        super();
+    }
+
+    execute(context: CommandExecutionContext): CommandResult {
+        this.effect(context);
+        return context.root;
+    }
+
+    undo(context: CommandExecutionContext): CommandResult {
+        return context.root;
+    }
+
+    redo(context: CommandExecutionContext): CommandResult {
+        return context.root;
+    }
+}

--- a/src/base/ui-extensions/ui-extension.ts
+++ b/src/base/ui-extensions/ui-extension.ts
@@ -1,0 +1,120 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { inject, injectable } from "inversify";
+import { ILogger } from "../../utils/logging";
+import { CommandExecutionContext } from "../commands/command";
+import { TYPES } from "../types";
+import { ViewerOptions } from "../views/viewer-options";
+
+/**
+ * A UI extension displaying additional UI elements on top of a sprotty diagram.
+ */
+export interface IUIExtension {
+    readonly id: string;
+    show(context: CommandExecutionContext): void;
+    hide(): void;
+}
+
+/**
+ * Abstract base class for UI extensions.
+ */
+@injectable()
+export abstract class AbstractUIExtension implements IUIExtension {
+
+    abstract readonly id: string;
+    abstract readonly containerClass: string;
+    protected containerElement: HTMLElement;
+    protected activeElement: Element | null;
+
+    constructor(
+        @inject(TYPES.ViewerOptions) protected options: ViewerOptions,
+        @inject(TYPES.ILogger) protected logger: ILogger) { }
+
+    show(context: CommandExecutionContext): void {
+        this.activeElement = document.activeElement;
+        if (!this.containerElement) {
+            if (!this.initialize()) return;
+        }
+        this.updateBeforeBecomingVisible(this.containerElement, context);
+        this.setContainerVisible(true);
+    }
+
+    hide(): void {
+        this.setContainerVisible(false);
+        this.restoreFocus();
+        this.activeElement = null;
+    }
+
+    protected restoreFocus() {
+        const focusedElement = this.activeElement as HTMLElement;
+        if (focusedElement) {
+            focusedElement.focus();
+        }
+    }
+
+    protected initialize(): boolean {
+        const baseDiv = document.getElementById(this.options.baseDiv);
+        if (!baseDiv) {
+            this.logger.warn(this, `Could not obtain sprotty base container for initializing UI extension ${this.id}`, this);
+            return false;
+        }
+        this.containerElement = this.getOrCreateContainer(baseDiv.id);
+        this.initializeUIExtension(this.containerElement);
+        if (baseDiv) {
+            baseDiv.insertBefore(this.containerElement, baseDiv.firstChild);
+        }
+        return true;
+    }
+
+    protected getOrCreateContainer(baseDivId: string): HTMLElement {
+        let container = document.getElementById(this.id);
+        if (container === null) {
+            container = document.createElement('div');
+            container.id = baseDivId + "_" + this.id;
+            container.classList.add(this.containerClass);
+        }
+        return container;
+    }
+
+    protected setContainerVisible(value: boolean) {
+        if (this.containerElement) {
+            if (value) {
+                this.containerElement.style.visibility = 'visible';
+                this.containerElement.style.opacity = '1';
+            } else {
+                this.containerElement.style.visibility = 'hidden';
+                this.containerElement.style.opacity = '0';
+            }
+        }
+    }
+
+    /**
+     * Updates the `containerElement` under the given `context` before it becomes visible.
+     *
+     * Subclasses may override this method to, for instance, modfying the position of the
+     * `containerElement`, add or remove elements, etc. depending on the specified `context`.
+     */
+    protected updateBeforeBecomingVisible(containerElement: HTMLElement, context: CommandExecutionContext): void {
+        // default: do nothing
+    }
+
+    /**
+     * Initializes the contents of this UI extension.
+     *
+     * Subclasses must implement this method to initialize the UI elements of this UI extension inside the specified `containerElement`.
+     */
+    protected abstract initializeUIExtension(containerElement: HTMLElement): void;
+}

--- a/src/base/ui-extensions/ui-extension.ts
+++ b/src/base/ui-extensions/ui-extension.ts
@@ -102,7 +102,7 @@ export abstract class AbstractUIExtension implements IUIExtension {
     /**
      * Updates the `containerElement` under the given `context` before it becomes visible.
      *
-     * Subclasses may override this method to, for instance, modfying the position of the
+     * Subclasses may override this method to, for instance, modifying the position of the
      * `containerElement`, add or remove elements, etc. depending on the specified `root`.
      */
     protected onBeforeShow(containerElement: HTMLElement, root: Readonly<SModelRoot>): void {

--- a/src/features/command-palette/action-providers.ts
+++ b/src/features/command-palette/action-providers.ts
@@ -1,0 +1,67 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { inject, injectable, multiInject, optional } from "inversify";
+import { Action } from "../../base/actions/action";
+import { CommandExecutionContext } from "../../base/commands/command";
+import { SModelRoot } from "../../base/model/smodel";
+import { TYPES } from "../../base/types";
+import { toArray } from "../../utils/iterable";
+import { ILogger } from "../../utils/logging";
+import { isNameable, name } from "../nameable/model";
+import { CenterAction } from "../viewport/center-fit";
+import { SelectAction } from "../select/select";
+
+export interface ICommandPaletteActionProvider {
+    getActions(context: CommandExecutionContext): Promise<LabeledAction[]>;
+}
+
+export type ICommandPaletteActionProviderRegistry = () => Promise<ICommandPaletteActionProvider>;
+
+@injectable()
+export class CommandPaletteActionProviderRegistry implements ICommandPaletteActionProvider {
+    public actionProvider: ICommandPaletteActionProvider[] = [];
+
+    constructor(@multiInject(TYPES.ICommandPaletteActionProvider) @optional() protected registeredActionProviders: ICommandPaletteActionProvider[] = []) {
+        for (const registeredProvider of registeredActionProviders) {
+            this.actionProvider.push(registeredProvider);
+        }
+    }
+
+    getActions(context: CommandExecutionContext): Promise<LabeledAction[]> {
+        const actionLists = this.actionProvider.map(provider => provider.getActions(context));
+        return Promise.all(actionLists).then(p => p.reduce((acc, promise) => acc.concat(promise)));
+    }
+}
+
+export class LabeledAction {
+    constructor(readonly label: string, readonly actions: Action[]) { }
+}
+
+@injectable()
+export class RevealNamedElementActionProvider implements ICommandPaletteActionProvider {
+
+    constructor(@inject(TYPES.ILogger) protected logger: ILogger) { }
+
+    getActions(context: CommandExecutionContext): Promise<LabeledAction[]> {
+        return Promise.resolve(this.createSelectActions(context.root));
+    }
+
+    createSelectActions(modelRoot: SModelRoot): LabeledAction[] {
+        const nameables = toArray(modelRoot.index.all().filter(element => isNameable(element)));
+        return nameables.map(nameable => new LabeledAction(`Reveal ${name(nameable)}`,
+            [new SelectAction([nameable.id]), new CenterAction([nameable.id])]));
+    }
+}

--- a/src/features/command-palette/action-providers.ts
+++ b/src/features/command-palette/action-providers.ts
@@ -42,12 +42,18 @@ export class CommandPaletteActionProviderRegistry implements ICommandPaletteActi
 
     getActions(context: CommandExecutionContext): Promise<LabeledAction[]> {
         const actionLists = this.actionProvider.map(provider => provider.getActions(context));
-        return Promise.all(actionLists).then(p => p.reduce((acc, promise) => acc.concat(promise)));
+        return Promise.all(actionLists).then(p => p.reduce((acc, promise) => promise !== undefined ? acc.concat(promise): acc));
     }
 }
 
 export class LabeledAction {
     constructor(readonly label: string, readonly actions: Action[]) { }
+}
+
+export function isLabeledAction(element: any): element is LabeledAction {
+    return element !== undefined
+        && (<LabeledAction>element).label !== undefined
+        && (<LabeledAction>element).actions !== undefined;
 }
 
 @injectable()

--- a/src/features/command-palette/command-palette.ts
+++ b/src/features/command-palette/command-palette.ts
@@ -1,0 +1,167 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { AutocompleteResult, AutocompleteSettings } from "autocompleter";
+import { inject, injectable } from "inversify";
+import { Action, isAction } from "../../base/actions/action";
+import { IActionDispatcherProvider } from "../../base/actions/action-dispatcher";
+import { CommandExecutionContext } from "../../base/commands/command";
+import { SModelElement } from "../../base/model/smodel";
+import { findParentByFeature } from "../../base/model/smodel-utils";
+import { TYPES } from "../../base/types";
+import { AbstractUIExtension } from "../../base/ui-extensions/ui-extension";
+import { HideUIExtensionAction, ShowUIExtensionAction } from "../../base/ui-extensions/ui-extension-registry";
+import { KeyListener } from "../../base/views/key-tool";
+import { ViewerOptions } from "../../base/views/viewer-options";
+import { toArray } from "../../utils/iterable";
+import { matchesKeystroke } from "../../utils/keyboard";
+import { ILogger } from "../../utils/logging";
+import { isBoundsAware } from "../bounds/model";
+import { isSelectable } from "../select/model";
+import { isViewport } from "../viewport/model";
+import { ICommandPaletteActionProviderRegistry, LabeledAction } from "./action-providers";
+
+
+// import of function autocomplete(...) doesn't work
+// see also https://github.com/kraaden/autocomplete/issues/13
+// this is a workaround to still get the function including type support
+const configureAutocomplete: (settings: AutocompleteSettings<LabeledAction>) => AutocompleteResult = require("autocompleter");
+
+@injectable()
+export class CommandPalette extends AbstractUIExtension {
+    static readonly ID = "command-palette";
+    readonly id = CommandPalette.ID;
+
+    readonly containerClass = "command-palette";
+    readonly xOffset = 20;
+    readonly yOffset = 30;
+    readonly defaultWidth = 400;
+
+    protected inputElement: HTMLInputElement;
+    protected autoCompleteResult: AutocompleteResult;
+
+    constructor(
+        @inject(TYPES.ViewerOptions) protected options: ViewerOptions,
+        @inject(TYPES.IActionDispatcherProvider) protected actionDispatcherProvider: IActionDispatcherProvider,
+        @inject(TYPES.ICommandPaletteActionProviderRegistry) protected actionProvider: ICommandPaletteActionProviderRegistry,
+        @inject(TYPES.ILogger) protected logger: ILogger) {
+        super(options, logger);
+    }
+
+    show(context: CommandExecutionContext) {
+        super.show(context);
+        if (this.inputElement.value) {
+            this.inputElement.setSelectionRange(0, this.inputElement.value.length);
+        }
+        this.autoCompleteResult = configureAutocomplete(this.autocompleteSettings(context));
+        this.inputElement.focus();
+    }
+
+    protected initializeUIExtension(containerElement: HTMLElement) {
+        containerElement.style.position = "absolute";
+        this.inputElement = document.createElement('input');
+        this.inputElement.style.width = '100%';
+        containerElement.appendChild(this.inputElement);
+        this.inputElement.onblur = () => window.setTimeout(() => this.hide(), 200);
+    }
+
+    protected updateBeforeBecomingVisible(containerElement: HTMLElement, context: CommandExecutionContext) {
+        let x = this.xOffset;
+        let y = this.yOffset;
+        const selectedElements = toArray(context.root.index.all().filter(e => isSelectable(e) && e.selected));
+        if (selectedElements.length === 1) {
+            const firstElement = selectedElements[0];
+            if (isBoundsAware(firstElement)) {
+                const viewport = findParentByFeature(firstElement, isViewport);
+                if (viewport) {
+                    x += (firstElement.bounds.x - viewport.scroll.x) * viewport.zoom;
+                    y += (firstElement.bounds.y - viewport.scroll.y) * viewport.zoom;
+                } else {
+                    x += firstElement.bounds.x;
+                    y += firstElement.bounds.y;
+                }
+            }
+        }
+        containerElement.style.left = `${x}px`;
+        containerElement.style.top = `${y}px`;
+        containerElement.style.width = `${this.defaultWidth}px`;
+    }
+
+    private autocompleteSettings(context: CommandExecutionContext): AutocompleteSettings<LabeledAction> {
+        return {
+            input: this.inputElement,
+            emptyMsg: "No commands available",
+            className: "command-palette-suggestions",
+            minLength: -1,
+            fetch: (text: string, update: (items: LabeledAction[]) => void) => {
+                this.actionProvider()
+                    .then(provider => provider.getActions(context))
+                    .then(actions => update(this.filterActions(text, actions)))
+                    .catch((reason) => this.logger.error(this, "Failed to obtain actions from command palette action providers", reason));
+            },
+            onSelect: (item: LabeledAction) => {
+                this.executeAction(item);
+                this.hide();
+            },
+            customize: (input: HTMLInputElement, inputRect: ClientRect | DOMRect, container: HTMLDivElement, maxHeight: number) => {
+                // move container into our command palette container as this is already positioned correctly
+                if (this.containerElement) {
+                    this.containerElement.appendChild(container);
+                }
+            }
+        };
+    }
+
+    protected filterActions(filterText: string, actions: LabeledAction[]): LabeledAction[] {
+        return toArray(actions.filter(action => {
+            const label = action.label.toLowerCase();
+            const searchWords = filterText.split(' ');
+            return searchWords.every(word => label.indexOf(word.toLowerCase()) !== -1);
+        }));
+    }
+
+    hide() {
+        super.hide();
+        if (this.autoCompleteResult) {
+            this.autoCompleteResult.destroy();
+        }
+    }
+
+    protected executeAction(input: LabeledAction | Action[] | Action) {
+        this.actionDispatcherProvider()
+            .then((actionDispatcher) => actionDispatcher.dispatchAll(toActionArray(input)))
+            .catch((reason) => this.logger.error(this, 'No action dispatcher available to execute command palette action', reason));
+    }
+}
+
+function toActionArray(input: LabeledAction | Action[] | Action): Action[] {
+    if (input instanceof LabeledAction) {
+        return input.actions;
+    } else if (isAction(input)) {
+        return [input];
+    }
+    return [];
+}
+
+export class CommandPaletteKeyListener extends KeyListener {
+    keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
+        if (matchesKeystroke(event, 'Escape')) {
+            return [new HideUIExtensionAction(CommandPalette.ID)];
+        } else if (matchesKeystroke(event, 'Space', 'ctrl')) {
+            return [new ShowUIExtensionAction(CommandPalette.ID)];
+        }
+        return [];
+    }
+}

--- a/src/features/command-palette/di.config.ts
+++ b/src/features/command-palette/di.config.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 import { ContainerModule } from "inversify";
 import { TYPES } from "../../base/types";
-import { CommandPaletteActionProviderRegistry, ICommandPaletteActionProvider } from "./action-providers";
+import { CommandPaletteActionProviderRegistry } from "./action-providers";
 import { CommandPalette, CommandPaletteKeyListener } from "./command-palette";
 
 const commandPaletteModule = new ContainerModule((bind) => {
@@ -23,13 +23,7 @@ const commandPaletteModule = new ContainerModule((bind) => {
     bind(TYPES.IUIExtension).toService(CommandPalette);
     bind(TYPES.KeyListener).to(CommandPaletteKeyListener);
     bind(CommandPaletteActionProviderRegistry).toSelf().inSingletonScope();
-    bind(TYPES.ICommandPaletteActionProviderRegistry).toProvider<ICommandPaletteActionProvider>((context) => {
-        return () => {
-            return new Promise<ICommandPaletteActionProvider>((resolve) => {
-                resolve(context.container.get<ICommandPaletteActionProvider>(CommandPaletteActionProviderRegistry));
-            });
-        };
-    });
+    bind(TYPES.ICommandPaletteActionProviderRegistry).toService(CommandPaletteActionProviderRegistry);
 });
 
 export default commandPaletteModule;

--- a/src/features/command-palette/di.config.ts
+++ b/src/features/command-palette/di.config.ts
@@ -1,0 +1,35 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { ContainerModule } from "inversify";
+import { TYPES } from "../../base/types";
+import { CommandPaletteActionProviderRegistry, ICommandPaletteActionProvider } from "./action-providers";
+import { CommandPalette, CommandPaletteKeyListener } from "./command-palette";
+
+const commandPaletteModule = new ContainerModule((bind) => {
+    bind(CommandPalette).toSelf().inSingletonScope();
+    bind(TYPES.IUIExtension).toService(CommandPalette);
+    bind(TYPES.KeyListener).to(CommandPaletteKeyListener);
+    bind(CommandPaletteActionProviderRegistry).toSelf().inSingletonScope();
+    bind(TYPES.ICommandPaletteActionProviderRegistry).toProvider<ICommandPaletteActionProvider>((context) => {
+        return () => {
+            return new Promise<ICommandPaletteActionProvider>((resolve) => {
+                resolve(context.container.get<ICommandPaletteActionProvider>(CommandPaletteActionProviderRegistry));
+            });
+        };
+    });
+});
+
+export default commandPaletteModule;

--- a/src/features/nameable/model.ts
+++ b/src/features/nameable/model.ts
@@ -26,10 +26,10 @@ export function isNameable(element: SModelElement): element is SModelElement & N
     return element.hasFeature(nameFeature);
 }
 
-export function name(element: SModelElement): string {
+export function name(element: SModelElement): string|undefined {
     if (isNameable(element)) {
         return element.name;
     } else {
-        return 'unnamed';
+        return undefined;
     }
 }

--- a/src/features/nameable/model.ts
+++ b/src/features/nameable/model.ts
@@ -1,0 +1,35 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { SModelElement } from "../../base/model/smodel";
+import { SModelExtension } from "../../base/model/smodel-extension";
+
+export const nameFeature = Symbol('nameableFeature');
+
+export interface Nameable extends SModelExtension {
+    name: string
+}
+
+export function isNameable(element: SModelElement): element is SModelElement & Nameable {
+    return element.hasFeature(nameFeature);
+}
+
+export function name(element: SModelElement): string {
+    if (isNameable(element)) {
+        return element.name;
+    } else {
+        return 'unnamed';
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,9 @@ export * from "./features/bounds/stack-layout";
 export * from "./features/button/button-handler";
 export * from "./features/button/model";
 
+export * from "./features/command-palette/action-providers";
+export * from "./features/command-palette/command-palette";
+
 export * from "./features/edge-layout/di.config";
 export * from "./features/edge-layout/edge-layout";
 export * from "./features/edge-layout/model";
@@ -105,6 +108,8 @@ export * from "./features/decoration/decoration-placer";
 export * from "./features/move/model";
 export * from "./features/move/move";
 
+export * from "./features/nameable/model";
+
 export * from "./features/open/open";
 export * from "./features/open/model";
 
@@ -136,6 +141,7 @@ import graphModule from "./graph/di.config";
 
 import boundsModule from "./features/bounds/di.config";
 import buttonModule from "./features/button/di.config";
+import commandPaletteModule from "./features/command-palette/di.config";
 import decorationModule from "./features/decoration/di.config";
 import edgeLayoutModule from "./features/edge-layout/di.config";
 import expandModule from "./features/expand/di.config";
@@ -151,7 +157,7 @@ import updateModule from "./features/update/di.config";
 import viewportModule from "./features/viewport/di.config";
 
 export {
-    graphModule, boundsModule, buttonModule, decorationModule, edgeLayoutModule,
+    graphModule, boundsModule, buttonModule, commandPaletteModule, decorationModule, edgeLayoutModule,
     expandModule, exportModule, fadeModule, hoverModule, moveModule, openModule, routingModule,
     selectModule, undoRedoModule, updateModule, viewportModule
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,9 @@ export * from './base/model/smodel';
 export * from './base/tool-manager/tool-manager';
 export * from './base/tool-manager/tool';
 
+export * from './base/ui-extensions/ui-extension-registry';
+export * from './base/ui-extensions/ui-extension';
+
 export * from './base/views/key-tool';
 export * from './base/views/mouse-tool';
 export * from './base/views/thunk-view';
@@ -147,8 +150,9 @@ import undoRedoModule from "./features/undo-redo/di.config";
 import updateModule from "./features/update/di.config";
 import viewportModule from "./features/viewport/di.config";
 
-export { graphModule, boundsModule, buttonModule, decorationModule, edgeLayoutModule,
-    expandModule,  exportModule, fadeModule, hoverModule, moveModule, openModule, routingModule,
+export {
+    graphModule, boundsModule, buttonModule, decorationModule, edgeLayoutModule,
+    expandModule, exportModule, fadeModule, hoverModule, moveModule, openModule, routingModule,
     selectModule, undoRedoModule, updateModule, viewportModule
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -372,6 +372,11 @@ atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
 
+autocompleter@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/autocompleter/-/autocompleter-4.0.2.tgz#74fd9eaa733258e5ac2a72362c4bab0951ab6a01"
+  integrity sha512-joYpKB3gsYSVIzBdiuUU/LOpvNEN68rSTPlroH+RQ38Ff8OmSUE0ue+C6aSc+powTRrSUnZfvYGvOsa++3HRtA==
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"


### PR DESCRIPTION
Introduces an extensible command palette as a keyboard-oriented way of invoking actions similar to a Code Completion / IntelliSense / Quick-Fix functionality for code. The available commands are determined by registered action providers that provide a set of `LabeledAction`s for a context. A `LabeledAction` is essentially a label to be shown in the list and an array of Sprotty `Action`s to be dispatched on invocation.

The command palette is shown on <kbd>Ctrl</kbd> + <kbd>Space</kbd>. If there is no selection or multi-selection, it shows up in the left-upper corner of the base div. If there is a single selection, it is shown on top of the selected element.

The command palette is built on top of a UI extension mechanism introduced with this PR as well to register UI extensions. UI extensions allow to show additional UI elements (HTML elements) on top of Sprotty diagrams. Such UI extensions can be registered with an ID and then enabled or disabled by dispatching respective actions for showing and hiding extensions.
A UI extension is rendered in a separate div element but can be positioned on top of Sprotty diagrams based on a current context (e.g. selected elements, etc.).

In near future, we can implement a graphical palette on top of the same UI extension basis easily (as is currently done in GLSP).

Finally, for demonstration purposes, we integrated the introduced a command palette with a simple action provider in Sprotty's class diagram example.

Fixes #34.