### PR TITLE
Fix label validation if edit control is text area

### DIFF
--- a/src/features/edit/edit-label-ui.ts
+++ b/src/features/edit/edit-label-ui.ts
@@ -86,13 +86,13 @@ export class EditLabelUI extends AbstractUIExtension {
         this.textAreaElement.onkeydown = (event) => this.applyLabelEditOnEvent(event, 'Enter', 'ctrl');
     }
 
-    protected configureAndAdd(element: HTMLElement, containerElement: HTMLElement) {
+    protected configureAndAdd(element: HTMLInputElement | HTMLTextAreaElement, containerElement: HTMLElement) {
         element.style.visibility = 'hidden';
         element.style.position = 'absolute';
         element.style.top = '0px';
         element.style.left = '0px';
-        element.addEventListener('keydown', (event) => this.hideIfEscapeEvent(event));
-        element.addEventListener('keyup', (event) => this.validateLabelIfContentChange(event, this.inputElement.value));
+        element.addEventListener('keydown', (event: KeyboardEvent) => this.hideIfEscapeEvent(event));
+        element.addEventListener('keyup', (event: KeyboardEvent) => this.validateLabelIfContentChange(event, element.value));
         element.addEventListener('blur', () => window.setTimeout(() => this.applyLabelEdit(), 200));
         containerElement.appendChild(element);
     }


### PR DESCRIPTION
We always add the event listener for label validation to the input element
but not to the text area. For the label edit validation to work, we need to
also add an event listener to the text area (ie the element that is passed
as argument in configureAndAdd(...).