### PR TITLE
Omit 'transform' and 'opacity' when they have no effect

### DIFF
--- a/src/features/fade/fade.ts
+++ b/src/features/fade/fade.ts
@@ -58,7 +58,7 @@ export class FadeAnimation extends Animation {
 export class ElementFader implements IVNodePostprocessor {
 
     decorate(vnode: VNode, element: SModelElement): VNode {
-        if (isFadeable(element)) {
+        if (isFadeable(element) && element.opacity !== 1) {
             setAttr(vnode, 'opacity', element.opacity);
         }
         return vnode;

--- a/src/features/move/move.ts
+++ b/src/features/move/move.ts
@@ -575,15 +575,23 @@ export class LocationPostprocessor implements IVNodePostprocessor {
         }
         let translate: string  = '';
         if (isLocateable(element) && element instanceof SChildElement && element.parent !== undefined) {
-            translate = 'translate(' + element.position.x + ', ' + element.position.y + ')';
+            const pos = element.position;
+            if (pos.x !== 0 || pos.y !== 0) {
+                translate = 'translate(' + pos.x + ', ' + pos.y + ')';
+            }
         }
         if (isAlignable(element)) {
-            if (translate.length > 0)
-                translate += ' ';
-            translate += 'translate('  + element.alignment.x + ', ' + element.alignment.y + ')';
+            const ali = element.alignment;
+            if (ali.x !== 0 || ali.y !== 0) {
+                if (translate.length > 0) {
+                    translate += ' ';
+                }
+                translate += 'translate('  + ali.x + ', ' + ali.y + ')';
+            }
         }
-        if (translate.length > 0)
+        if (translate.length > 0) {
             setAttr(vnode, 'transform', translate);
+        }
         return vnode;
     }
 


### PR DESCRIPTION
This change omits `transform` attributes generated by LocationPostprocessor when they have no effect (x and y are zero), and it omits `opacity` attributes generated by ElementFader when they have no effect (opacity is 1).