### PR TITLE
Enhance context information for command palette action providers

### DIFF
--- a/css/command-palette.css
+++ b/css/command-palette.css
@@ -31,6 +31,10 @@
     font: inherit;
 }
 
+.command-palette-suggestions em {
+    font-weight: bold;
+}
+
 .command-palette-suggestions > div {
     padding: 0 4px;
 }

--- a/css/command-palette.css
+++ b/css/command-palette.css
@@ -27,12 +27,13 @@
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
 }
 
-.command-palette-suggestions * {
-    font: inherit;
+.command-palette-suggestions .icon {
+    padding-right: 0.3em;
 }
 
 .command-palette-suggestions em {
     font-weight: bold;
+    font-style: normal;
 }
 
 .command-palette-suggestions > div {

--- a/examples/classdiagram/class-diagram.html
+++ b/examples/classdiagram/class-diagram.html
@@ -6,6 +6,7 @@
     <title>sprotty Class Diagram Example</title>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css">    
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/balloon-css/0.5.0/balloon.min.css">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="css/page.css">
     <!-- support Microsoft browsers -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dom4/3.0.0/dom4.js">

--- a/src/base/di.config.ts
+++ b/src/base/di.config.ts
@@ -26,7 +26,7 @@ import { SModelFactory, SModelRegistry } from './model/smodel-factory';
 import { AnimationFrameSyncer } from "./animations/animation-frame-syncer";
 import { IViewer, Viewer, ModelRenderer } from "./views/viewer";
 import { ViewerOptions, defaultViewerOptions } from "./views/viewer-options";
-import { MouseTool, PopupMouseTool } from "./views/mouse-tool";
+import { MouseTool, PopupMouseTool, MousePositionTracker } from "./views/mouse-tool";
 import { KeyTool } from "./views/key-tool";
 import { FocusFixDecorator, IVNodeDecorator } from "./views/vnode-decorators";
 import { ViewRegistry } from "./views/view";
@@ -147,6 +147,10 @@ const defaultContainerModule = new ContainerModule((bind, _unbind, isBound) => {
     // UIExtension registry initialization ------------------------------------
     bind(TYPES.UIExtensionRegistry).to(UIExtensionRegistry).inSingletonScope();
     configureCommand({ bind, isBound }, SetUIExtensionVisibilityCommand);
+
+    // Tracker for last known mouse position on diagram ------------------------
+    bind(MousePositionTracker).toSelf().inSingletonScope();
+    bind(TYPES.MouseListener).toService(MousePositionTracker);
 });
 
 export default defaultContainerModule;

--- a/src/base/views/mouse-tool.ts
+++ b/src/base/views/mouse-tool.ts
@@ -23,8 +23,6 @@ import { TYPES } from "../types";
 import { DOMHelper } from "./dom-helper";
 import { IVNodeDecorator } from "./vnode-decorators";
 import { on } from "./vnode-utils";
-import { findParentByFeature } from "../model/smodel-utils";
-import { isViewport } from "../../features/viewport/model";
 import { Point } from "../../utils/geometry";
 
 @injectable()
@@ -33,7 +31,7 @@ export class MouseTool implements IVNodeDecorator {
     @inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher;
     @inject(TYPES.DOMHelper) protected domHelper: DOMHelper;
 
-    constructor(@multiInject(TYPES.MouseListener)@optional() protected mouseListeners: MouseListener[] = []) {}
+    constructor(@multiInject(TYPES.MouseListener) @optional() protected mouseListeners: MouseListener[] = []) { }
 
     register(mouseListener: MouseListener) {
         this.mouseListeners.push(mouseListener);
@@ -45,7 +43,7 @@ export class MouseTool implements IVNodeDecorator {
             this.mouseListeners.splice(index, 1);
     }
 
-    protected getTargetElement(model: SModelRoot, event: MouseEvent): SModelElement |undefined {
+    protected getTargetElement(model: SModelRoot, event: MouseEvent): SModelElement | undefined {
         let target = event.target as Element;
         const index = model.index;
         while (target) {
@@ -152,7 +150,7 @@ export class MouseTool implements IVNodeDecorator {
 
 @injectable()
 export class PopupMouseTool extends MouseTool {
-    constructor(@multiInject(TYPES.PopupMouseListener)@optional() protected mouseListeners: MouseListener[] = []) {
+    constructor(@multiInject(TYPES.PopupMouseListener) @optional() protected mouseListeners: MouseListener[] = []) {
         super(mouseListeners);
     }
 }
@@ -207,16 +205,14 @@ export class MousePositionTracker extends MouseListener {
     protected lastPosition: Point | undefined;
 
     mouseMove(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
-        const viewport = findParentByFeature(target, isViewport);
-        if (viewport) {
-            this.lastPosition = {
-                x: viewport.scroll.x + (event.offsetX / viewport.zoom),
-                y: viewport.scroll.y + (event.offsetY / viewport.zoom)
-            };
-        }
+        this.lastPosition = target.root.parentToLocal({ x: event.offsetX, y: event.offsetY });
         return [];
     }
 
+    /**
+     * Returns the last tracked mouse cursor position relative to the diagram root or `undefined`
+     * if no mouse cursor position was ever tracked yet.
+     */
     get lastPositionOnDiagram(): Point | undefined {
         return this.lastPosition;
     }

--- a/src/features/command-palette/action-providers.ts
+++ b/src/features/command-palette/action-providers.ts
@@ -22,9 +22,10 @@ import { ILogger } from "../../utils/logging";
 import { isNameable, name } from "../nameable/model";
 import { SelectAction } from "../select/select";
 import { CenterAction } from "../viewport/center-fit";
+import { Point } from "../../utils/geometry";
 
 export interface ICommandPaletteActionProvider {
-    getActions(root: Readonly<SModelRoot>): Promise<LabeledAction[]>;
+    getActions(root: Readonly<SModelRoot>, text: string, lastMousePosition?: Point): Promise<LabeledAction[]>;
 }
 
 @injectable()
@@ -33,8 +34,8 @@ export class CommandPaletteActionProviderRegistry implements ICommandPaletteActi
     constructor(@multiInject(TYPES.ICommandPaletteActionProvider) @optional() protected actionProviders: ICommandPaletteActionProvider[] = []) {
     }
 
-    getActions(root: Readonly<SModelRoot>) {
-        const actionLists = this.actionProviders.map(provider => provider.getActions(root));
+    getActions(root: Readonly<SModelRoot>, text: string, lastMousePosition?: Point) {
+        const actionLists = this.actionProviders.map(provider => provider.getActions(root, text, lastMousePosition));
         return Promise.all(actionLists).then(p => p.reduce((acc, promise) => promise !== undefined ? acc.concat(promise) : acc));
     }
 }
@@ -54,7 +55,7 @@ export class RevealNamedElementActionProvider implements ICommandPaletteActionPr
 
     constructor(@inject(TYPES.ILogger) protected logger: ILogger) { }
 
-    getActions(root: Readonly<SModelRoot>) {
+    getActions(root: Readonly<SModelRoot>, text: string, lastMousePosition?: Point) {
         return Promise.resolve(this.createSelectActions(root));
     }
 

--- a/src/features/command-palette/action-providers.ts
+++ b/src/features/command-palette/action-providers.ts
@@ -41,7 +41,7 @@ export class CommandPaletteActionProviderRegistry implements ICommandPaletteActi
 }
 
 export class LabeledAction {
-    constructor(readonly label: string, readonly actions: Action[]) { }
+    constructor(readonly label: string, readonly actions: Action[], readonly icon?: string) { }
 }
 
 export function isLabeledAction(element: any): element is LabeledAction {
@@ -62,6 +62,6 @@ export class RevealNamedElementActionProvider implements ICommandPaletteActionPr
     createSelectActions(modelRoot: SModelRoot): LabeledAction[] {
         const nameables = toArray(modelRoot.index.all().filter(element => isNameable(element)));
         return nameables.map(nameable => new LabeledAction(`Reveal ${name(nameable)}`,
-            [new SelectAction([nameable.id]), new CenterAction([nameable.id])]));
+            [new SelectAction([nameable.id]), new CenterAction([nameable.id])], 'fa-eye'));
     }
 }

--- a/src/features/command-palette/command-palette.ts
+++ b/src/features/command-palette/command-palette.ts
@@ -147,8 +147,15 @@ export class CommandPalette extends AbstractUIExtension {
         const itemElement = document.createElement("div");
         const wordMatcher = value.split(" ").join("|");
         const regex = new RegExp(wordMatcher, "gi");
-        itemElement.innerHTML = item.label.replace(regex, (match) => "<em>" + match + "</em>");
+        if (item.icon) {
+            this.renderIcon(itemElement, item.icon);
+        }
+        itemElement.innerHTML += item.label.replace(regex, (match) => "<em>" + match + "</em>");
         return itemElement;
+    }
+
+    protected renderIcon(itemElement: HTMLDivElement, icon: string) {
+        itemElement.innerHTML += `<span class="icon fa ${icon}"></span>`;
     }
 
     protected filterActions(filterText: string, actions: LabeledAction[]): LabeledAction[] {


### PR DESCRIPTION
This additional info includes the last known mouse position on the
diagram as well as the text entered into the command palette so far.
This additional info is helpful to allow for more sophisticated
and context sensitive suggestions and ordering of those suggestions.

Moreover, this change makes it easier to override the behavior for
fetching the command palette actions on typing, introduces a debounce
delay to avoid flooding the action providers with requests on each
keystroke, and finally, it adds a HTML class to the input element
while loading actions to allow visually showing that actions are
currently being loaded.

Signed-off-by: Philip Langer <planger@eclipsesource.com>