### PR TITLE
Support for cycling through command palettes (#140)

### DIFF
--- a/src/features/command-palette/command-palette.ts
+++ b/src/features/command-palette/command-palette.ts
@@ -64,10 +64,7 @@ export class CommandPalette extends AbstractUIExtension {
         super.show(root, ...contextElementIds);
         this.paletteIndex = 0;
         this.contextActions = undefined;
-
-        if (this.inputElement!.value) {
-            this.inputElement.setSelectionRange(0, this.inputElement.value.length);
-        }
+        this.inputElement!.value = "";
         this.autoCompleteResult = configureAutocomplete(this.autocompleteSettings(root));
         this.inputElement.focus();
     }


### PR DESCRIPTION
Fixes #140 
For illustration purposes, I integrated this -- as usual -- into the class diagram example (below I pushed <kbd>Ctrl+Space</kbd> multiple times).
![Peek 2019-11-02 20-50](https://user-images.githubusercontent.com/588090/68076240-6dd21000-fdb2-11e9-803b-0ef5e4947ac2.gif)
