### PR TITLE
viewport: Fixed FitToScreenCommand from zooming to Infinity

### DIFF
--- a/src/features/viewport/center-fit.ts
+++ b/src/features/viewport/center-fit.ts
@@ -205,6 +205,9 @@ export class FitToScreenCommand extends BoundsAwareViewportCommand {
             model.canvasBounds.height / (bounds.height + delta));
         if (this.action.maxZoom !== undefined)
            zoom = Math.min(zoom, this.action.maxZoom);
+        if (zoom === Infinity) {
+            zoom = 1;
+        }
         return {
             scroll: {
                 x: c.x - 0.5 * model.canvasBounds.width / zoom,


### PR DESCRIPTION
This was breaking all other zoom features, if some initial model that was drawn had zero size and therefore infinite zoom. With this, it just defaults back to a zoom level of 1.

Signed-off-by: Niklas Rentz <nre@informatik.uni-kiel.de>