### PR TITLE
Reset previous hover feedback on mouseover

### DIFF
--- a/src/features/hover/hover.spec.ts
+++ b/src/features/hover/hover.spec.ts
@@ -65,6 +65,11 @@ describe('hover', () => {
     class HoverableTarget extends SModelElement implements Hoverable {
         hoverFeedback: boolean = false;
 
+        constructor(id: string = "1") {
+            super();
+            this.id = id;
+        }
+
         hasFeature(feature: symbol): boolean {
             return feature === hoverFeedbackFeature;
         }
@@ -89,6 +94,25 @@ describe('hover', () => {
 
             expect(mouseOverResult).to.have.lengthOf(1);
             expect(mouseOverResult[0]).to.be.an.instanceof(HoverFeedbackAction);
+        });
+        it('resets the hover feedback on hovering over another element', () => {
+            const target = new HoverableTarget("1");
+            const anotherTarget = new HoverableTarget("2");
+            hoverListener.mouseOver(target, event);
+            const mouseOverResult: (Action | Promise<Action>)[] = hoverListener.mouseOver(anotherTarget, event);
+
+            expect(mouseOverResult).to.have.lengthOf(2);
+            expect(mouseOverResult[0]).to.be.an.instanceof(HoverFeedbackAction);
+            expect(mouseOverResult[1]).to.be.an.instanceof(HoverFeedbackAction);
+
+            const action1 = mouseOverResult[0] as HoverFeedbackAction;
+            const action2 = mouseOverResult[1] as HoverFeedbackAction;
+            const actionForTarget = [action1, action2].filter(action => action.mouseoverElement === target.id);
+            const actionForAnotherTarget = [action1, action2].filter(action => action.mouseoverElement === anotherTarget.id);
+            expect(actionForTarget[0].mouseIsOver).to.be.false;
+            expect(actionForAnotherTarget[0].mouseIsOver).to.be.true;
+            // reset state by hovering over the root
+            hoverListener.mouseOver(new SModelRoot(), event);
         });
         it('contains SetPopupModelAction if popup is open and hovering over an non-hoverable element', () => {
             hoverListener.popupIsOpen = true;

--- a/src/features/hover/hover.ts
+++ b/src/features/hover/hover.ts
@@ -182,6 +182,8 @@ export abstract class AbstractHoverMouseListener extends MouseListener {
 @injectable()
 export class HoverMouseListener extends AbstractHoverMouseListener {
 
+    protected lastHoverFeedbackElementId?: string;
+
     @inject(TYPES.ViewerOptions) protected options: ViewerOptions;
 
     protected computePopupBounds(target: SModelElement, mousePosition: Point): Bounds {
@@ -245,9 +247,15 @@ export class HoverMouseListener extends AbstractHoverMouseListener {
                 (this.state.previousPopupElement === undefined || this.state.previousPopupElement.id !== popupTarget.id)) {
                 result.push(this.startMouseOverTimer(popupTarget, event));
             }
+            if (this.lastHoverFeedbackElementId) {
+                result.push(new HoverFeedbackAction(this.lastHoverFeedbackElementId, false));
+                this.lastHoverFeedbackElementId = undefined;
+            }
             const hoverTarget = findParentByFeature(target, isHoverable);
-            if (hoverTarget !== undefined)
+            if (hoverTarget !== undefined) {
                 result.push(new HoverFeedbackAction(hoverTarget.id, true));
+                this.lastHoverFeedbackElementId = hoverTarget.id;
+            }
         }
         return result;
     }
@@ -265,8 +273,10 @@ export class HoverMouseListener extends AbstractHoverMouseListener {
                 }
                 this.stopMouseOverTimer();
                 const hoverTarget = findParentByFeature(target, isHoverable);
-                if (hoverTarget !== undefined)
+                if (hoverTarget !== undefined) {
                     result.push(new HoverFeedbackAction(hoverTarget.id, false));
+                    this.lastHoverFeedbackElementId = undefined;
+                }
             }
         }
         return result;


### PR DESCRIPTION
With this change, I suggest to always reset the hover feedback of the previous element on mouseover of any diagram element. This ensures that we reset the hover feedback also if the user exited the element without producing any mouseout event of the original hovered element.

Resolves #152

Signed-off-by: Philip Langer <planger@eclipsesource.com>