### PR TITLE
#162: IE11-compatible window scroll retrieval

### DIFF
--- a/src/base/features/initialize-canvas.ts
+++ b/src/base/features/initialize-canvas.ts
@@ -17,12 +17,13 @@
 import { injectable, inject } from "inversify";
 import { VNode } from "snabbdom/vnode";
 import { TYPES } from "../types";
-import { almostEquals, Bounds, isValidDimension, ORIGIN_POINT } from '../../utils/geometry';
+import { almostEquals, Bounds, isValidDimension } from '../../utils/geometry';
 import { Action } from '../actions/action';
 import { IActionDispatcher } from '../actions/action-dispatcher';
 import { IVNodePostprocessor } from "../views/vnode-postprocessor";
 import { SModelElement, SModelRoot } from "../model/smodel";
 import { SystemCommand, CommandExecutionContext, CommandReturn } from '../commands/command';
+import { getWindowScroll } from "../../utils/browser";
 
 /**
  * Grabs the bounds from the root element in page coordinates and fires a
@@ -62,7 +63,7 @@ export class CanvasBoundsInitializer implements IVNodePostprocessor {
 
     protected getBoundsInPage(element: Element) {
         const bounds = element.getBoundingClientRect();
-        const scroll = typeof window !== 'undefined' ? { x: window.scrollX, y: window.scrollY } : ORIGIN_POINT;
+        const scroll = getWindowScroll();
         return {
             x: bounds.left + scroll.x,
             y: bounds.top + scroll.y,

--- a/src/features/bounds/model.ts
+++ b/src/features/bounds/model.ts
@@ -21,6 +21,7 @@ import { DOMHelper } from "../../base/views/dom-helper";
 import { ViewerOptions } from "../../base/views/viewer-options";
 import { Bounds, Dimension, EMPTY_BOUNDS, EMPTY_DIMENSION, includes, isBounds, ORIGIN_POINT, Point } from "../../utils/geometry";
 import { Locateable } from '../move/model';
+import { getWindowScroll } from "../../utils/browser";
 
 export const boundsFeature = Symbol('boundsFeature');
 export const layoutContainerFeature = Symbol('layoutContainerFeature');
@@ -117,8 +118,9 @@ export function getAbsoluteClientBounds(element: SModelElement, domHelper: DOMHe
     const svgElement = document.getElementById(svgElementId);
     if (svgElement) {
         const rect = svgElement.getBoundingClientRect();
-        x = rect.left + window.scrollX;
-        y = rect.top + window.scrollY;
+        const scroll = getWindowScroll();
+        x = rect.left + scroll.x;
+        y = rect.top + scroll.y;
         width = rect.width;
         height = rect.height;
     }

--- a/src/features/hover/popup-position-updater.ts
+++ b/src/features/hover/popup-position-updater.ts
@@ -35,11 +35,11 @@ export class PopupPositionUpdater implements IVNodePostprocessor {
         if (popupDiv !== null && typeof window !== 'undefined') {
             const boundingClientRect = popupDiv.getBoundingClientRect();
             if (window.innerHeight < boundingClientRect.height + boundingClientRect.top) {
-                popupDiv.style.top = (window.scrollY + window.innerHeight - boundingClientRect.height - 5) + 'px';
+                popupDiv.style.top = (window.pageYOffset + window.innerHeight - boundingClientRect.height - 5) + 'px';
             }
 
             if (window.innerWidth < boundingClientRect.left + boundingClientRect.width) {
-                popupDiv.style.left = (window.scrollX + window.innerWidth - boundingClientRect.width - 5) + 'px';
+                popupDiv.style.left = (window.pageXOffset + window.innerWidth - boundingClientRect.width - 5) + 'px';
             }
 
             if (boundingClientRect.left < 0) {

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -51,7 +51,7 @@ export function getWindowScroll(): Point {
         return ORIGIN_POINT;
     }
     return {
-        x: window.scrollX,
-        y: window.scrollY
+        x: window.pageXOffset,
+        y: window.pageYOffset
     };
 }


### PR DESCRIPTION
Use of window.pageXOffset instead of window.scrollX  (same for Y) to support all browsers.
https://github.com/eclipse/sprotty/wiki/Browsers-and-Compatibility was updated accordingly