### PR TITLE
Add user interface for label editing (#83)

### DIFF
--- a/css/edit-label.css
+++ b/css/edit-label.css
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+.label-edit input {
+    background: rgba(0, 0, 0, 0.0);
+    border: 0;
+    width: 99%;
+    height: 99%;
+}
+
+.label-edit input:focus {
+    outline: none;
+    outline-offset: 0px;
+}

--- a/css/edit-label.css
+++ b/css/edit-label.css
@@ -25,3 +25,17 @@
     outline: none;
     outline-offset: 0px;
 }
+
+.label-edit {
+    border-left: 1px dotted gray;
+}
+
+.label-edit.validation-warning {
+    color: orange;
+    border-left: 1px dotted orange;
+}
+
+.label-edit.validation-error {
+    color: red;
+    border-left: 1px dotted red;
+}

--- a/css/edit-label.css
+++ b/css/edit-label.css
@@ -15,7 +15,8 @@
  ********************************************************************************/
 
 .label-edit input {
-    background: rgba(0, 0, 0, 0.0);
+    background: rgba(255, 255, 255, 0.5);
+    border-radius: 5px;
     border: 0;
     width: 99%;
     height: 99%;

--- a/examples/classdiagram/class-diagram.html
+++ b/examples/classdiagram/class-diagram.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>sprotty Class Diagram Example</title>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css">    
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/balloon-css/0.5.0/balloon.min.css">
     <link rel="stylesheet" href="css/page.css">
     <!-- support Microsoft browsers -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dom4/3.0.0/dom4.js">

--- a/examples/classdiagram/src/di.config.ts
+++ b/examples/classdiagram/src/di.config.ts
@@ -27,6 +27,7 @@ import {
 import { ClassNodeView, IconView} from "./views";
 import { PopupModelProvider } from "./popup";
 import { ClassDiagramModelSource } from './model-source';
+import { ClassDiagramLabelValidator } from './label-validator';
 import { Icon, ClassNode, ClassLabel, PropertyLabel } from "./model";
 
 export default (useWebsocket: boolean, containerId: string) => {
@@ -44,6 +45,7 @@ export default (useWebsocket: boolean, containerId: string) => {
         bind(TYPES.IPopupModelProvider).to(PopupModelProvider);
         bind(TYPES.ICommandPaletteActionProvider).to(RevealNamedElementActionProvider);
         bind(TYPES.ISnapper).to(CenterGridSnapper);
+        bind(TYPES.IEditLabelValidator).to(ClassDiagramLabelValidator);
         const context = { bind, unbind, isBound, rebind };
         configureModelElement(context, 'graph', SGraph, SGraphView);
         configureModelElement(context, 'node:class', ClassNode, ClassNodeView);

--- a/examples/classdiagram/src/di.config.ts
+++ b/examples/classdiagram/src/di.config.ts
@@ -22,16 +22,17 @@ import {
     fadeModule, ExpandButtonView, buttonModule, edgeEditModule, SRoutingHandleView, PreRenderedElement,
     HtmlRoot, SGraph, configureModelElement, SLabel, SCompartment, SEdge, SButton, SRoutingHandle,
     edgeLayoutModule, updateModule, graphModule, routingModule, modelSourceModule, commandPaletteModule,
-    RevealNamedElementActionProvider, CenterGridSnapper
+    RevealNamedElementActionProvider, CenterGridSnapper, labelEditModule, labelEditUiModule
 } from "../../../src";
 import { ClassNodeView, IconView} from "./views";
 import { PopupModelProvider } from "./popup";
 import { ClassDiagramModelSource } from './model-source';
-import { Icon, ClassNode } from "./model";
+import { Icon, ClassNode, ClassLabel, PropertyLabel } from "./model";
 
 export default (useWebsocket: boolean, containerId: string) => {
     require("../../../css/sprotty.css");
     require("../../../css/command-palette.css");
+    require("../../../css/edit-label.css");
     require("../css/diagram.css");
     const classDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => {
         if (useWebsocket)
@@ -46,8 +47,8 @@ export default (useWebsocket: boolean, containerId: string) => {
         const context = { bind, unbind, isBound, rebind };
         configureModelElement(context, 'graph', SGraph, SGraphView);
         configureModelElement(context, 'node:class', ClassNode, ClassNodeView);
-        configureModelElement(context, 'label:heading', SLabel, SLabelView);
-        configureModelElement(context, 'label:text', SLabel, SLabelView);
+        configureModelElement(context, 'label:heading', ClassLabel, SLabelView);
+        configureModelElement(context, 'label:text', PropertyLabel, SLabelView);
         configureModelElement(context, 'comp:comp', SCompartment, SCompartmentView);
         configureModelElement(context, 'comp:header', SCompartment, SCompartmentView);
         configureModelElement(context, 'icon', Icon, IconView);
@@ -67,7 +68,7 @@ export default (useWebsocket: boolean, containerId: string) => {
     const container = new Container();
     container.load(defaultModule, selectModule, moveModule, boundsModule, undoRedoModule,
         viewportModule, fadeModule, hoverModule, exportModule, expandModule, buttonModule,
-        updateModule, graphModule, routingModule, edgeEditModule, edgeLayoutModule,
-        modelSourceModule, commandPaletteModule, classDiagramModule);
+        updateModule, graphModule, routingModule, edgeEditModule, edgeLayoutModule, labelEditModule,
+        labelEditUiModule, modelSourceModule, commandPaletteModule, classDiagramModule);
     return container;
 };

--- a/examples/classdiagram/src/di.config.ts
+++ b/examples/classdiagram/src/di.config.ts
@@ -27,7 +27,7 @@ import {
 import { ClassNodeView, IconView} from "./views";
 import { PopupModelProvider } from "./popup";
 import { ClassDiagramModelSource } from './model-source';
-import { ClassDiagramLabelValidator } from './label-validator';
+import { ClassDiagramLabelValidator, ClassDiagramLabelValidationDecorator } from './label-validation';
 import { Icon, ClassNode, ClassLabel, PropertyLabel } from "./model";
 
 export default (useWebsocket: boolean, containerId: string) => {
@@ -46,6 +46,7 @@ export default (useWebsocket: boolean, containerId: string) => {
         bind(TYPES.ICommandPaletteActionProvider).to(RevealNamedElementActionProvider);
         bind(TYPES.ISnapper).to(CenterGridSnapper);
         bind(TYPES.IEditLabelValidator).to(ClassDiagramLabelValidator);
+        bind(TYPES.IEditLabelValidationDecorator).to(ClassDiagramLabelValidationDecorator);
         const context = { bind, unbind, isBound, rebind };
         configureModelElement(context, 'graph', SGraph, SGraphView);
         configureModelElement(context, 'node:class', ClassNode, ClassNodeView);

--- a/examples/classdiagram/src/label-validation.ts
+++ b/examples/classdiagram/src/label-validation.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { IEditLabelValidator, EditableLabel, SModelElement, EditLabelValidationResult, Severity } from "../../../src";
+import { IEditLabelValidator, EditableLabel, SModelElement, EditLabelValidationResult, Severity, IEditLabelValidationDecorator } from "../../../src";
 import { injectable } from "inversify";
 
 @injectable()
@@ -33,5 +33,36 @@ export class ClassDiagramLabelValidator implements IEditLabelValidator {
         return {
             severity: <Severity>'ok', message: undefined
         };
+    }
+}
+
+@injectable()
+export class ClassDiagramLabelValidationDecorator implements IEditLabelValidationDecorator {
+
+    decorate(input: HTMLInputElement, result: EditLabelValidationResult): void {
+        const containerElement = input.parentElement;
+        if (!containerElement) {
+            return;
+        }
+        if (result.message) {
+            containerElement.setAttribute('data-balloon', result.message);
+            containerElement.setAttribute('data-balloon-pos', 'up-left');
+            containerElement.setAttribute('data-balloon-visible', 'true');
+        }
+        switch (result.severity) {
+            case 'ok': containerElement.classList.add('validation-ok'); break;
+            case 'warning': containerElement.classList.add('validation-warning'); break;
+            case 'error': containerElement.classList.add('validation-error'); break;
+        }
+    }
+
+    dispose(input: HTMLInputElement): void {
+        const containerElement = input.parentElement;
+        if (containerElement) {
+            containerElement.removeAttribute('data-balloon');
+            containerElement.removeAttribute('data-balloon-pos');
+            containerElement.removeAttribute('data-balloon-visible');
+            containerElement.classList.remove('validation-ok', 'validation-warning', 'validation-error');
+        }
     }
 }

--- a/examples/classdiagram/src/label-validator.ts
+++ b/examples/classdiagram/src/label-validator.ts
@@ -18,20 +18,20 @@ import { injectable } from "inversify";
 
 @injectable()
 export class ClassDiagramLabelValidator implements IEditLabelValidator {
-    validate(value: string, label: EditableLabel & SModelElement): Promise<EditLabelValidationResult> {
+    async validate(value: string, label: EditableLabel & SModelElement): Promise<EditLabelValidationResult> {
         if (value.length < 1) {
-            return Promise.resolve({
+            return {
                 severity: <Severity>'error',
                 message: 'Name must not be empty'
-            });
+            };
         } else if (value.indexOf('!') !== -1) {
-            return Promise.resolve({
+            return {
                 severity: <Severity>'warning',
                 message: 'Name should not contain exclamation marks'
-            });
+            };
         }
-        return Promise.resolve({
+        return {
             severity: <Severity>'ok', message: undefined
-        });
+        };
     }
 }

--- a/examples/classdiagram/src/label-validator.ts
+++ b/examples/classdiagram/src/label-validator.ts
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { IEditLabelValidator, EditableLabel, SModelElement, EditLabelValidationResult, Severity } from "../../../src";
+import { injectable } from "inversify";
+
+@injectable()
+export class ClassDiagramLabelValidator implements IEditLabelValidator {
+    validate(value: string, label: EditableLabel & SModelElement): Promise<EditLabelValidationResult> {
+        if (value.length < 1) {
+            return Promise.resolve({
+                severity: <Severity>'error',
+                message: 'Name must not be empty'
+            });
+        } else if (value.indexOf('!') !== -1) {
+            return Promise.resolve({
+                severity: <Severity>'warning',
+                message: 'Name should not contain exclamation marks'
+            });
+        }
+        return Promise.resolve({
+            severity: <Severity>'ok', message: undefined
+        });
+    }
+}

--- a/examples/classdiagram/src/model-source.ts
+++ b/examples/classdiagram/src/model-source.ts
@@ -35,6 +35,12 @@ export class ClassDiagramModelSource extends LocalModelSource {
         registry.register(CollapseExpandAllAction.KIND, this);
     }
 
+    commitModel(newRoot: SModelRootSchema) {
+        const previousModel = super.commitModel(newRoot);
+        this.updateModel();
+        return previousModel;
+    }
+
     handle(action: Action) {
         switch (action.kind) {
             case CollapseExpandAction.KIND:

--- a/examples/classdiagram/src/model.ts
+++ b/examples/classdiagram/src/model.ts
@@ -16,27 +16,43 @@
 
 import {
     SShapeElement, Expandable, boundsFeature, expandFeature, fadeFeature, layoutContainerFeature,
-    layoutableChildFeature, RectangularNode, Nameable, nameFeature, SLabel
+    layoutableChildFeature, RectangularNode, Nameable, nameFeature, SLabel, EditableLabel, editLabelFeature,
+    WithEditableLabel, isEditableLabel, withEditLabelFeature
 } from "../../../src";
 
-export class ClassNode extends RectangularNode implements Expandable, Nameable {
+export class ClassNode extends RectangularNode implements Expandable, Nameable, WithEditableLabel {
     expanded: boolean = false;
 
-    get name() {
+    get editableLabel() {
         const headerComp = this.children.find(element => element.type === 'comp:header');
         if (headerComp) {
             const label = headerComp.children.find(element => element.type === 'label:heading');
-            if (label && label instanceof SLabel) {
-                return label.text;
+            if (label && isEditableLabel(label)) {
+                return label;
             }
+        }
+        return undefined;
+    }
+
+    get name() {
+        if (this.editableLabel) {
+            return this.editableLabel.text;
         }
         return this.id;
     }
 
     hasFeature(feature: symbol) {
-        return feature === expandFeature || feature === nameFeature || super.hasFeature(feature);
+        return feature === expandFeature || feature === nameFeature || feature === withEditLabelFeature || super.hasFeature(feature);
     }
 }
+
+export class EditableSLabel extends SLabel implements EditableLabel {
+    hasFeature(feature: symbol) {
+        return feature === editLabelFeature || super.hasFeature(feature);
+    }
+}
+export class ClassLabel extends EditableSLabel { }
+export class PropertyLabel extends EditableSLabel { }
 
 export class Icon extends SShapeElement {
     size = {

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -61,5 +61,6 @@ export const TYPES = {
     UIExtensionRegistry: Symbol('UIExtensionRegistry'),
     ICommandPaletteActionProviderRegistry: Symbol('ICommandPaletteActionProviderRegistry'),
     ICommandPaletteActionProvider: Symbol('ICommandPaletteActionProvider'),
-    IEditLabelValidator: Symbol('IEditLabelValidator')
+    IEditLabelValidator: Symbol('IEditLabelValidator'),
+    IEditLabelValidationDecorator: Symbol('IEditLabelValidationDecorator')
 };

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -60,5 +60,6 @@ export const TYPES = {
     IUIExtension: Symbol('IUIExtension'),
     UIExtensionRegistry: Symbol('UIExtensionRegistry'),
     ICommandPaletteActionProviderRegistry: Symbol('ICommandPaletteActionProviderRegistry'),
-    ICommandPaletteActionProvider: Symbol('ICommandPaletteActionProvider')
+    ICommandPaletteActionProvider: Symbol('ICommandPaletteActionProvider'),
+    IEditLabelValidator: Symbol('IEditLabelValidator')
 };

--- a/src/base/ui-extensions/ui-extension-registry.ts
+++ b/src/base/ui-extensions/ui-extension-registry.ts
@@ -36,7 +36,7 @@ export class UIExtensionRegistry extends InstanceRegistry<IUIExtension>  {
  */
 export class SetUIExtensionVisibilityAction implements Action {
     readonly kind = SetUIExtensionVisibilityCommand.KIND;
-    constructor(public readonly extensionId: string, public readonly visible: boolean) { }
+    constructor(public readonly extensionId: string, public readonly visible: boolean, public readonly contextElementsId: string[] = []) { }
 }
 
 @injectable()
@@ -47,17 +47,18 @@ export class SetUIExtensionVisibilityCommand extends SystemCommand {
     constructor(@inject(TYPES.Action) public action: SetUIExtensionVisibilityAction) {
         super();
     }
+
     execute(context: CommandExecutionContext): CommandResult {
         const extension = this.registry.get(this.action.extensionId);
         if (extension) {
-            this.action.visible ? extension.show(context.root) : extension.hide();
+            this.action.visible ? extension.show(context.root, ...this.action.contextElementsId) : extension.hide();
         }
         return context.root;
     }
+
     undo(context: CommandExecutionContext): CommandResult {
         return context.root;
     }
-
     redo(context: CommandExecutionContext): CommandResult {
         return context.root;
     }

--- a/src/base/ui-extensions/ui-extension.ts
+++ b/src/base/ui-extensions/ui-extension.ts
@@ -24,7 +24,7 @@ import { ViewerOptions } from "../views/viewer-options";
  */
 export interface IUIExtension {
     readonly id: string;
-    show(root: Readonly<SModelRoot>): void;
+    show(root: Readonly<SModelRoot>, ...contextElementIds: string[]): void;
     hide(): void;
 }
 
@@ -41,12 +41,12 @@ export abstract class AbstractUIExtension implements IUIExtension {
     protected containerElement: HTMLElement;
     protected activeElement: Element | null;
 
-    show(root: Readonly<SModelRoot>): void {
+    show(root: Readonly<SModelRoot>, ...contextElementIds: string[]): void {
         this.activeElement = document.activeElement;
         if (!this.containerElement) {
             if (!this.initialize()) return;
         }
-        this.onBeforeShow(this.containerElement, root);
+        this.onBeforeShow(this.containerElement, root, ...contextElementIds);
         this.setContainerVisible(true);
     }
 
@@ -103,9 +103,10 @@ export abstract class AbstractUIExtension implements IUIExtension {
      * Updates the `containerElement` under the given `context` before it becomes visible.
      *
      * Subclasses may override this method to, for instance, modifying the position of the
-     * `containerElement`, add or remove elements, etc. depending on the specified `root`.
+     * `containerElement`, add or remove elements, etc. depending on the specified `root`
+     * or `contextElementIds`.
      */
-    protected onBeforeShow(containerElement: HTMLElement, root: Readonly<SModelRoot>): void {
+    protected onBeforeShow(containerElement: HTMLElement, root: Readonly<SModelRoot>, ...contextElementIds: string[]): void {
         // default: do nothing
     }
 

--- a/src/base/ui-extensions/ui-extension.ts
+++ b/src/base/ui-extensions/ui-extension.ts
@@ -87,9 +87,9 @@ export abstract class AbstractUIExtension implements IUIExtension {
         return container;
     }
 
-    protected setContainerVisible(value: boolean) {
+    protected setContainerVisible(visible: boolean) {
         if (this.containerElement) {
-            if (value) {
+            if (visible) {
                 this.containerElement.style.visibility = 'visible';
                 this.containerElement.style.opacity = '1';
             } else {

--- a/src/features/edit/di.config.ts
+++ b/src/features/edit/di.config.ts
@@ -22,7 +22,7 @@ import { SDanglingAnchor } from "../../features/routing/model";
 import { EmptyGroupView } from "../../lib/svg-views";
 import { DeleteElementCommand } from "./delete";
 import { EditLabelMouseListener, ApplyLabelEditCommand, EditLabelKeyListener } from "./edit-label";
-import { EditLabelCommand, EditLabelUI } from "./edit-label-ui";
+import { EditLabelUI, EditLabelActionHandlerInitializer } from "./edit-label-ui";
 import { SwitchEditModeCommand } from "./edit-routing";
 import { ReconnectCommand } from "./reconnect";
 
@@ -40,8 +40,7 @@ export const labelEditModule = new ContainerModule((bind, _unbind, isBound) => {
 });
 
 export const labelEditUiModule = new ContainerModule((bind, unbind, isBound, rebind) => {
+    bind(TYPES.IActionHandlerInitializer).to(EditLabelActionHandlerInitializer);
     bind(EditLabelUI).toSelf().inSingletonScope();
     bind(TYPES.IUIExtension).toService(EditLabelUI);
-    configureCommand({ bind, isBound }, EditLabelCommand);
 });
-

--- a/src/features/edit/di.config.ts
+++ b/src/features/edit/di.config.ts
@@ -15,23 +15,33 @@
  ********************************************************************************/
 
 import { ContainerModule } from "inversify";
+import { configureCommand } from "../../base/commands/command-registration";
 import { TYPES } from "../../base/types";
-import { SwitchEditModeCommand } from "./edit-routing";
-import { ReconnectCommand } from "./reconnect";
 import { configureModelElement } from "../../base/views/view";
 import { SDanglingAnchor } from "../../features/routing/model";
 import { EmptyGroupView } from "../../lib/svg-views";
 import { DeleteElementCommand } from "./delete";
-import { EditLabelMouseListener } from "./edit-label";
-import { configureCommand } from "../../base/commands/command-registration";
+import { EditLabelMouseListener, ApplyLabelEditCommand, EditLabelKeyListener } from "./edit-label";
+import { EditLabelCommand, EditLabelUI } from "./edit-label-ui";
+import { SwitchEditModeCommand } from "./edit-routing";
+import { ReconnectCommand } from "./reconnect";
 
-export const edgeEditModule = new ContainerModule((bind, _unbind, isBound)  => {
+export const edgeEditModule = new ContainerModule((bind, _unbind, isBound) => {
     configureCommand({ bind, isBound }, SwitchEditModeCommand);
     configureCommand({ bind, isBound }, ReconnectCommand);
     configureCommand({ bind, isBound }, DeleteElementCommand);
     configureModelElement({ bind, isBound }, 'dangling-anchor', SDanglingAnchor, EmptyGroupView);
 });
 
-export const labelEditModule = new ContainerModule(bind => {
+export const labelEditModule = new ContainerModule((bind, _unbind, isBound) => {
     bind(TYPES.MouseListener).to(EditLabelMouseListener);
+    bind(TYPES.KeyListener).to(EditLabelKeyListener);
+    configureCommand({ bind, isBound }, ApplyLabelEditCommand);
 });
+
+export const labelEditUiModule = new ContainerModule((bind, unbind, isBound, rebind) => {
+    bind(EditLabelUI).toSelf().inSingletonScope();
+    bind(TYPES.IUIExtension).toService(EditLabelUI);
+    configureCommand({ bind, isBound }, EditLabelCommand);
+});
+

--- a/src/features/edit/edit-label-ui.ts
+++ b/src/features/edit/edit-label-ui.ts
@@ -48,6 +48,11 @@ export class EditLabelActionHandlerInitializer implements IActionHandlerInitiali
     }
 }
 
+export interface IEditLabelValidationDecorator {
+    decorate(input: HTMLInputElement, validationResult: EditLabelValidationResult): void;
+    dispose(input: HTMLInputElement): void;
+}
+
 @injectable()
 export class EditLabelUI extends AbstractUIExtension {
     static readonly ID = "editLabelUi";
@@ -62,6 +67,7 @@ export class EditLabelUI extends AbstractUIExtension {
     @inject(TYPES.ViewerOptions) protected viewerOptions: ViewerOptions;
     @inject(TYPES.DOMHelper) protected domHelper: DOMHelper;
     @inject(TYPES.IEditLabelValidator) @optional() public labelValidator: IEditLabelValidator;
+    @inject(TYPES.IEditLabelValidationDecorator) @optional() public validationDecorator: IEditLabelValidationDecorator;
 
     protected inputElement: HTMLInputElement;
     protected label?: EditableLabel & SModelElement;
@@ -134,24 +140,14 @@ export class EditLabelUI extends AbstractUIExtension {
 
     protected showValidationResult(result: EditLabelValidationResult) {
         this.clearValidationResult();
-        if (result.message) {
-            this.containerElement.setAttribute('data-balloon', result.message);
-            this.containerElement.setAttribute('data-balloon-pos', 'up-left');
-            this.containerElement.setAttribute('data-balloon-visible', 'true');
-        }
-        switch (result.severity) {
-            case 'ok': this.containerElement.classList.add('validation-ok'); break;
-            case 'warning': this.containerElement.classList.add('validation-warning'); break;
-            case 'error': this.containerElement.classList.add('validation-error'); break;
+        if (this.validationDecorator) {
+            this.validationDecorator.decorate(this.inputElement, result);
         }
     }
 
     protected clearValidationResult() {
-        if (this.containerElement) {
-            this.containerElement.removeAttribute('data-balloon');
-            this.containerElement.removeAttribute('data-balloon-pos');
-            this.containerElement.removeAttribute('data-balloon-visible');
-            this.containerElement.classList.remove('validation-ok', 'validation-warning', 'validation-error');
+        if (this.validationDecorator) {
+            this.validationDecorator.dispose(this.inputElement);
         }
     }
 

--- a/src/features/edit/edit-label-ui.ts
+++ b/src/features/edit/edit-label-ui.ts
@@ -1,0 +1,180 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { inject, injectable } from "inversify";
+import { IActionDispatcherProvider } from "../../base/actions/action-dispatcher";
+import { CommandExecutionContext, CommandResult, SystemCommand } from "../../base/commands/command";
+import { SModelElement, SModelRoot } from "../../base/model/smodel";
+import { TYPES } from "../../base/types";
+import { AbstractUIExtension } from "../../base/ui-extensions/ui-extension";
+import { SetUIExtensionVisibilityAction } from "../../base/ui-extensions/ui-extension-registry";
+import { DOMHelper } from "../../base/views/dom-helper";
+import { ViewerOptions } from "../../base/views/viewer-options";
+import { matchesKeystroke } from "../../utils/keyboard";
+import { getAbsoluteClientBounds } from "../bounds/model";
+import { ApplyLabelEditAction, EditableLabel, EditLabelAction, isEditableLabel } from "./edit-label";
+import { getZoom } from "../viewport/zoom";
+
+/** Shows a UI extension for editing a label on emitted `EditLabelAction`s. */
+@injectable()
+export class EditLabelCommand extends SystemCommand {
+    static KIND: string = EditLabelAction.KIND;
+    @inject(TYPES.IActionDispatcherProvider) public actionDispatcherProvider: IActionDispatcherProvider;
+
+    constructor(@inject(TYPES.Action) public action: EditLabelAction) {
+        super();
+    }
+
+    execute(context: CommandExecutionContext): CommandResult {
+        this.actionDispatcherProvider().then(dispatcher =>
+            dispatcher.dispatch(new SetUIExtensionVisibilityAction(EditLabelUI.ID, true, [this.action.labelId])));
+        return context.root;
+    }
+
+    undo(context: CommandExecutionContext): CommandResult {
+        return context.root;
+    }
+
+    redo(context: CommandExecutionContext): CommandResult {
+        return context.root;
+    }
+}
+
+@injectable()
+export class EditLabelUI extends AbstractUIExtension {
+    static readonly ID = "editLabelUi";
+
+    readonly id = EditLabelUI.ID;
+    readonly containerClass = "label-edit";
+
+    /** The additional width to be added to the current label length for editing in pixel. Will be scaled depending on zoom level. */
+    readonly additionalInputWidth = 100;
+
+    @inject(TYPES.IActionDispatcherProvider) public actionDispatcherProvider: IActionDispatcherProvider;
+    @inject(TYPES.ViewerOptions) protected viewerOptions: ViewerOptions;
+    @inject(TYPES.DOMHelper) protected domHelper: DOMHelper;
+
+    protected inputElement: HTMLInputElement;
+    protected label?: EditableLabel & SModelElement;
+    protected labelElement: HTMLElement | null;
+
+    protected get labelId() { return this.label ? this.label.id : 'unknown'; }
+
+    protected initializeContents(containerElement: HTMLElement): void {
+        containerElement.style.position = "absolute";
+        this.inputElement = document.createElement('input');
+        this.inputElement.addEventListener('keydown', (event) => this.hideIfEscapeEvent(event));
+        this.inputElement.onblur = () => window.setTimeout(() => this.hide(), 200);
+        this.inputElement.addEventListener('keydown', (event) => this.applyLabelEditIfEnterEvent(event));
+        containerElement.appendChild(this.inputElement);
+    }
+
+    protected hideIfEscapeEvent(event: KeyboardEvent): any {
+        if (matchesKeystroke(event, 'Escape')) { this.hide(); }
+    }
+
+    protected applyLabelEditIfEnterEvent(event: KeyboardEvent): any {
+        if (matchesKeystroke(event, 'Enter')) {
+            this.actionDispatcherProvider()
+                .then(actionDispatcher =>
+                    actionDispatcher.dispatch(new ApplyLabelEditAction(this.labelId, this.inputElement.value)))
+                .catch((reason) =>
+                    this.logger.error(this, 'No action dispatcher available to execute apply label edit action', reason));
+            this.hide();
+        }
+    }
+
+    show(root: Readonly<SModelRoot>, ...contextElementIds: string[]) {
+        if (!hasEditableLabel(contextElementIds, root)) {
+            return;
+        }
+        super.show(root, ...contextElementIds);
+        this.inputElement.focus();
+    }
+
+    hide(): void {
+        super.hide();
+        if (this.labelElement) {
+            this.labelElement.style.visibility = 'visible';
+        }
+    }
+
+    protected onBeforeShow(containerElement: HTMLElement, root: Readonly<SModelRoot>, ...contextElementIds: string[]) {
+        this.label = getEditableLabels(contextElementIds, root)[0];
+        this.setPosition(containerElement);
+        this.applyTextContents();
+        this.applyFontStyling();
+    }
+
+    protected setPosition(containerElement: HTMLElement) {
+        let x = 0;
+        let y = 0;
+        let width = 100;
+        let height = 20;
+
+        if (this.label) {
+            const bounds = getAbsoluteClientBounds(this.label, this.domHelper, this.viewerOptions);
+            x = bounds.x;
+            y = bounds.y;
+            height = bounds.height;
+            width = bounds.width + (this.additionalInputWidth * getZoom(this.label));
+        }
+
+        containerElement.style.left = `${x}px`;
+        containerElement.style.top = `${y}px`;
+        containerElement.style.width = `${width}px`;
+        containerElement.style.height = `${height}px`;
+        this.inputElement.style.position = 'absolute';
+    }
+
+    protected applyTextContents() {
+        if (this.label) {
+            this.inputElement.value = this.label.text;
+            this.inputElement.setSelectionRange(0, this.inputElement.value.length);
+        }
+    }
+
+    protected applyFontStyling() {
+        if (this.label) {
+            this.labelElement = document.getElementById(this.domHelper.createUniqueDOMElementId(this.label));
+            if (this.labelElement) {
+                this.labelElement.style.visibility = 'hidden';
+                const style = window.getComputedStyle(this.labelElement);
+                this.inputElement.style.font = style.font;
+                this.inputElement.style.fontStyle = style.fontStyle;
+                this.inputElement.style.fontFamily = style.fontFamily;
+                this.inputElement.style.fontSize = scaledFont(style.fontSize, getZoom(this.label));
+                this.inputElement.style.fontWeight = style.fontWeight;
+            }
+        }
+    }
+}
+
+function hasEditableLabel(contextElementIds: string[], root: Readonly<SModelRoot>) {
+    return getEditableLabels(contextElementIds, root).length === 1;
+}
+
+function getEditableLabels(contextElementIds: string[], root: Readonly<SModelRoot>) {
+    return contextElementIds.map(id => root.index.getById(id)).filter(isEditableLabel);
+}
+
+function scaledFont(font: string | null, zoom: number): string | null {
+    if (font === null) {
+        return null;
+    }
+    return font.replace(/([0-9]+)/, (match) => {
+        return String(Number.parseInt(match, 10) * zoom);
+    });
+}

--- a/src/features/edit/edit-label.ts
+++ b/src/features/edit/edit-label.ts
@@ -14,32 +14,120 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { inject } from "inversify";
 import { Action } from "../../base/actions/action";
+import { Command, CommandExecutionContext, CommandResult } from "../../base/commands/command";
 import { SModelElement } from "../../base/model/smodel";
-import { MouseListener } from "../../base/views/mouse-tool";
-import { SLabel } from "../../graph/sgraph";
 import { SModelExtension } from "../../base/model/smodel-extension";
+import { TYPES } from "../../base/types";
+import { MouseListener } from "../../base/views/mouse-tool";
+import { KeyListener } from "../../base/views/key-tool";
+import { matchesKeystroke } from "../../utils/keyboard";
+import { isSelectable } from "../select/model";
+import { toArray } from "../../utils/iterable";
 
 export const editLabelFeature = Symbol('editLabelFeature');
 
 export interface EditableLabel extends SModelExtension {
+    text: string;
 }
 
 export function isEditableLabel<T extends SModelElement>(element: T): element is T & EditableLabel {
-    return element instanceof SLabel && element.hasFeature(editLabelFeature);
+    return 'text' in element && element.hasFeature(editLabelFeature);
+}
+
+export const withEditLabelFeature = Symbol('withEditLabelFeature');
+
+export interface WithEditableLabel extends SModelExtension {
+    readonly editableLabel?: EditableLabel & SModelElement;
+}
+
+export function isWithEditableLabel<T extends SModelElement>(element: T): element is T & WithEditableLabel {
+    return 'editableLabel' in element && element.hasFeature(withEditLabelFeature);
 }
 
 export class EditLabelAction implements Action {
     static KIND = 'EditLabel';
     kind = EditLabelAction.KIND;
-    constructor(readonly labelId: string) {}
+    constructor(readonly labelId: string) { }
+}
+
+export class ApplyLabelEditAction implements Action {
+    static KIND = 'ApplyLabelEdit';
+    kind = ApplyLabelEditAction.KIND;
+    constructor(readonly labelId: string, readonly text: string) { }
+}
+
+export class ResolvedLabelEdit {
+    label: EditableLabel;
+    oldLabel: string;
+    newLabel: string;
+}
+
+export class ApplyLabelEditCommand extends Command {
+    static KIND = ApplyLabelEditAction.KIND;
+
+    resolvedLabelEdit: ResolvedLabelEdit;
+
+    constructor(@inject(TYPES.Action) public action: ApplyLabelEditAction) {
+        super();
+    }
+
+    execute(context: CommandExecutionContext): CommandResult {
+        const index = context.root.index;
+        const label = index.getById(this.action.labelId);
+        if (label && isEditableLabel(label)) {
+            this.resolvedLabelEdit = { label, oldLabel: label.text, newLabel: this.action.text };
+            label.text = this.action.text;
+        }
+        return context.root;
+    }
+
+    undo(context: CommandExecutionContext): CommandResult {
+        if (this.resolvedLabelEdit) {
+            this.resolvedLabelEdit.label.text = this.resolvedLabelEdit.oldLabel;
+        }
+        return context.root;
+    }
+
+    redo(context: CommandExecutionContext): CommandResult {
+        if (this.resolvedLabelEdit) {
+            this.resolvedLabelEdit.label.text = this.resolvedLabelEdit.newLabel;
+        }
+        return context.root;
+    }
+
 }
 
 export class EditLabelMouseListener extends MouseListener {
     doubleClick(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
-        if (target instanceof SLabel && isEditableLabel(target)) {
-            return [new EditLabelAction(target.id)];
+        const editableLabel = getEditableLabel(target);
+        if (editableLabel) {
+            return [new EditLabelAction(editableLabel.id)];
         }
         return [];
     }
+}
+
+export class EditLabelKeyListener extends KeyListener {
+    keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
+        if (matchesKeystroke(event, 'F2')) {
+            const editableLabels = toArray(element.index.all()
+                .filter(e => isSelectable(e) && e.selected)).map(getEditableLabel)
+                .filter((e): e is EditableLabel & SModelElement => e !== undefined);
+            if (editableLabels.length === 1) {
+                return [new EditLabelAction(editableLabels[0].id)];
+            }
+        }
+        return [];
+    }
+}
+
+export function getEditableLabel(element: SModelElement): EditableLabel & SModelElement | undefined {
+    if (isEditableLabel(element)) {
+        return element;
+    } else if (isWithEditableLabel(element) && element.editableLabel) {
+        return element.editableLabel;
+    }
+    return undefined;
 }

--- a/src/features/edit/edit-label.ts
+++ b/src/features/edit/edit-label.ts
@@ -99,6 +99,17 @@ export class ApplyLabelEditCommand extends Command {
 
 }
 
+export interface IEditLabelValidator {
+    validate(value: string, label: EditableLabel & SModelElement): Promise<EditLabelValidationResult>;
+}
+
+export interface EditLabelValidationResult {
+    readonly severity: Severity;
+    readonly message?: string;
+}
+
+export type Severity = 'ok' | 'warning' | 'error';
+
 export class EditLabelMouseListener extends MouseListener {
     doubleClick(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
         const editableLabel = getEditableLabel(target);

--- a/src/features/edit/edit-label.ts
+++ b/src/features/edit/edit-label.ts
@@ -15,41 +15,25 @@
  ********************************************************************************/
 
 import { inject } from "inversify";
-import { Action } from "../../base/actions/action";
-import { Command, CommandExecutionContext, CommandResult } from "../../base/commands/command";
+import { Action, isAction } from "../../base/actions/action";
+import { CommandExecutionContext, CommandResult, Command } from "../../base/commands/command";
 import { SModelElement } from "../../base/model/smodel";
-import { SModelExtension } from "../../base/model/smodel-extension";
 import { TYPES } from "../../base/types";
 import { MouseListener } from "../../base/views/mouse-tool";
 import { KeyListener } from "../../base/views/key-tool";
 import { matchesKeystroke } from "../../utils/keyboard";
 import { isSelectable } from "../select/model";
 import { toArray } from "../../utils/iterable";
-
-export const editLabelFeature = Symbol('editLabelFeature');
-
-export interface EditableLabel extends SModelExtension {
-    text: string;
-}
-
-export function isEditableLabel<T extends SModelElement>(element: T): element is T & EditableLabel {
-    return 'text' in element && element.hasFeature(editLabelFeature);
-}
-
-export const withEditLabelFeature = Symbol('withEditLabelFeature');
-
-export interface WithEditableLabel extends SModelExtension {
-    readonly editableLabel?: EditableLabel & SModelElement;
-}
-
-export function isWithEditableLabel<T extends SModelElement>(element: T): element is T & WithEditableLabel {
-    return 'editableLabel' in element && element.hasFeature(withEditLabelFeature);
-}
+import { EditableLabel, isEditableLabel, isWithEditableLabel } from "./model";
 
 export class EditLabelAction implements Action {
     static KIND = 'EditLabel';
     kind = EditLabelAction.KIND;
     constructor(readonly labelId: string) { }
+}
+
+export function isEditLabelAction(element?: any): element is EditLabelAction {
+    return isAction(element) && element.kind === EditLabelAction.KIND && 'labelId' in element;
 }
 
 export class ApplyLabelEditAction implements Action {

--- a/src/features/edit/model.ts
+++ b/src/features/edit/model.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2019 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,6 +16,7 @@
 
 import { SModelElement } from '../../base/model/smodel';
 import { SRoutableElement } from '../routing/model';
+import { SModelExtension } from '../../base/model/smodel-extension';
 
 export const editFeature = Symbol('editFeature');
 
@@ -23,3 +24,22 @@ export function canEditRouting(element: SModelElement): element is SRoutableElem
     return element instanceof SRoutableElement && element.hasFeature(editFeature);
 }
 
+export const editLabelFeature = Symbol('editLabelFeature');
+
+export interface EditableLabel extends SModelExtension {
+    text: string;
+}
+
+export function isEditableLabel<T extends SModelElement>(element: T): element is T & EditableLabel {
+    return 'text' in element && element.hasFeature(editLabelFeature);
+}
+
+export const withEditLabelFeature = Symbol('withEditLabelFeature');
+
+export interface WithEditableLabel extends SModelExtension {
+    readonly editableLabel?: EditableLabel & SModelElement;
+}
+
+export function isWithEditableLabel<T extends SModelElement>(element: T): element is T & WithEditableLabel {
+    return 'editableLabel' in element && element.hasFeature(withEditLabelFeature);
+}

--- a/src/features/viewport/zoom.ts
+++ b/src/features/viewport/zoom.ts
@@ -30,6 +30,15 @@ export function isZoomable(element: SModelElement | Zoomable): element is Zoomab
     return 'zoom' in element;
 }
 
+export function getZoom(label: SModelElement) {
+    let zoom = 1;
+    const viewport = findParentByFeature(label, isViewport);
+    if (viewport) {
+        zoom = viewport.zoom;
+    }
+    return zoom;
+}
+
 export class ZoomMouseListener extends MouseListener {
 
     wheel(target: SModelElement, event: WheelEvent): Action[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,7 @@ export * from "./features/edit/create-on-drag";
 export * from "./features/edit/di.config";
 export * from "./features/edit/delete";
 export * from "./features/edit/edit-label";
+export * from "./features/edit/edit-label-ui";
 export * from "./features/edit/edit-routing";
 export * from "./features/edit/model";
 export * from "./features/edit/reconnect";


### PR DESCRIPTION
This change introduces a user interface -- as discussed in #83 -- for editing labels.

The UI for label editing is hooked up in the optional `labelEditUiModule` which reacts to the existing `EditLabelAction` and then provides a UI based on the `UIExtension` mechanism introduced a while ago. When the user confirms the edit, the UI extension sends out an `ApplyLabelEditAction`, which should be handled by a command actually updating the model. The default command just updates the text of the `EditableLabel`. In other use cases, such as GLSP or LSP driven diagrams, a different command could be bound that delegates performing the actual update to the respective server.

I tried to leave as much as possible in terms of styling to the CSS. However, the UI extension tries to obtain the label's font size and weight to provide a nice UX while editing. This can be overwritten however in `EditLabelUI.applyFontStyling(...)`.

By default, the editing is initiated by double-clicking an element (as before), or when pressing <kbd>F2</kbd> on a selected element. The target of the double-click or when <kbd>F2</kbd> is pressed can either be an `EditableLabel` directly or an `WithEditableLabel` that points to an `EditableLabel`. The latter is useful when the selectable element is in fact not a label directly but contains one somewhere (sort of the main label of an element).

In #83 we discussed how the default `ApplyLabelEditCommand` should be implemented and @spoenemann suggested to perform the label edit based on the nameable feature. In a first shot, however, it felt more flexible to just directly apply the label edit by updating the `EditableLabel.text` property. Together with the `WithEditableLabel` interface this makes it quite easy and flexible, imho.
However, if you prefer to have the default `ApplyLabelEditCommand` look up an element with the `Nameable` extension, I'm happy to change the implementation.

Moreover, note how the UI extension, command, etc. are exclusively built on `EditableLabel` and `WithEditableLabel`, as well as on `SModelElement` (for obtaining the ID). Thus, the editable label does not even have to be a label, which I think could be useful in some scenarios.

This change also introduces a basic label edit validation mechanism, if an `IEditLabelValidator` is bound. The validation result is added in terms of classes and attributes to the container element of the HTML input.

Finally, this change also slightly adapts the `UIExtension` mechanism so that we can more easily pass context elements into the extension, without relying on attributes that are set in the `SModel` only (such as the selected flag, which we used before).

All functionality is integrated in Sprotty's class diagram example. Here is the obligatory animated gif :)

![label-edit2](https://user-images.githubusercontent.com/588090/57472446-bdb19d80-728d-11e9-9574-360874bbce2f.gif)

Please let me know what you think! Thanks in advance!