### PR TITLE
MouseEvents: corrected doubleClick to be a MouseEvent

### DIFF
--- a/src/base/views/mouse-tool.ts
+++ b/src/base/views/mouse-tool.ts
@@ -118,7 +118,7 @@ export class MouseTool implements IVNodeDecorator {
         this.handleEvent('wheel', model, event);
     }
 
-    doubleClick(model: SModelRoot, event: WheelEvent) {
+    doubleClick(model: SModelRoot, event: MouseEvent) {
         this.handleEvent('doubleClick', model, event);
     }
 
@@ -189,7 +189,7 @@ export class MouseListener {
         return [];
     }
 
-    doubleClick(target: SModelElement, event: WheelEvent): (Action | Promise<Action>)[] {
+    doubleClick(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
         return [];
     }
 
@@ -197,4 +197,3 @@ export class MouseListener {
         return vnode;
     }
 }
-

--- a/src/features/open/open.ts
+++ b/src/features/open/open.ts
@@ -27,7 +27,7 @@ export class OpenAction {
 }
 
 export class OpenMouseListener extends MouseListener {
-    doubleClick(target: SModelElement, event: WheelEvent): (Action | Promise<Action>)[] {
+    doubleClick(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
         const openableTarget = findParentByFeature(target, isOpenable);
         if (openableTarget !== undefined) {
             return [ new OpenAction(openableTarget.id) ];


### PR DESCRIPTION
MouseEvents: corrected doubleClick to be a MouseEvent

Signed-off-by: Niklas Rentz <nre@informatik.uni-kiel.de>