### PR TITLE
Rename context menu provider for delete

### DIFF
--- a/src/features/context-menu/context-menu-service.ts
+++ b/src/features/context-menu/context-menu-service.ts
@@ -29,11 +29,11 @@ export interface MenuItem extends LabeledAction {
      */
     readonly parentId?: string;
     /** Function determining whether the element is enabled. */
-    readonly isEnabled?: () => boolean | Promise<boolean>;
+    readonly isEnabled?: () => boolean;
     /** Function determining whether the element is visible. */
-    readonly isVisible?: () => boolean | Promise<boolean>;
+    readonly isVisible?: () => boolean;
     /** Function determining whether the element is toggled on or off. */
-    readonly isToggled?: () => boolean | Promise<boolean>;
+    readonly isToggled?: () => boolean;
     /** Children of this item. If this item has children, they will be added into a submenu of this item. */
     children?: MenuItem[];
 }

--- a/src/features/context-menu/menu-providers.ts
+++ b/src/features/context-menu/menu-providers.ts
@@ -65,7 +65,7 @@ export class ContextMenuProviderRegistry implements IContextMenuItemProvider {
 }
 
 @injectable()
-export class DeleteContextMenuProviderRegistry implements IContextMenuItemProvider {
+export class DeleteContextMenuItemProvider implements IContextMenuItemProvider {
     getItems(root: Readonly<SModelRoot>, lastMousePosition?: Point): Promise<MenuItem[]> {
         const selectedElements = Array.from(root.index.all().filter(isSelected).filter(isDeletable));
         return Promise.resolve([


### PR DESCRIPTION
Also remove Promise<boolean> from the allowed return types in
`MenuItem`, since this may cause issues for `ContextMenuServiceProvider`
that can't handle a promise as they need to return synchonosly.
This is for instance true for the Theia CommandHandler in sprotty-theia:
src/sprotty/theia-sprotty-context-menu-service.ts#L117