### PR TITLE
Improve loading indicator of command palette

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,13 @@ spec:
   - name: node
     image: node:8.12-alpine
     tty: true
+    resources:
+      limits:
+        memory: "2Gi"
+        cpu: "1"
+      requests:
+        memory: "2Gi"
+        cpu: "1"
 """
 
 pipeline {

--- a/src/features/command-palette/command-palette.ts
+++ b/src/features/command-palette/command-palette.ts
@@ -119,6 +119,7 @@ export class CommandPalette extends AbstractUIExtension {
             emptyMsg: "No commands available",
             className: "command-palette-suggestions",
             debounceWaitMs: this.debounceWaitMs,
+            showOnFocus: true,
             minLength: -1,
             fetch: (text: string, update: (items: LabeledAction[]) => void) =>
                 this.updateAutoCompleteActions(update, text, root),

--- a/src/features/command-palette/command-palette.ts
+++ b/src/features/command-palette/command-palette.ts
@@ -50,6 +50,7 @@ export class CommandPalette extends AbstractUIExtension {
     protected yOffset = 20;
     protected defaultWidth = 400;
     protected debounceWaitMs = 100;
+    protected noCommandsMsg = "No commands available";
 
     protected inputElement: HTMLInputElement;
     protected loadingIndicator: HTMLSpanElement;
@@ -116,7 +117,7 @@ export class CommandPalette extends AbstractUIExtension {
     private autocompleteSettings(root: Readonly<SModelRoot>): AutocompleteSettings<LabeledAction> {
         return {
             input: this.inputElement,
-            emptyMsg: "No commands available",
+            emptyMsg: this.noCommandsMsg,
             className: "command-palette-suggestions",
             debounceWaitMs: this.debounceWaitMs,
             showOnFocus: true,
@@ -170,7 +171,7 @@ export class CommandPalette extends AbstractUIExtension {
 
     protected renderLabeledActionSuggestion(item: LabeledAction, value: string) {
         const itemElement = document.createElement("div");
-        const wordMatcher = value.split(" ").join("|");
+        const wordMatcher = espaceForRegExp(value).split(" ").join("|");
         const regex = new RegExp(wordMatcher, "gi");
         if (item.icon) {
             this.renderIcon(itemElement, item.icon);
@@ -212,6 +213,10 @@ function toActionArray(input: LabeledAction | Action[] | Action): Action[] {
         return [input];
     }
     return [];
+}
+
+function espaceForRegExp(value: string): string {
+    return value.replace(/([.?*+^$[\]\\(){}|-])/g, '\\$1');
 }
 
 export class CommandPaletteKeyListener extends KeyListener {


### PR DESCRIPTION
This change simplifies showing a loading indicator while the
command palette is loading actions, e.g. with fontawesome.
It is now easy to just override loadingIndicatorClasses, which
will be assigned to a span element after the command palette
input. With CSS and fontawesome, clients can then show a
spinning icon while the actions are loading with plain css.

Signed-off-by: Philip Langer <planger@eclipsesource.com>