### PR TITLE
Added parameter to specify CustomFeatures in configureModelElement

### DIFF
--- a/examples/circlegraph/src/di.config.ts
+++ b/examples/circlegraph/src/di.config.ts
@@ -23,15 +23,6 @@ import {
 } from "../../../src";
 import { CircleNodeView } from "./views";
 
-class CustomEdge extends SEdge {
-    hasFeature(feature: symbol): boolean {
-        if (feature === selectFeature)
-            return false;
-        else
-            return super.hasFeature(feature);
-    }
-}
-
 export default (useWebsocket: boolean) => {
     require("../../../css/sprotty.css");
     require("../css/diagram.css");
@@ -45,7 +36,9 @@ export default (useWebsocket: boolean) => {
         const context = { bind, unbind, isBound, rebind };
         configureModelElement(context, 'graph', SGraph, SGraphView);
         configureModelElement(context, 'node:circle', CircularNode, CircleNodeView);
-        configureModelElement(context, 'edge:straight', CustomEdge, PolylineEdgeView);
+        configureModelElement(context, 'edge:straight', SEdge, PolylineEdgeView, {
+            disable: [selectFeature]
+        });
         configureViewerOptions(context, {
             needsClientLayout: false
         });

--- a/examples/circlegraph/src/di.config.ts
+++ b/examples/circlegraph/src/di.config.ts
@@ -33,6 +33,7 @@ export default (useWebsocket: boolean) => {
             bind(TYPES.ModelSource).to(LocalModelSource).inSingletonScope();
         rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
         rebind(TYPES.LogLevel).toConstantValue(LogLevel.log);
+
         const context = { bind, unbind, isBound, rebind };
         configureModelElement(context, 'graph', SGraph, SGraphView);
         configureModelElement(context, 'node:circle', CircularNode, CircleNodeView);

--- a/examples/classdiagram/src/di.config.ts
+++ b/examples/classdiagram/src/di.config.ts
@@ -22,7 +22,8 @@ import {
     fadeModule, ExpandButtonView, buttonModule, edgeEditModule, SRoutingHandleView, PreRenderedElement,
     HtmlRoot, SGraph, configureModelElement, SLabel, SCompartment, SEdge, SButton, SRoutingHandle,
     edgeLayoutModule, updateModule, graphModule, routingModule, modelSourceModule, commandPaletteModule,
-    RevealNamedElementActionProvider, CenterGridSnapper, labelEditModule, labelEditUiModule
+    RevealNamedElementActionProvider, CenterGridSnapper, labelEditModule, labelEditUiModule, expandFeature,
+    nameFeature, withEditLabelFeature, editLabelFeature
 } from "../../../src";
 import { ClassNodeView, IconView} from "./views";
 import { PopupModelProvider } from "./popup";
@@ -47,11 +48,18 @@ export default (useWebsocket: boolean, containerId: string) => {
         bind(TYPES.ISnapper).to(CenterGridSnapper);
         bind(TYPES.IEditLabelValidator).to(ClassDiagramLabelValidator);
         bind(TYPES.IEditLabelValidationDecorator).to(ClassDiagramLabelValidationDecorator);
+
         const context = { bind, unbind, isBound, rebind };
         configureModelElement(context, 'graph', SGraph, SGraphView);
-        configureModelElement(context, 'node:class', ClassNode, ClassNodeView);
-        configureModelElement(context, 'label:heading', ClassLabel, SLabelView);
-        configureModelElement(context, 'label:text', PropertyLabel, SLabelView);
+        configureModelElement(context, 'node:class', ClassNode, ClassNodeView, {
+            enable: [expandFeature, nameFeature, withEditLabelFeature]
+        });
+        configureModelElement(context, 'label:heading', ClassLabel, SLabelView, {
+            enable: [editLabelFeature]
+        });
+        configureModelElement(context, 'label:text', PropertyLabel, SLabelView, {
+            enable: [editLabelFeature]
+        });
         configureModelElement(context, 'comp:comp', SCompartment, SCompartmentView);
         configureModelElement(context, 'comp:header', SCompartment, SCompartmentView);
         configureModelElement(context, 'icon', Icon, IconView);
@@ -62,6 +70,7 @@ export default (useWebsocket: boolean, containerId: string) => {
         configureModelElement(context, 'button:expand', SButton, ExpandButtonView);
         configureModelElement(context, 'routing-point', SRoutingHandle, SRoutingHandleView);
         configureModelElement(context, 'volatile-routing-point', SRoutingHandle, SRoutingHandleView);
+
         configureViewerOptions(context, {
             needsClientLayout: true,
             baseDiv: containerId

--- a/examples/classdiagram/src/model.ts
+++ b/examples/classdiagram/src/model.ts
@@ -15,9 +15,8 @@
  ********************************************************************************/
 
 import {
-    SShapeElement, Expandable, boundsFeature, expandFeature, fadeFeature, layoutContainerFeature,
-    layoutableChildFeature, RectangularNode, Nameable, nameFeature, SLabel, EditableLabel, editLabelFeature,
-    WithEditableLabel, isEditableLabel, withEditLabelFeature
+    SShapeElement, Expandable, RectangularNode, Nameable, SLabel, WithEditableLabel, isEditableLabel,
+    boundsFeature, layoutContainerFeature, layoutableChildFeature, fadeFeature
 } from "../../../src";
 
 export class ClassNode extends RectangularNode implements Expandable, Nameable, WithEditableLabel {
@@ -40,27 +39,16 @@ export class ClassNode extends RectangularNode implements Expandable, Nameable, 
         }
         return this.id;
     }
-
-    hasFeature(feature: symbol) {
-        return feature === expandFeature || feature === nameFeature || feature === withEditLabelFeature || super.hasFeature(feature);
-    }
 }
 
-export class EditableSLabel extends SLabel implements EditableLabel {
-    hasFeature(feature: symbol) {
-        return feature === editLabelFeature || super.hasFeature(feature);
-    }
-}
-export class ClassLabel extends EditableSLabel { }
-export class PropertyLabel extends EditableSLabel { }
+export class ClassLabel extends SLabel { }
+export class PropertyLabel extends SLabel { }
 
 export class Icon extends SShapeElement {
+    static readonly DEFAULT_FEATURES = [boundsFeature, layoutContainerFeature, layoutableChildFeature, fadeFeature];
+
     size = {
         width: 32,
         height: 32
     };
-
-    hasFeature(feature: symbol): boolean {
-        return feature === boundsFeature || feature === layoutContainerFeature || feature === layoutableChildFeature || feature === fadeFeature;
-    }
 }

--- a/examples/mindmap/src/di.config.ts
+++ b/examples/mindmap/src/di.config.ts
@@ -20,7 +20,8 @@ import {
     LogLevel, WebSocketDiagramServer, boundsModule, moveModule, selectModule, undoRedoModule,
     viewportModule, hoverModule, LocalModelSource, HtmlRootView, PreRenderedView, exportModule,
     expandModule, fadeModule, buttonModule, PreRenderedElement, SNode, SLabel, HtmlRoot,
-    configureModelElement, configureCommand, graphModule, updateModule, routingModule, modelSourceModule
+    configureModelElement, configureCommand, graphModule, updateModule, routingModule,
+    modelSourceModule, popupFeature
 } from "../../../src";
 import { MindmapNodeView, PopupButtonView } from "./views";
 import { PopupButtonMouseListener, AddElementCommand, PopupModelProvider } from "./popup";
@@ -39,13 +40,17 @@ export default (useWebsocket: boolean, containerId: string) => {
         bind(TYPES.IPopupModelProvider).to(PopupModelProvider).inSingletonScope();
         bind(TYPES.PopupMouseListener).to(PopupButtonMouseListener);
         configureCommand(container, AddElementCommand);
+
         const context = { bind, unbind, isBound, rebind };
-        configureModelElement(container, 'mindmap', Mindmap, SGraphView);
+        configureModelElement(container, 'mindmap', Mindmap, SGraphView, {
+            enable: [popupFeature]
+        });
         configureModelElement(container, 'node', SNode, MindmapNodeView);
         configureModelElement(container, 'label', SLabel, SLabelView);
         configureModelElement(container, 'html', HtmlRoot, HtmlRootView);
         configureModelElement(container, 'pre-rendered', PreRenderedElement, PreRenderedView);
         configureModelElement(container, 'popup:button', PopupButton, PopupButtonView);
+
         configureViewerOptions(context, {
             needsClientLayout: false,
             baseDiv: containerId,

--- a/examples/mindmap/src/model.ts
+++ b/examples/mindmap/src/model.ts
@@ -14,17 +14,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { SModelRoot, SModelRootSchema, SGraph, popupFeature } from "../../../src";
+import { SModelRoot, SModelRootSchema, SGraph } from "../../../src";
 
 export class Mindmap extends SGraph {
-
-    hasFeature(feature: symbol): boolean {
-        if (feature === popupFeature)
-            return true;
-        else
-            return super.hasFeature(feature);
-    }
-
 }
 
 export interface PopupButtonSchema extends SModelRootSchema {

--- a/examples/multicore/src/chipmodel-factory.ts
+++ b/examples/multicore/src/chipmodel-factory.ts
@@ -16,7 +16,7 @@
 
 import {
     SGraphFactory, SChildElement, SModelElementSchema, SModelRoot, SModelRootSchema, SParentElement, getBasicType,
-    Direction, HtmlRootSchema, PreRenderedElementSchema, PreRenderedElement, HtmlRoot
+    Direction, HtmlRootSchema, PreRenderedElementSchema, PreRenderedElement, HtmlRoot, createFeatureSet
 } from '../../../src';
 import {
     Channel, ChannelSchema, Core, CoreSchema, Crossbar, CrossbarSchema, Processor, ProcessorSchema
@@ -31,6 +31,7 @@ export class ChipModelFactory extends SGraphFactory {
             if (this.isCoreSchema(schema)) {
                 this.validate(schema, parent);
                 const core = this.initializeChild(new Core(), schema, parent) as Core;
+                core.features = createFeatureSet(Core.DEFAULT_FEATURES);
                 core.bounds = {
                     x: core.column * (CORE_WIDTH + CORE_DISTANCE),
                     y: core.row * (CORE_WIDTH + CORE_DISTANCE),
@@ -40,11 +41,14 @@ export class ChipModelFactory extends SGraphFactory {
                 return core;
             } else if (this.isChannelSchema(schema)) {
                 this.validate(schema, parent);
-                return this.initializeChild(new Channel(), schema, parent);
-            } else if (this.isCrossbarSchema(schema))
+                const channel = this.initializeChild(new Channel(), schema, parent);
+                channel.features = createFeatureSet(Channel.DEFAULT_FEATURES);
+                return channel;
+            } else if (this.isCrossbarSchema(schema)) {
                 return this.initializeChild(new Crossbar(), schema, parent);
-            else if (this.isPreRenderedSchema(schema))
+            } else if (this.isPreRenderedSchema(schema)) {
                 return this.initializeChild(new PreRenderedElement(), schema, parent);
+            }
         } catch (e) {
             console.error(e.message);
         }
@@ -52,12 +56,15 @@ export class ChipModelFactory extends SGraphFactory {
     }
 
     createRoot(schema: SModelRootSchema): SModelRoot {
-        if (this.isProcessorSchema(schema))
-            return this.initializeRoot(new Processor(), schema);
-        else if (this.isHtmlRootSchema(schema))
+        if (this.isProcessorSchema(schema)) {
+            const processor = this.initializeRoot(new Processor(), schema);
+            processor.features = createFeatureSet(Processor.DEFAULT_FEATURES);
+            return processor;
+        } else if (this.isHtmlRootSchema(schema)) {
             return this.initializeRoot(new HtmlRoot(), schema);
-        else
+        } else {
             return super.createRoot(schema);
+        }
     }
 
     private validate(coreOrChannel: CoreSchema | ChannelSchema, processor?: SParentElement) {

--- a/examples/multicore/src/chipmodel.ts
+++ b/examples/multicore/src/chipmodel.ts
@@ -27,6 +27,8 @@ export interface ProcessorSchema extends SModelRootSchema {
 }
 
 export class Processor extends ViewportRootElement implements BoundsAware {
+    static readonly DEFAULT_FEATURES = [...ViewportRootElement.DEFAULT_FEATURES, boundsFeature];
+
     rows: number = 0;
     columns: number = 0;
     layoutOptions: any;
@@ -44,9 +46,6 @@ export class Processor extends ViewportRootElement implements BoundsAware {
         // Ignore the new bounds
     }
 
-    hasFeature(feature: symbol): boolean {
-        return feature === boundsFeature || super.hasFeature(feature);
-    }
 }
 
 export interface CoreSchema extends SModelElementSchema {
@@ -60,6 +59,9 @@ export interface CoreSchema extends SModelElementSchema {
 }
 
 export class Core extends SShapeElement implements Selectable, Fadeable, Hoverable, LayoutContainer {
+    static readonly DEFAULT_FEATURES = [selectFeature, fadeFeature, layoutContainerFeature,
+        hoverFeedbackFeature, popupFeature];
+
     hoverFeedback: boolean = false;
     column: number = 0;
     row: number = 0;
@@ -69,13 +71,6 @@ export class Core extends SShapeElement implements Selectable, Fadeable, Hoverab
     layout: string = 'vbox';
     resizeContainer: boolean = false;
 
-    hasFeature(feature: symbol): boolean {
-        return feature === selectFeature
-            || feature === fadeFeature
-            || feature === layoutContainerFeature
-            || feature === hoverFeedbackFeature
-            || feature === popupFeature;
-    }
 }
 
 export interface CrossbarSchema extends SModelElementSchema {
@@ -98,15 +93,14 @@ export interface ChannelSchema extends SModelElementSchema {
 }
 
 export class Channel extends SChildElement implements Selectable {
+    static readonly DEFAULT_FEATURES = [selectFeature];
+
     column: number = 0;
     row: number = 0;
     direction: Direction;
     load: number = 0;
     selected: boolean = false;
 
-    hasFeature(feature: symbol): boolean {
-        return feature === selectFeature;
-    }
 }
 
 

--- a/src/base/model/smodel-factory.ts
+++ b/src/base/model/smodel-factory.ts
@@ -163,7 +163,9 @@ export class SModelRegistry extends FactoryRegistry<SModelElement, void> {
         super();
 
         registrations.forEach(registration => {
-            const defaultFeatures = this.getDefaultFeatures(registration.constr);
+            let defaultFeatures = this.getDefaultFeatures(registration.constr);
+            if (!defaultFeatures && registration.features && registration.features.enable)
+                defaultFeatures = [];
             if (defaultFeatures) {
                 const featureSet = createFeatureSet(defaultFeatures, registration.features);
                 this.register(registration.type, () => {

--- a/src/base/model/smodel-utils.ts
+++ b/src/base/model/smodel-utils.ts
@@ -14,8 +14,21 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { SChildElement, SModelElement, SModelElementSchema } from "./smodel";
+import { interfaces } from "inversify";
+import { TYPES } from "../types";
 import { Point, Bounds } from "../../utils/geometry";
+import { SChildElement, SModelElement, SModelElementSchema } from "./smodel";
+import { SModelElementRegistration, CustomFeatures } from "./smodel-factory";
+
+/**
+ * Register a model element constructor for an element type.
+ */
+export function registerModelElement(context: { bind: interfaces.Bind, isBound: interfaces.IsBound },
+        type: string, constr: new () => SModelElement, features?: CustomFeatures): void {
+    context.bind<SModelElementRegistration>(TYPES.SModelElementRegistration).toConstantValue({
+        type, constr, features
+    });
+}
 
 /**
  * Model element types can include a colon to separate the basic type and a sub-type. This function

--- a/src/base/model/smodel.ts
+++ b/src/base/model/smodel.ts
@@ -44,6 +44,7 @@ export interface SModelRootSchema extends SModelElementSchema {
 export class SModelElement {
     type: string;
     id: string;
+    features?: FeatureSet;
     cssClasses?: string[];
 
     get root(): SModelRoot {
@@ -65,11 +66,15 @@ export class SModelElement {
 
     /**
      * A feature is a symbol identifying some functionality that can be enabled or disabled for
-     * a model element. The base implementation always returns false, so it disables all features.
+     * a model element. The set of supported features is determined by the `features` property.
      */
     hasFeature(feature: symbol): boolean {
-        return false;
+        return this.features !== undefined && this.features.has(feature);
     }
+}
+
+export interface FeatureSet {
+    has(feature: symbol): boolean
 }
 
 export function isParent(element: SModelElementSchema | SModelElement):

--- a/src/base/views/view.tsx
+++ b/src/base/views/view.tsx
@@ -20,11 +20,12 @@ import { svg } from 'snabbdom-jsx';
 import { injectable, multiInject, optional, interfaces } from "inversify";
 import { VNode } from "snabbdom/vnode";
 import { TYPES } from "../types";
-import { SModelElement, SModelRoot, SParentElement } from "../model/smodel";
-import { EMPTY_ROOT, SModelElementRegistration } from "../model/smodel-factory";
 import { InstanceRegistry } from "../../utils/registry";
 import { Point, ORIGIN_POINT } from "../../utils/geometry";
 import { isInjectable } from '../../utils/inversify';
+import { SModelElement, SModelRoot, SParentElement } from "../model/smodel";
+import { EMPTY_ROOT, CustomFeatures } from "../model/smodel-factory";
+import { registerModelElement } from '../model/smodel-utils';
 
 /**
  * Base interface for the components that turn GModelElements into virtual DOM elements.
@@ -79,15 +80,12 @@ export class ViewRegistry extends InstanceRegistry<IView> {
 }
 
 /**
- * Utility function to register model and view constructors for a model element type.
+ * Combines `registerModelElement` and `configureView`.
  */
 export function configureModelElement(context: { bind: interfaces.Bind, isBound: interfaces.IsBound }, type: string,
-    modelConstr: new () => SModelElement, constr: new () => IView): void {
-    context.bind<SModelElementRegistration>(TYPES.SModelElementRegistration).toConstantValue({
-        type,
-        constr: modelConstr
-    });
-    configureView(context, type, constr);
+        modelConstr: new () => SModelElement, viewConstr: new () => IView, features?: CustomFeatures): void {
+    registerModelElement(context, type, modelConstr, features);
+    configureView(context, type, viewConstr);
 }
 
 /**

--- a/src/features/bounds/hbox-layout.spec.ts
+++ b/src/features/bounds/hbox-layout.spec.ts
@@ -17,6 +17,7 @@
 import 'mocha';
 import { expect } from "chai";
 import { SModelElement, SParentElement } from '../../base/model/smodel';
+import { createFeatureSet } from '../../base/model/smodel-factory';
 import { SNode, SLabel } from '../../graph/sgraph';
 import { StatefulLayouter, LayoutRegistry } from './layout';
 import { BoundsData } from './hidden-bounds-updater';
@@ -25,12 +26,6 @@ import { ConsoleLogger } from '../../utils/logging';
 import { Dimension } from '../../utils/geometry';
 import { layoutableChildFeature } from './model';
 
-class ChildNode extends SNode {
-    hasFeature(feature: symbol) {
-        return feature === layoutableChildFeature || super.hasFeature(feature);
-    }
-}
-
 describe('HBoxLayouter', () => {
 
     const log = new ConsoleLogger();
@@ -38,7 +33,8 @@ describe('HBoxLayouter', () => {
     const map = new Map<SModelElement, BoundsData>();
 
     function snode(size: Dimension): SNode {
-        const node = new ChildNode();
+        const node = new SNode();
+        node.features = createFeatureSet(SNode.DEFAULT_FEATURES, { enable: [layoutableChildFeature] })
         node.bounds = {
             x: 0, y: 0, width: size.width, height: size.height
         };
@@ -47,6 +43,7 @@ describe('HBoxLayouter', () => {
 
     function slabel(size: Dimension): SLabel {
         const label = new SLabel();
+        label.features = createFeatureSet(SLabel.DEFAULT_FEATURES);
         label.bounds = {
             x: 0, y: 0, width: size.width, height: size.height
         };

--- a/src/features/bounds/stack-layout.spec.ts
+++ b/src/features/bounds/stack-layout.spec.ts
@@ -17,6 +17,7 @@
 import 'mocha';
 import { expect } from "chai";
 import { SModelElement, SParentElement } from '../../base/model/smodel';
+import { createFeatureSet } from '../../base/model/smodel-factory';
 import { SNode, SLabel } from '../../graph/sgraph';
 import { StatefulLayouter, LayoutRegistry } from './layout';
 import { BoundsData } from './hidden-bounds-updater';
@@ -32,6 +33,7 @@ describe('StackLayouter', () => {
 
     function snode(size: Dimension): SNode {
         const node = new SNode();
+        node.features = createFeatureSet(SNode.DEFAULT_FEATURES);
         node.bounds = {
             x: 0, y: 0, width: size.width, height: size.height
         };
@@ -40,6 +42,7 @@ describe('StackLayouter', () => {
 
     function slabel(size: Dimension): SLabel {
         const label = new SLabel();
+        label.features = createFeatureSet(SLabel.DEFAULT_FEATURES);
         label.bounds = {
             x: 0, y: 0, width: size.width, height: size.height
         };

--- a/src/features/bounds/vbox-layout.spec.ts
+++ b/src/features/bounds/vbox-layout.spec.ts
@@ -17,6 +17,7 @@
 import 'mocha';
 import { expect } from "chai";
 import { SModelElement, SParentElement } from '../../base/model/smodel';
+import { createFeatureSet } from '../../base/model/smodel-factory';
 import { SNode, SLabel } from '../../graph/sgraph';
 import { StatefulLayouter, LayoutRegistry } from './layout';
 import { BoundsData } from './hidden-bounds-updater';
@@ -32,6 +33,7 @@ describe('VBoxLayouter', () => {
 
     function snode(size: Dimension): SNode {
         const node = new SNode();
+        node.features = createFeatureSet(SNode.DEFAULT_FEATURES);
         node.bounds = {
             x: 0, y: 0, width: size.width, height: size.height
         };
@@ -40,6 +42,7 @@ describe('VBoxLayouter', () => {
 
     function slabel(size: Dimension): SLabel {
         const label = new SLabel();
+        label.features = createFeatureSet(SLabel.DEFAULT_FEATURES);
         label.bounds = {
             x: 0, y: 0, width: size.width, height: size.height
         };

--- a/src/features/button/model.ts
+++ b/src/features/button/model.ts
@@ -23,9 +23,7 @@ export interface SButtonSchema extends SShapeElementSchema {
 }
 
 export class SButton extends SShapeElement {
-    enabled = true;
+    static readonly DEFAULT_FEATURES = [boundsFeature, layoutableChildFeature, fadeFeature];
 
-    hasFeature(feature: symbol) {
-        return feature === boundsFeature || feature === fadeFeature || feature === layoutableChildFeature;
-    }
+    enabled = true;
 }

--- a/src/features/decoration/model.ts
+++ b/src/features/decoration/model.ts
@@ -29,13 +29,7 @@ export function isDecoration<T extends SModelElement>(e: T): e is T & Decoration
 }
 
 export class SDecoration extends SShapeElement implements Decoration {
-    hasFeature(feature: symbol) {
-        return feature === decorationFeature
-            || feature === boundsFeature
-            || feature === hoverFeedbackFeature
-            || feature === popupFeature
-            || super.hasFeature(feature);
-    }
+    static readonly DEFAULT_FEATURES = [decorationFeature, boundsFeature, hoverFeedbackFeature, popupFeature];
 }
 
 export type SIssueSeverity = 'error' | 'warning' | 'info';

--- a/src/features/routing/model.ts
+++ b/src/features/routing/model.ts
@@ -97,6 +97,8 @@ export abstract class SConnectableElement extends SShapeElement implements Conne
 export type RoutingHandleKind = 'junction' | 'line' | 'source' | 'target' | 'manhattan-50%';
 
 export class SRoutingHandle extends SChildElement implements Selectable, Hoverable {
+    static readonly DEFAULT_FEATURES = [selectFeature, moveFeature, hoverFeedbackFeature];
+
     /**
      * 'junction' is a point where two line segments meet,
      * 'line' is a volatile handle placed on a line segment,
@@ -112,22 +114,17 @@ export class SRoutingHandle extends SChildElement implements Selectable, Hoverab
     selected: boolean = false;
     danglingAnchor?: SDanglingAnchor;
 
-    hasFeature(feature: symbol): boolean {
-        return feature === selectFeature || feature === moveFeature || feature === hoverFeedbackFeature;
-    }
 }
 
 export class SDanglingAnchor extends SConnectableElement {
+    static readonly DEFAULT_FEATURES = [deletableFeature];
+
     original?: SModelElement;
     type = 'dangling-anchor';
 
     constructor() {
         super();
         this.size = { width: 0, height: 0 };
-    }
-
-    hasFeature(feature: symbol) {
-        return feature === deletableFeature;
     }
 }
 

--- a/src/features/viewport/viewport-root.ts
+++ b/src/features/viewport/viewport-root.ts
@@ -24,15 +24,13 @@ import { exportFeature } from "../export/model";
  * a `scroll` translation and a `zoom` scaling.
  */
 export class ViewportRootElement extends SModelRoot implements Viewport {
+    static readonly DEFAULT_FEATURES = [viewportFeature, exportFeature];
+
     scroll: Point = { x: 0, y: 0 };
     zoom: number = 1;
 
     constructor(index?: SModelIndex<SModelElement>) {
         super(index);
-    }
-
-    hasFeature(feature: symbol): boolean {
-        return feature === viewportFeature || feature === exportFeature;
     }
 
     localToParent(point: Point | Bounds): Bounds {

--- a/src/graph/sgraph-factory.ts
+++ b/src/graph/sgraph-factory.ts
@@ -26,6 +26,11 @@ import {
 } from "./sgraph";
 import { SButton, SButtonSchema } from '../features/button/model';
 
+/**
+ * @deprecated
+ * Subclassing SModelFactory is discouraged. Use `registerModelElement`
+ * or `configureModelElement` instead.
+ */
 @injectable()
 export class SGraphFactory extends SModelFactory {
 

--- a/src/graph/sgraph-factory.ts
+++ b/src/graph/sgraph-factory.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { injectable } from "inversify";
-import { SModelFactory } from "../base/model/smodel-factory";
+import { SModelFactory, createFeatureSet } from "../base/model/smodel-factory";
 import {
     SChildElement, SModelElementSchema, SModelRoot, SModelRootSchema, SParentElement
 } from "../base/model/smodel";
@@ -29,6 +29,14 @@ import { SButton, SButtonSchema } from '../features/button/model';
 @injectable()
 export class SGraphFactory extends SModelFactory {
 
+    protected readonly defaultGraphFeatures = createFeatureSet(SGraph.DEFAULT_FEATURES);
+    protected readonly defaultNodeFeatures = createFeatureSet(SNode.DEFAULT_FEATURES);
+    protected readonly defaultPortFeatures = createFeatureSet(SPort.DEFAULT_FEATURES);
+    protected readonly defaultEdgeFeatures = createFeatureSet(SEdge.DEFAULT_FEATURES);
+    protected readonly defaultLabelFeatures = createFeatureSet(SLabel.DEFAULT_FEATURES);
+    protected readonly defaultCompartmentFeatures = createFeatureSet(SCompartment.DEFAULT_FEATURES);
+    protected readonly defaultButtonFeatures = createFeatureSet(SButton.DEFAULT_FEATURES);
+
     createElement(schema: SModelElementSchema, parent?: SParentElement): SChildElement {
         let child: SChildElement;
         if (this.registry.hasKey(schema.type)) {
@@ -38,16 +46,22 @@ export class SGraphFactory extends SModelFactory {
             child = regElement;
         } else if (this.isNodeSchema(schema)) {
             child = new SNode();
+            child.features = this.defaultNodeFeatures;
         } else if (this.isPortSchema(schema)) {
             child = new SPort();
+            child.features = this.defaultPortFeatures;
         } else if (this.isEdgeSchema(schema)) {
             child = new SEdge();
+            child.features = this.defaultEdgeFeatures;
         } else if (this.isLabelSchema(schema)) {
             child = new SLabel();
+            child.features = this.defaultLabelFeatures;
         } else if (this.isCompartmentSchema(schema)) {
             child = new SCompartment();
+            child.features = this.defaultCompartmentFeatures;
         } else if (this.isButtonSchema(schema)) {
             child = new SButton();
+            child.features = this.defaultButtonFeatures;
         } else {
             child = new SChildElement();
         }
@@ -63,6 +77,7 @@ export class SGraphFactory extends SModelFactory {
             root = regElement;
         } else if (this.isGraphSchema(schema)) {
             root = new SGraph();
+            root.features = this.defaultGraphFeatures;
         } else {
             root = new SModelRoot();
         }

--- a/src/graph/sgraph.ts
+++ b/src/graph/sgraph.ts
@@ -68,6 +68,9 @@ export interface SNodeSchema extends SShapeElementSchema {
  * the edge, or indirect through a port, i.e. it contains an SPort which is the source or target of the edge.
  */
 export class SNode extends SConnectableElement implements Selectable, Fadeable, Hoverable {
+    static readonly DEFAULT_FEATURES = [connectableFeature, deletableFeature, selectFeature, boundsFeature,
+        moveFeature, layoutContainerFeature, fadeFeature, hoverFeedbackFeature, popupFeature];
+
     children: SChildElement[];
     layout?: string;
     selected: boolean = false;
@@ -78,11 +81,6 @@ export class SNode extends SConnectableElement implements Selectable, Fadeable, 
         return this.children.find(c => c instanceof SPort) === undefined;
     }
 
-    hasFeature(feature: symbol): boolean {
-        return feature === selectFeature || feature === moveFeature || feature === boundsFeature
-            || feature === layoutContainerFeature || feature === fadeFeature || feature === hoverFeedbackFeature
-            || feature === popupFeature || feature === connectableFeature || feature === deletableFeature;
-    }
 }
 
 /**
@@ -99,14 +97,13 @@ export interface SPortSchema extends SShapeElementSchema {
  * A port is a connection point for edges. It should always be contained in an SNode.
  */
 export class SPort extends SConnectableElement implements Selectable, Fadeable, Hoverable {
+    static readonly DEFAULT_FEATURES = [connectableFeature, selectFeature, boundsFeature, fadeFeature,
+        hoverFeedbackFeature];
+
     selected: boolean = false;
     hoverFeedback: boolean = false;
     opacity: number = 1;
 
-    hasFeature(feature: symbol): boolean {
-        return feature === selectFeature || feature === boundsFeature || feature === fadeFeature
-            || feature === hoverFeedbackFeature || feature === connectableFeature;
-    }
 }
 
 /**
@@ -128,15 +125,13 @@ export interface SEdgeSchema extends SModelElementSchema {
  * ids and can be resolved with the index stored in the root element.
  */
 export class SEdge extends SRoutableElement implements Fadeable, Selectable, Hoverable, BoundsAware {
+    static readonly DEFAULT_FEATURES = [editFeature, deletableFeature, selectFeature, fadeFeature,
+        hoverFeedbackFeature];
+
     selected: boolean = false;
     hoverFeedback: boolean = false;
     opacity: number = 1;
 
-    hasFeature(feature: symbol): boolean {
-        return feature === fadeFeature || feature === selectFeature ||
-            feature === editFeature || feature === hoverFeedbackFeature ||
-            feature === deletableFeature;
-    }
 }
 
 /**
@@ -151,15 +146,15 @@ export interface SLabelSchema extends SShapeElementSchema {
  * A label can be attached to a node, edge, or port, and contains some text to be rendered in its view.
  */
 export class SLabel extends SShapeElement implements Selectable, Alignable, Fadeable {
+    static readonly DEFAULT_FEATURES = [boundsFeature, alignFeature, layoutableChildFeature,
+        edgeLayoutFeature, fadeFeature];
+
     text: string;
     selected: boolean = false;
     alignment: Point = ORIGIN_POINT;
     opacity = 1;
     edgePlacement?: EdgePlacement;
 
-    hasFeature(feature: symbol) {
-        return feature === boundsFeature || feature === alignFeature || feature === fadeFeature || feature === layoutableChildFeature || feature === edgeLayoutFeature;
-    }
 }
 
 /**
@@ -174,14 +169,14 @@ export interface SCompartmentSchema extends SShapeElementSchema {
  * or `hbox` layout is used to arrange these children.
  */
 export class SCompartment extends SShapeElement implements Fadeable {
+    static readonly DEFAULT_FEATURES = [boundsFeature, layoutContainerFeature, layoutableChildFeature,
+        fadeFeature];
+
     children: SChildElement[];
     layout?: string;
     layoutOptions?: {[key: string]: string | number | boolean};
     opacity = 1;
 
-    hasFeature(feature: symbol) {
-        return feature === boundsFeature || feature === layoutContainerFeature || feature === layoutableChildFeature || feature === fadeFeature;
-    }
 }
 
 /**

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -108,6 +108,8 @@ export interface ShapedPreRenderedElementSchema extends PreRenderedElementSchema
  * Same as PreRenderedElement, but with a position and a size.
  */
 export class ShapedPreRenderedElement extends PreRenderedElement implements BoundsAware, Locateable, Selectable, Alignable {
+    static readonly DEFAULT_FEATURES = [moveFeature, boundsFeature, selectFeature, alignFeature];
+
     position: Point = ORIGIN_POINT;
     size: Dimension = EMPTY_DIMENSION;
     selected: boolean = false;
@@ -133,7 +135,4 @@ export class ShapedPreRenderedElement extends PreRenderedElement implements Boun
         };
     }
 
-    hasFeature(feature: symbol): boolean {
-        return feature === moveFeature || feature === boundsFeature || feature === selectFeature || feature === alignFeature;
-    }
 }

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -18,7 +18,7 @@ import { injectable } from "inversify";
 
 @injectable()
 export class ProviderRegistry<T, U> {
-    protected elements: Map<string, new(u: U) => T> = new Map;
+    protected elements: Map<string, new (u: U) => T> = new Map;
 
     register(key: string, cstr: new (u: U) => T) {
         if (key === undefined)


### PR DESCRIPTION
Fixes #104. I chose a solution that operates in the registry for model elements, not in the factory or the element constructors, because I wanted to make sure that all instances of an element type hold a reference to the same feature set, to avoid unnecessarily high memory usage.