### PR TITLE
Fixed zooming for Firefox

### DIFF
--- a/src/base/views/viewer.tsx
+++ b/src/base/views/viewer.tsx
@@ -28,7 +28,7 @@ import { classModule } from "snabbdom/modules/class";
 import { inject, injectable, multiInject, optional } from "inversify";
 import { TYPES } from "../types";
 import { ILogger } from "../../utils/logging";
-import { ORIGIN_POINT } from "../../utils/geometry";
+import { getWindowScroll } from '../../utils/browser';
 import { SModelElement, SModelRoot, SParentElement } from "../model/smodel";
 import { IActionDispatcher } from "../actions/action-dispatcher";
 import { Action } from '../actions/action';
@@ -186,7 +186,7 @@ export class ModelViewer implements IViewer {
 
     protected getBoundsInPage(element: Element) {
         const bounds = element.getBoundingClientRect();
-        const scroll = typeof window !== 'undefined' ? {x: window.scrollX, y: window.scrollY} : ORIGIN_POINT;
+        const scroll = getWindowScroll();
         return {
             x: bounds.left + scroll.x,
             y: bounds.top + scroll.y,

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -14,6 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Point, ORIGIN_POINT } from "./geometry";
+
 /**
  * Returns whether the mouse or keyboard event includes the CMD key
  * on Mac or CTRL key on Linux / others.
@@ -39,4 +41,17 @@ export function isCrossSite(url: string): boolean {
         return baseURL.length > 0 && !url.startsWith(baseURL);
     }
     return false;
+}
+
+/**
+ * Returns the amount of scroll of the browser window as a point.
+ */
+export function getWindowScroll(): Point {
+    if (typeof window === 'undefined') {
+        return ORIGIN_POINT;
+    }
+    return {
+        x: window.scrollX,
+        y: window.scrollY
+    };
 }


### PR DESCRIPTION
Fixes #114.

 * Take into account the `deltaMode` of the WheelEvent.
 * Use `clientX` / `clientY` instead of the unreliable `offsetX` / `offsetY`