### PR TITLE
Allow to skip rendering invisible elements

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,3 +15,7 @@ github:
     addComment: true
     addBadge: false
     addLabel: prebuilt-in-gitpod
+
+vscode:
+  extensions:
+    - ms-vscode.vscode-typescript-tslint-plugin@1.2.2:0nQ3PEEA0NPEt3UcbCYiIQ==

--- a/examples/circlegraph/css/diagram.css
+++ b/examples/circlegraph/css/diagram.css
@@ -31,6 +31,10 @@
     stroke-width: 2;
 }
 
+.sprotty-node.mouseover {
+    stroke-width: 6;
+}
+
 .sprotty-node.selected {
     stroke: #dd8;
     stroke-width: 6;

--- a/examples/circlegraph/src/di.config.ts
+++ b/examples/circlegraph/src/di.config.ts
@@ -16,11 +16,10 @@
 
 import { Container, ContainerModule } from "inversify";
 import {
-    TYPES, configureViewerOptions, SGraphView, PolylineEdgeView, ConsoleLogger,
-    LogLevel, loadDefaultModules, LocalModelSource, CircularNode, configureModelElement,
-    SGraph, SEdge, selectFeature
+    TYPES, configureViewerOptions, SGraphView, ConsoleLogger, LogLevel, loadDefaultModules,
+    LocalModelSource, CircularNode, configureModelElement, SGraph, SEdge, selectFeature
 } from "../../../src";
-import { CircleNodeView } from "./views";
+import { CircleNodeView, StraightEdgeView } from "./views";
 
 export default () => {
     require("../../../css/sprotty.css");
@@ -34,7 +33,7 @@ export default () => {
         const context = { bind, unbind, isBound, rebind };
         configureModelElement(context, 'graph', SGraph, SGraphView);
         configureModelElement(context, 'node:circle', CircularNode, CircleNodeView);
-        configureModelElement(context, 'edge:straight', SEdge, PolylineEdgeView, {
+        configureModelElement(context, 'edge:straight', SEdge, StraightEdgeView, {
             disable: [selectFeature]
         });
         configureViewerOptions(context, {

--- a/examples/circlegraph/src/di.config.ts
+++ b/examples/circlegraph/src/di.config.ts
@@ -17,9 +17,9 @@
 import { Container, ContainerModule } from "inversify";
 import {
     TYPES, configureViewerOptions, SGraphView, ConsoleLogger, LogLevel, loadDefaultModules,
-    LocalModelSource, CircularNode, configureModelElement, SGraph, SEdge, selectFeature
+    LocalModelSource, CircularNode, configureModelElement, SGraph, SEdge, selectFeature, PolylineEdgeView
 } from "../../../src";
-import { CircleNodeView, StraightEdgeView } from "./views";
+import { CircleNodeView } from "./views";
 
 export default () => {
     require("../../../css/sprotty.css");
@@ -33,7 +33,7 @@ export default () => {
         const context = { bind, unbind, isBound, rebind };
         configureModelElement(context, 'graph', SGraph, SGraphView);
         configureModelElement(context, 'node:circle', CircularNode, CircleNodeView);
-        configureModelElement(context, 'edge:straight', SEdge, StraightEdgeView, {
+        configureModelElement(context, 'edge:straight', SEdge, PolylineEdgeView, {
             disable: [selectFeature]
         });
         configureViewerOptions(context, {

--- a/examples/circlegraph/src/standalone.ts
+++ b/examples/circlegraph/src/standalone.ts
@@ -58,7 +58,7 @@ export default async function runCircleGraph() {
             ...scroll,
             width: canvasBounds.width / zoom,
             height: canvasBounds.height / zoom
-        }
+        };
     }
 
     const container = createContainer();
@@ -69,7 +69,7 @@ export default async function runCircleGraph() {
     const node0 = { id: 'node0', type: 'node:circle', position: { x: 100, y: 100 }, size: { width: NODE_SIZE, height: NODE_SIZE } };
     const graph: SGraphSchema = { id: 'graph', type: 'graph', children: [node0] };
 
-    const initialViewport = await modelSource.getViewport()
+    const initialViewport = await modelSource.getViewport();
     for (let i = 0; i < 200; ++i) {
         const newElements = addNode(getVisibleBounds(initialViewport));
         graph.children.push(...newElements);
@@ -80,7 +80,7 @@ export default async function runCircleGraph() {
 
     // Button features
     document.getElementById('addNode')!.addEventListener('click', async () => {
-        const viewport = await modelSource.getViewport()
+        const viewport = await modelSource.getViewport();
         const newElements = addNode(getVisibleBounds(viewport));
         modelSource.addElements(newElements);
         dispatcher.dispatch(new SelectAction(newElements.map(e => e.id)));
@@ -88,7 +88,7 @@ export default async function runCircleGraph() {
     });
 
     document.getElementById('scrambleAll')!.addEventListener('click', async () => {
-        const viewport = await modelSource.getViewport()
+        const viewport = await modelSource.getViewport();
         const bounds = getVisibleBounds(viewport);
         const nodeMoves: ElementMove[] = [];
         graph.children.forEach(shape => {
@@ -108,7 +108,7 @@ export default async function runCircleGraph() {
 
     document.getElementById('scrambleSelection')!.addEventListener('click', async () => {
         const selection = await modelSource.getSelection();
-        const viewport = await modelSource.getViewport()
+        const viewport = await modelSource.getViewport();
         const bounds = getVisibleBounds(viewport);
         const nodeMoves: ElementMove[] = [];
         selection.forEach(shape => {

--- a/examples/circlegraph/src/views.tsx
+++ b/examples/circlegraph/src/views.tsx
@@ -26,7 +26,7 @@ import { RenderingContext, SNode, ShapeView } from "../../../src";
 @injectable()
 export class CircleNodeView extends ShapeView {
     render(node: SNode, context: RenderingContext): VNode | undefined {
-        if (!this.isInViewport(node, context)) {
+        if (!this.isVisible(node, context)) {
             return undefined;
         }
         const radius = this.getRadius(node);

--- a/examples/circlegraph/src/views.tsx
+++ b/examples/circlegraph/src/views.tsx
@@ -18,15 +18,15 @@
 import { svg } from 'snabbdom-jsx';
 import { injectable } from 'inversify';
 import { VNode } from "snabbdom/vnode";
-import { RenderingContext, SNode, IView, isVisible } from "../../../src";
+import { RenderingContext, SNode, ShapeView } from "../../../src";
 
 /**
  * A very simple example node consisting of a plain circle.
  */
 @injectable()
-export class CircleNodeView implements IView {
+export class CircleNodeView extends ShapeView {
     render(node: SNode, context: RenderingContext): VNode | undefined {
-        if (!isVisible(node, context)) {
+        if (!this.isInViewport(node, context)) {
             return undefined;
         }
         const radius = this.getRadius(node);

--- a/examples/circlegraph/src/views.tsx
+++ b/examples/circlegraph/src/views.tsx
@@ -16,20 +16,26 @@
 
 /** @jsx svg */
 import { svg } from 'snabbdom-jsx';
-
-import { VNode } from "snabbdom/vnode";
-import { RenderingContext, SNode, IView } from "../../../src";
 import { injectable } from 'inversify';
+import { VNode } from "snabbdom/vnode";
+import { RenderingContext, SNode, IView, isVisible, PolylineEdgeView, SEdge, isRouteVisible } from "../../../src";
 
 /**
  * A very simple example node consisting of a plain circle.
  */
 @injectable()
 export class CircleNodeView implements IView {
-    render(node: SNode, context: RenderingContext): VNode {
+    render(node: SNode, context: RenderingContext): VNode | undefined {
+        if (!isVisible(node, context)) {
+            return undefined;
+        }
         const radius = this.getRadius(node);
         return <g>
-            <circle class-sprotty-node={true} class-selected={node.selected} r={radius} cx={radius} cy={radius}></circle>
+            <circle class-sprotty-node={true}
+                    class-selected={node.selected}
+                    class-mouseover={node.hoverFeedback}
+                    r={radius} cx={radius} cy={radius}>
+            </circle>
             <text x={radius} y={radius + 7} class-sprotty-text={true}>{node.id.substr(4)}</text>
         </g>;
     }
@@ -38,4 +44,26 @@ export class CircleNodeView implements IView {
         const d = Math.min(node.size.width, node.size.height);
         return d > 0 ? d / 2 : 0;
     }
+}
+
+@injectable()
+export class StraightEdgeView extends PolylineEdgeView {
+
+    render(edge: Readonly<SEdge>, context: RenderingContext): VNode {
+        const router = this.edgeRouterRegistry.get(edge.routerKind);
+        const route = router.route(edge);
+        if (route.length === 0) {
+            return this.renderDanglingEdge("Cannot compute route", edge, context);
+        }
+        if (!isRouteVisible(edge, route, context)) {
+            return undefined!;
+        }
+
+        return <g class-sprotty-edge={true} class-mouseover={edge.hoverFeedback}>
+            {this.renderLine(edge, route, context)}
+            {this.renderAdditionals(edge, route, context)}
+            {context.renderChildren(edge, { route })}
+        </g>;
+    }
+
 }

--- a/examples/circlegraph/src/views.tsx
+++ b/examples/circlegraph/src/views.tsx
@@ -18,7 +18,7 @@
 import { svg } from 'snabbdom-jsx';
 import { injectable } from 'inversify';
 import { VNode } from "snabbdom/vnode";
-import { RenderingContext, SNode, IView, isVisible, PolylineEdgeView, SEdge, isRouteVisible } from "../../../src";
+import { RenderingContext, SNode, IView, isVisible } from "../../../src";
 
 /**
  * A very simple example node consisting of a plain circle.
@@ -44,26 +44,4 @@ export class CircleNodeView implements IView {
         const d = Math.min(node.size.width, node.size.height);
         return d > 0 ? d / 2 : 0;
     }
-}
-
-@injectable()
-export class StraightEdgeView extends PolylineEdgeView {
-
-    render(edge: Readonly<SEdge>, context: RenderingContext): VNode {
-        const router = this.edgeRouterRegistry.get(edge.routerKind);
-        const route = router.route(edge);
-        if (route.length === 0) {
-            return this.renderDanglingEdge("Cannot compute route", edge, context);
-        }
-        if (!isRouteVisible(edge, route, context)) {
-            return undefined!;
-        }
-
-        return <g class-sprotty-edge={true} class-mouseover={edge.hoverFeedback}>
-            {this.renderLine(edge, route, context)}
-            {this.renderAdditionals(edge, route, context)}
-            {context.renderChildren(edge, { route })}
-        </g>;
-    }
-
 }

--- a/examples/classdiagram/src/views.tsx
+++ b/examples/classdiagram/src/views.tsx
@@ -17,14 +17,17 @@
 /** @jsx svg */
 import { svg } from 'snabbdom-jsx';
 
-import { RenderingContext, IView, RectangularNodeView, SNode } from "../../../src";
+import { RenderingContext, IView, RectangularNodeView, SNode, isVisible } from "../../../src";
 import { VNode } from "snabbdom/vnode";
 import { Icon } from './model';
 import { injectable } from 'inversify';
 
 @injectable()
 export class NodeView extends RectangularNodeView {
-    render(node: Readonly<SNode>, context: RenderingContext): VNode {
+    render(node: Readonly<SNode>, context: RenderingContext): VNode | undefined {
+        if (!isVisible(node, context)) {
+            return undefined;
+        }
         return <g>
             <rect class-sprotty-node={true}
                   class-node-package={node.type === 'node:package'}

--- a/examples/classdiagram/src/views.tsx
+++ b/examples/classdiagram/src/views.tsx
@@ -25,7 +25,7 @@ import { injectable } from 'inversify';
 @injectable()
 export class NodeView extends RectangularNodeView {
     render(node: Readonly<SNode>, context: RenderingContext): VNode | undefined {
-        if (!this.isInViewport(node, context)) {
+        if (!this.isVisible(node, context)) {
             return undefined;
         }
         return <g>

--- a/examples/classdiagram/src/views.tsx
+++ b/examples/classdiagram/src/views.tsx
@@ -17,7 +17,7 @@
 /** @jsx svg */
 import { svg } from 'snabbdom-jsx';
 
-import { RenderingContext, IView, RectangularNodeView, SNode, isVisible } from "../../../src";
+import { RenderingContext, IView, RectangularNodeView, SNode } from "../../../src";
 import { VNode } from "snabbdom/vnode";
 import { Icon } from './model';
 import { injectable } from 'inversify';
@@ -25,7 +25,7 @@ import { injectable } from 'inversify';
 @injectable()
 export class NodeView extends RectangularNodeView {
     render(node: Readonly<SNode>, context: RenderingContext): VNode | undefined {
-        if (!isVisible(node, context)) {
+        if (!this.isInViewport(node, context)) {
             return undefined;
         }
         return <g>

--- a/examples/multicore/src/views.tsx
+++ b/examples/multicore/src/views.tsx
@@ -18,7 +18,7 @@
 import { svg } from 'snabbdom-jsx';
 
 import { VNode } from "snabbdom/vnode";
-import { IView, RenderingContext, setAttr, ThunkView, Direction, RGBColor, toSVG, rgb, isVisible } from '../../../src';
+import { IView, RenderingContext, setAttr, ThunkView, Direction, RGBColor, toSVG, rgb, ShapeView } from '../../../src';
 import { Channel, Core, Crossbar, Processor } from './chipmodel';
 import { injectable } from 'inversify';
 
@@ -43,10 +43,10 @@ export const CORE_WIDTH = 50;
 export const CORE_DISTANCE = 10;
 
 @injectable()
-export class SimpleCoreView implements IView {
+export class SimpleCoreView extends ShapeView {
 
     render(model: Core, context: RenderingContext): VNode | undefined {
-        if (!isVisible(model, context)) {
+        if (!this.isInViewport(model, context)) {
             return undefined;
         }
         const fillColor = KernelColor.getSVG(model.kernelNr);
@@ -67,10 +67,10 @@ export class SimpleCoreView implements IView {
 }
 
 @injectable()
-export class CoreView implements IView {
+export class CoreView extends ShapeView {
 
     render(model: Core, context: RenderingContext): VNode | undefined {
-        if (!isVisible(model, context)) {
+        if (!this.isInViewport(model, context)) {
             return undefined;
         }
         const fillColor = KernelColor.getSVG(model.kernelNr);

--- a/examples/multicore/src/views.tsx
+++ b/examples/multicore/src/views.tsx
@@ -18,7 +18,7 @@
 import { svg } from 'snabbdom-jsx';
 
 import { VNode } from "snabbdom/vnode";
-import { IView, RenderingContext, setAttr, ThunkView, Direction, RGBColor, toSVG, rgb } from '../../../src';
+import { IView, RenderingContext, setAttr, ThunkView, Direction, RGBColor, toSVG, rgb, isVisible } from '../../../src';
 import { Channel, Core, Crossbar, Processor } from './chipmodel';
 import { injectable } from 'inversify';
 
@@ -43,17 +43,12 @@ export const CORE_WIDTH = 50;
 export const CORE_DISTANCE = 10;
 
 @injectable()
-export class SimpleCoreView extends ThunkView {
+export class SimpleCoreView implements IView {
 
-    watchedArgs(model: Core): any[] {
-        return [ model.kernelNr, model.opacity ];
-    }
-
-    selector(model: Core): string {
-        return 'g';
-    }
-
-    doRender(model: Core, context: RenderingContext): VNode {
+    render(model: Core, context: RenderingContext): VNode | undefined {
+        if (!isVisible(model, context)) {
+            return undefined;
+        }
         const fillColor = KernelColor.getSVG(model.kernelNr);
         const content = <g>
                 {context.renderChildren(model)}
@@ -74,7 +69,10 @@ export class SimpleCoreView extends ThunkView {
 @injectable()
 export class CoreView implements IView {
 
-    render(model: Core, context: RenderingContext): VNode {
+    render(model: Core, context: RenderingContext): VNode | undefined {
+        if (!isVisible(model, context)) {
+            return undefined;
+        }
         const fillColor = KernelColor.getSVG(model.kernelNr);
         const content = <g>
                 {context.renderChildren(model)}

--- a/examples/multicore/src/views.tsx
+++ b/examples/multicore/src/views.tsx
@@ -46,7 +46,7 @@ export const CORE_DISTANCE = 10;
 export class SimpleCoreView extends ShapeView {
 
     render(model: Core, context: RenderingContext): VNode | undefined {
-        if (!this.isInViewport(model, context)) {
+        if (!this.isVisible(model, context)) {
             return undefined;
         }
         const fillColor = KernelColor.getSVG(model.kernelNr);
@@ -70,7 +70,7 @@ export class SimpleCoreView extends ShapeView {
 export class CoreView extends ShapeView {
 
     render(model: Core, context: RenderingContext): VNode | undefined {
-        if (!this.isInViewport(model, context)) {
+        if (!this.isVisible(model, context)) {
             return undefined;
         }
         const fillColor = KernelColor.getSVG(model.kernelNr);

--- a/src/base/di.config.ts
+++ b/src/base/di.config.ts
@@ -29,7 +29,7 @@ import { ViewerOptions, defaultViewerOptions } from "./views/viewer-options";
 import { MouseTool, PopupMouseTool, MousePositionTracker } from "./views/mouse-tool";
 import { KeyTool } from "./views/key-tool";
 import { FocusFixPostprocessor, IVNodePostprocessor } from "./views/vnode-postprocessor";
-import { ViewRegistry } from "./views/view";
+import { ViewRegistry, RenderingTargetKind } from "./views/view";
 import { ViewerCache } from "./views/viewer-cache";
 import { DOMHelper } from "./views/dom-helper";
 import { IdPostprocessor } from "./views/id-postprocessor";
@@ -123,9 +123,9 @@ const defaultContainerModule = new ContainerModule((bind, _unbind, isBound) => {
     bind(TYPES.PatcherProvider).to(PatcherProvider).inSingletonScope();
     bind(TYPES.DOMHelper).to(DOMHelper).inSingletonScope();
     bind(TYPES.ModelRendererFactory).toFactory<ModelRenderer>(ctx => {
-        return (processors: IVNodePostprocessor[]) => {
+        return (targetKind: RenderingTargetKind, processors: IVNodePostprocessor[]) => {
             const viewRegistry = ctx.container.get<ViewRegistry>(TYPES.ViewRegistry);
-            return new ModelRenderer(viewRegistry, processors);
+            return new ModelRenderer(viewRegistry, targetKind, processors);
         };
     });
 

--- a/src/base/views/thunk-view.spec.tsx
+++ b/src/base/views/thunk-view.spec.tsx
@@ -59,7 +59,7 @@ describe('ThunkView', () => {
         }
     }
 
-    const context = new ModelRenderer(undefined!, []);
+    const context = new ModelRenderer(undefined!, 'main', []);
 
     const patcher = init([]);
 

--- a/src/base/views/view.spec.ts
+++ b/src/base/views/view.spec.ts
@@ -33,7 +33,7 @@ describe('base views', () => {
 
     const modelFactory = container.get<SModelFactory>(TYPES.IModelFactory);
     const emptyRoot = modelFactory.createRoot(EMPTY_ROOT);
-    const context = new ModelRenderer(undefined!, []);
+    const context = new ModelRenderer(undefined!, 'main', []);
 
     it('empty view', () => {
         const emptyView = new EmptyView();

--- a/src/base/views/view.tsx
+++ b/src/base/views/view.tsx
@@ -31,18 +31,21 @@ import { registerModelElement } from '../model/smodel-utils';
  * Base interface for the components that turn GModelElements into virtual DOM elements.
  */
 export interface IView {
-    render(model: Readonly<SModelElement>, context: RenderingContext, args?: object): VNode
+    render(model: Readonly<SModelElement>, context: RenderingContext, args?: object): VNode | undefined
 }
+
+export type RenderingTargetKind = 'main' | 'popup' | 'hidden';
 
 /**
  * Bundles additional data that is passed to views for VNode creation.
  */
 export interface RenderingContext {
-    viewRegistry: ViewRegistry
+    readonly viewRegistry: ViewRegistry
+    readonly targetKind: RenderingTargetKind;
 
     decorate(vnode: VNode, element: Readonly<SModelElement>): VNode
 
-    renderElement(element: Readonly<SModelElement>, args?: object): VNode
+    renderElement(element: Readonly<SModelElement>, args?: object): VNode | undefined
 
     renderChildren(element: Readonly<SParentElement>, args?: object): VNode[]
 }

--- a/src/features/bounds/model.spec.ts
+++ b/src/features/bounds/model.spec.ts
@@ -17,9 +17,7 @@
 import 'mocha';
 import { expect } from "chai";
 import { SModelRoot } from '../../base/model/smodel';
-import { RenderingContext } from '../../base/views/view';
-import { ViewportRootElement } from '../viewport/viewport-root';
-import { SShapeElement, getAbsoluteBounds, isVisible } from './model';
+import { SShapeElement, getAbsoluteBounds } from './model';
 
 describe('getAbsoluteBounds', () => {
     function createModel(): SModelRoot {
@@ -38,49 +36,6 @@ describe('getAbsoluteBounds', () => {
         expect(getAbsoluteBounds(model.children[0].children[0])).to.deep.equal({
             x: 120, y: 140, width: 10, height: 10
         });
-    });
-});
-
-describe('isVisible', () => {
-    function createModel(): ViewportRootElement {
-        const root = new ViewportRootElement();
-        root.canvasBounds = { x: 0, y: 0, width: 100, height: 100 };
-        const node1 = new TestNode();
-        node1.bounds = { x: 100, y: 100, width: 100, height: 100 };
-        root.add(node1);
-        const node2 = new TestNode();
-        node2.bounds = { x: 20, y: 40, width: 10, height: 10 };
-        node1.add(node2);
-        return root;
-    }
-
-    it('should return true when an element intersects the canvas bounds', () => {
-        const model = createModel();
-        model.scroll = { x: 80, y: 80 };
-        model.zoom = 1;
-        expect(isVisible(model.children[0].children[0])).to.equal(true);
-    });
-
-    it('should return false when the viewport is panned away', () => {
-        const model = createModel();
-        model.scroll = { x: 150, y: 80 };
-        model.zoom = 1;
-        expect(isVisible(model.children[0].children[0])).to.equal(false);
-    });
-
-    it('should return false when the viewport is zoomed away', () => {
-        const model = createModel();
-        model.scroll = { x: 100, y: 100 };
-        model.zoom = 10;
-        expect(isVisible(model.children[0].children[0])).to.equal(false);
-    });
-
-    it('should return true when rendered in a hidden context', () => {
-        const model = createModel();
-        model.scroll = { x: 150, y: 80 };
-        model.zoom = 10;
-        const context = { targetKind: 'hidden' } as RenderingContext;
-        expect(isVisible(model.children[0].children[0], context)).to.equal(true);
     });
 });
 

--- a/src/features/bounds/model.spec.ts
+++ b/src/features/bounds/model.spec.ts
@@ -1,0 +1,88 @@
+/********************************************************************************
+ * Copyright (c) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import 'mocha';
+import { expect } from "chai";
+import { SModelRoot } from '../../base/model/smodel';
+import { RenderingContext } from '../../base/views/view';
+import { ViewportRootElement } from '../viewport/viewport-root';
+import { SShapeElement, getAbsoluteBounds, isVisible } from './model';
+
+describe('getAbsoluteBounds', () => {
+    function createModel(): SModelRoot {
+        const root = new SModelRoot();
+        const node1 = new TestNode();
+        node1.bounds = { x: 100, y: 100, width: 100, height: 100 };
+        root.add(node1);
+        const node2 = new TestNode();
+        node2.bounds = { x: 20, y: 40, width: 10, height: 10 };
+        node1.add(node2);
+        return root;
+    }
+
+    it('should compute the absolute bounds of a bounds aware element', () => {
+        const model = createModel();
+        expect(getAbsoluteBounds(model.children[0].children[0])).to.deep.equal({
+            x: 120, y: 140, width: 10, height: 10
+        });
+    });
+});
+
+describe('isVisible', () => {
+    function createModel(): ViewportRootElement {
+        const root = new ViewportRootElement();
+        root.canvasBounds = { x: 0, y: 0, width: 100, height: 100 };
+        const node1 = new TestNode();
+        node1.bounds = { x: 100, y: 100, width: 100, height: 100 };
+        root.add(node1);
+        const node2 = new TestNode();
+        node2.bounds = { x: 20, y: 40, width: 10, height: 10 };
+        node1.add(node2);
+        return root;
+    }
+
+    it('should return true when an element intersects the canvas bounds', () => {
+        const model = createModel();
+        model.scroll = { x: 80, y: 80 };
+        model.zoom = 1;
+        expect(isVisible(model.children[0].children[0])).to.equal(true);
+    });
+
+    it('should return false when the viewport is panned away', () => {
+        const model = createModel();
+        model.scroll = { x: 150, y: 80 };
+        model.zoom = 1;
+        expect(isVisible(model.children[0].children[0])).to.equal(false);
+    });
+
+    it('should return false when the viewport is zoomed away', () => {
+        const model = createModel();
+        model.scroll = { x: 100, y: 100 };
+        model.zoom = 10;
+        expect(isVisible(model.children[0].children[0])).to.equal(false);
+    });
+
+    it('should return true when rendered in a hidden context', () => {
+        const model = createModel();
+        model.scroll = { x: 150, y: 80 };
+        model.zoom = 10;
+        const context = { targetKind: 'hidden' } as RenderingContext;
+        expect(isVisible(model.children[0].children[0], context)).to.equal(true);
+    });
+});
+
+class TestNode extends SShapeElement {
+}

--- a/src/features/bounds/model.ts
+++ b/src/features/bounds/model.ts
@@ -18,6 +18,7 @@ import { SChildElement, SModelElement, SModelElementSchema, SModelRoot, SParentE
 import { SModelExtension } from "../../base/model/smodel-extension";
 import { findParentByFeature } from '../../base/model/smodel-utils';
 import { DOMHelper } from "../../base/views/dom-helper";
+import { RenderingContext } from '../../base/views/view';
 import { ViewerOptions } from "../../base/views/viewer-options";
 import { Bounds, Dimension, EMPTY_BOUNDS, EMPTY_DIMENSION, includes, isBounds, ORIGIN_POINT, Point } from "../../utils/geometry";
 import { Locateable } from '../move/model';
@@ -97,6 +98,22 @@ export function getAbsoluteBounds(element: SModelElement): Bounds {
     } else {
         return EMPTY_BOUNDS;
     }
+}
+
+/**
+ * Determine whether the given element is visible in the current canvas.
+ */
+export function isVisible(element: Readonly<SModelElement>, context?: RenderingContext): boolean {
+    if (context && context.targetKind === 'hidden') {
+        // Don't hide any element for hidden rendering
+        return true;
+    }
+    const ab = getAbsoluteBounds(element);
+    const canvasBounds = element.root.canvasBounds;
+    return ab.x <= canvasBounds.width
+        && ab.x + ab.width >= 0
+        && ab.y <= canvasBounds.height
+        && ab.y + ab.height >= 0;
 }
 
 /**

--- a/src/features/bounds/model.ts
+++ b/src/features/bounds/model.ts
@@ -20,7 +20,9 @@ import { findParentByFeature } from '../../base/model/smodel-utils';
 import { DOMHelper } from "../../base/views/dom-helper";
 import { RenderingContext } from '../../base/views/view';
 import { ViewerOptions } from "../../base/views/viewer-options";
-import { Bounds, Dimension, EMPTY_BOUNDS, EMPTY_DIMENSION, includes, isBounds, ORIGIN_POINT, Point } from "../../utils/geometry";
+import {
+    Bounds, Dimension, EMPTY_BOUNDS, EMPTY_DIMENSION, includes, isBounds, ORIGIN_POINT, Point, isValidDimension
+} from "../../utils/geometry";
 import { Locateable } from '../move/model';
 import { getWindowScroll } from "../../utils/browser";
 
@@ -67,7 +69,7 @@ export function isLayoutContainer(element: SModelElement): element is SParentEle
         && 'layout' in element;
 }
 
-export function isLayoutableChild(element: SModelElement): element is SParentElement & LayoutableChild {
+export function isLayoutableChild(element: SModelElement): element is SChildElement & LayoutableChild {
     return isBoundsAware(element)
         && element.hasFeature(layoutableChildFeature);
 }
@@ -106,6 +108,10 @@ export function getAbsoluteBounds(element: SModelElement): Bounds {
 export function isVisible(element: Readonly<SModelElement>, context?: RenderingContext): boolean {
     if (context && context.targetKind === 'hidden') {
         // Don't hide any element for hidden rendering
+        return true;
+    }
+    if (!isBoundsAware(element) || !isValidDimension(element.bounds)) {
+        // We should hide only if we know the element's bounds
         return true;
     }
     const ab = getAbsoluteBounds(element);

--- a/src/features/bounds/model.ts
+++ b/src/features/bounds/model.ts
@@ -18,10 +18,9 @@ import { SChildElement, SModelElement, SModelElementSchema, SModelRoot, SParentE
 import { SModelExtension } from "../../base/model/smodel-extension";
 import { findParentByFeature } from '../../base/model/smodel-utils';
 import { DOMHelper } from "../../base/views/dom-helper";
-import { RenderingContext } from '../../base/views/view';
 import { ViewerOptions } from "../../base/views/viewer-options";
 import {
-    Bounds, Dimension, EMPTY_BOUNDS, EMPTY_DIMENSION, includes, isBounds, ORIGIN_POINT, Point, isValidDimension
+    Bounds, Dimension, EMPTY_BOUNDS, EMPTY_DIMENSION, includes, isBounds, ORIGIN_POINT, Point
 } from "../../utils/geometry";
 import { Locateable } from '../move/model';
 import { getWindowScroll } from "../../utils/browser";
@@ -100,26 +99,6 @@ export function getAbsoluteBounds(element: SModelElement): Bounds {
     } else {
         return EMPTY_BOUNDS;
     }
-}
-
-/**
- * Determine whether the given element is visible in the current canvas.
- */
-export function isVisible(element: Readonly<SModelElement>, context?: RenderingContext): boolean {
-    if (context && context.targetKind === 'hidden') {
-        // Don't hide any element for hidden rendering
-        return true;
-    }
-    if (!isBoundsAware(element) || !isValidDimension(element.bounds)) {
-        // We should hide only if we know the element's bounds
-        return true;
-    }
-    const ab = getAbsoluteBounds(element);
-    const canvasBounds = element.root.canvasBounds;
-    return ab.x <= canvasBounds.width
-        && ab.x + ab.width >= 0
-        && ab.y <= canvasBounds.height
-        && ab.y + ab.height >= 0;
 }
 
 /**

--- a/src/features/bounds/views.spec.ts
+++ b/src/features/bounds/views.spec.ts
@@ -1,0 +1,84 @@
+/********************************************************************************
+ * Copyright (c) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import 'mocha';
+import { expect } from "chai";
+import { RenderingContext } from '../../base/views/view';
+import { ViewportRootElement } from '../viewport/viewport-root';
+import { SShapeElement } from './model';
+import { ShapeView } from './views';
+import { VNode } from 'snabbdom/vnode';
+
+describe('ShapeView.isInViewport', () => {
+
+    class TestNode extends SShapeElement {
+    }
+
+    class TestView extends ShapeView {
+        render(model: Readonly<SShapeElement>, context: RenderingContext, args?: object): VNode | undefined {
+            return undefined;
+        }
+    }
+
+    function createModel(): ViewportRootElement {
+        const root = new ViewportRootElement();
+        root.canvasBounds = { x: 0, y: 0, width: 100, height: 100 };
+        const node1 = new TestNode();
+        node1.bounds = { x: 100, y: 100, width: 100, height: 100 };
+        root.add(node1);
+        const node2 = new TestNode();
+        node2.bounds = { x: 20, y: 40, width: 10, height: 10 };
+        node1.add(node2);
+        return root;
+    }
+    const view = new TestView();
+
+    it('should return true when an element intersects the canvas bounds', () => {
+        const model = createModel();
+        model.scroll = { x: 80, y: 80 };
+        model.zoom = 1;
+        const node = model.children[0].children[0] as SShapeElement;
+        const context = { targetKind: 'main' } as RenderingContext;
+        expect(view.isInViewport(node, context)).to.equal(true);
+    });
+
+    it('should return false when the viewport is panned away', () => {
+        const model = createModel();
+        model.scroll = { x: 150, y: 80 };
+        model.zoom = 1;
+        const node = model.children[0].children[0] as SShapeElement;
+        const context = { targetKind: 'main' } as RenderingContext;
+        expect(view.isInViewport(node, context)).to.equal(false);
+    });
+
+    it('should return false when the viewport is zoomed away', () => {
+        const model = createModel();
+        model.scroll = { x: 100, y: 100 };
+        model.zoom = 10;
+        const node = model.children[0].children[0] as SShapeElement;
+        const context = { targetKind: 'main' } as RenderingContext;
+        expect(view.isInViewport(node, context)).to.equal(false);
+    });
+
+    it('should return true when rendered in a hidden context', () => {
+        const model = createModel();
+        model.scroll = { x: 150, y: 80 };
+        model.zoom = 10;
+        const node = model.children[0].children[0] as SShapeElement;
+        const context = { targetKind: 'hidden' } as RenderingContext;
+        expect(view.isInViewport(node, context)).to.equal(true);
+    });
+});

--- a/src/features/bounds/views.spec.ts
+++ b/src/features/bounds/views.spec.ts
@@ -22,7 +22,7 @@ import { SShapeElement } from './model';
 import { ShapeView } from './views';
 import { VNode } from 'snabbdom/vnode';
 
-describe('ShapeView.isInViewport', () => {
+describe('ShapeView.isVisible', () => {
 
     class TestNode extends SShapeElement {
     }
@@ -52,7 +52,7 @@ describe('ShapeView.isInViewport', () => {
         model.zoom = 1;
         const node = model.children[0].children[0] as SShapeElement;
         const context = { targetKind: 'main' } as RenderingContext;
-        expect(view.isInViewport(node, context)).to.equal(true);
+        expect(view.isVisible(node, context)).to.equal(true);
     });
 
     it('should return false when the viewport is panned away', () => {
@@ -61,7 +61,7 @@ describe('ShapeView.isInViewport', () => {
         model.zoom = 1;
         const node = model.children[0].children[0] as SShapeElement;
         const context = { targetKind: 'main' } as RenderingContext;
-        expect(view.isInViewport(node, context)).to.equal(false);
+        expect(view.isVisible(node, context)).to.equal(false);
     });
 
     it('should return false when the viewport is zoomed away', () => {
@@ -70,7 +70,7 @@ describe('ShapeView.isInViewport', () => {
         model.zoom = 10;
         const node = model.children[0].children[0] as SShapeElement;
         const context = { targetKind: 'main' } as RenderingContext;
-        expect(view.isInViewport(node, context)).to.equal(false);
+        expect(view.isVisible(node, context)).to.equal(false);
     });
 
     it('should return true when rendered in a hidden context', () => {
@@ -79,6 +79,6 @@ describe('ShapeView.isInViewport', () => {
         model.zoom = 10;
         const node = model.children[0].children[0] as SShapeElement;
         const context = { targetKind: 'hidden' } as RenderingContext;
-        expect(view.isInViewport(node, context)).to.equal(true);
+        expect(view.isVisible(node, context)).to.equal(true);
     });
 });

--- a/src/features/bounds/views.ts
+++ b/src/features/bounds/views.ts
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (c) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { VNode } from 'snabbdom/vnode';
+import { isValidDimension } from '../../utils/geometry';
+import { IView, RenderingContext } from '../../base/views/view';
+import { getAbsoluteBounds, BoundsAware } from './model';
+import { SChildElement } from '../../base/model/smodel';
+
+@injectable()
+export abstract class ShapeView implements IView {
+    /**
+     * Check whether the given model element is in the current viewport. Use this method
+     * in your `render` implementation to skip rendering in case the element is not visible.
+     * This can greatly enhance performance for large models.
+     */
+    isInViewport(model: Readonly<SChildElement & BoundsAware>, context: RenderingContext): boolean {
+        if (context.targetKind === 'hidden') {
+            // Don't hide any element for hidden rendering
+            return true;
+        }
+        if (!isValidDimension(model.bounds)) {
+            // We should hide only if we know the element's bounds
+            return true;
+        }
+        const ab = getAbsoluteBounds(model);
+        const canvasBounds = model.root.canvasBounds;
+        return ab.x <= canvasBounds.width
+            && ab.x + ab.width >= 0
+            && ab.y <= canvasBounds.height
+            && ab.y + ab.height >= 0;
+    }
+
+    abstract render(model: Readonly<SChildElement>, context: RenderingContext, args?: object): VNode | undefined;
+}

--- a/src/features/bounds/views.ts
+++ b/src/features/bounds/views.ts
@@ -28,7 +28,7 @@ export abstract class ShapeView implements IView {
      * in your `render` implementation to skip rendering in case the element is not visible.
      * This can greatly enhance performance for large models.
      */
-    isInViewport(model: Readonly<SChildElement & BoundsAware>, context: RenderingContext): boolean {
+    isVisible(model: Readonly<SChildElement & BoundsAware>, context: RenderingContext): boolean {
         if (context.targetKind === 'hidden') {
             // Don't hide any element for hidden rendering
             return true;

--- a/src/features/routing/model.spec.ts
+++ b/src/features/routing/model.spec.ts
@@ -20,9 +20,9 @@ import { SModelRoot } from '../../base/model/smodel';
 import { RenderingContext } from '../../base/views/view';
 import { SShapeElement } from '../bounds/model';
 import { ViewportRootElement } from '../viewport/viewport-root';
-import { SRoutableElement, getAbsoluteRouteBounds, isRouteVisible } from './model';
+import { SRoutableElement } from './model';
 
-describe('getAbsoluteRouteBounds', () => {
+describe('SRoutableElement.getAbsoluteBounds', () => {
     function createModel(): SModelRoot {
         const root = new SModelRoot();
         const node1 = new TestNode();
@@ -40,13 +40,14 @@ describe('getAbsoluteRouteBounds', () => {
 
     it('should compute the absolute bounds of a routable element', () => {
         const model = createModel();
-        expect(getAbsoluteRouteBounds(model.children[0].children[0] as SRoutableElement)).to.deep.equal({
+        const routable = model.children[0].children[0] as SRoutableElement;
+        expect(routable.getAbsoluteBounds()).to.deep.equal({
             x: 110, y: 110, width: 30, height: 20
         });
     });
 });
 
-describe('isRouteVisible', () => {
+describe('SRoutableElement.isVisible', () => {
     function createModel(): ViewportRootElement {
         const root = new ViewportRootElement();
         root.canvasBounds = { x: 0, y: 0, width: 100, height: 100 };
@@ -67,21 +68,24 @@ describe('isRouteVisible', () => {
         const model = createModel();
         model.scroll = { x: 80, y: 80 };
         model.zoom = 1;
-        expect(isRouteVisible(model.children[0].children[0] as SRoutableElement)).to.equal(true);
+        const routable = model.children[0].children[0] as SRoutableElement;
+        expect(routable.isVisible()).to.equal(true);
     });
 
     it('should return false when the viewport is panned away', () => {
         const model = createModel();
         model.scroll = { x: 150, y: 80 };
         model.zoom = 1;
-        expect(isRouteVisible(model.children[0].children[0] as SRoutableElement)).to.equal(false);
+        const routable = model.children[0].children[0] as SRoutableElement;
+        expect(routable.isVisible()).to.equal(false);
     });
 
     it('should return false when the viewport is zoomed away', () => {
         const model = createModel();
         model.scroll = { x: 80, y: 80 };
         model.zoom = 10;
-        expect(isRouteVisible(model.children[0].children[0] as SRoutableElement)).to.equal(false);
+        const routable = model.children[0].children[0] as SRoutableElement;
+        expect(routable.isVisible()).to.equal(false);
     });
 
     it('should return true when rendered in a hidden context', () => {
@@ -89,7 +93,8 @@ describe('isRouteVisible', () => {
         model.scroll = { x: 150, y: 80 };
         model.zoom = 10;
         const context = { targetKind: 'hidden' } as RenderingContext;
-        expect(isRouteVisible(model.children[0].children[0] as SRoutableElement, undefined, context)).to.equal(true);
+        const routable = model.children[0].children[0] as SRoutableElement;
+        expect(routable.isVisible(undefined, context)).to.equal(true);
     });
 });
 

--- a/src/features/routing/model.spec.ts
+++ b/src/features/routing/model.spec.ts
@@ -17,12 +17,10 @@
 import 'mocha';
 import { expect } from "chai";
 import { SModelRoot } from '../../base/model/smodel';
-import { RenderingContext } from '../../base/views/view';
 import { SShapeElement } from '../bounds/model';
-import { ViewportRootElement } from '../viewport/viewport-root';
-import { SRoutableElement } from './model';
+import { SRoutableElement, getAbsoluteRouteBounds } from './model';
 
-describe('SRoutableElement.getAbsoluteBounds', () => {
+describe('getAbsoluteRouteBounds', () => {
     function createModel(): SModelRoot {
         const root = new SModelRoot();
         const node1 = new TestNode();
@@ -41,60 +39,9 @@ describe('SRoutableElement.getAbsoluteBounds', () => {
     it('should compute the absolute bounds of a routable element', () => {
         const model = createModel();
         const routable = model.children[0].children[0] as SRoutableElement;
-        expect(routable.getAbsoluteBounds()).to.deep.equal({
+        expect(getAbsoluteRouteBounds(routable)).to.deep.equal({
             x: 110, y: 110, width: 30, height: 20
         });
-    });
-});
-
-describe('SRoutableElement.isVisible', () => {
-    function createModel(): ViewportRootElement {
-        const root = new ViewportRootElement();
-        root.canvasBounds = { x: 0, y: 0, width: 100, height: 100 };
-        const node1 = new TestNode();
-        node1.bounds = { x: 100, y: 100, width: 100, height: 100 };
-        root.add(node1);
-        const edge1 = new TestEdge();
-        edge1.routingPoints = [
-            { x: 10, y: 30 },
-            { x: 20, y: 10 },
-            { x: 40, y: 20 }
-        ];
-        node1.add(edge1);
-        return root;
-    }
-
-    it('should return true when an element intersects the canvas bounds', () => {
-        const model = createModel();
-        model.scroll = { x: 80, y: 80 };
-        model.zoom = 1;
-        const routable = model.children[0].children[0] as SRoutableElement;
-        expect(routable.isVisible()).to.equal(true);
-    });
-
-    it('should return false when the viewport is panned away', () => {
-        const model = createModel();
-        model.scroll = { x: 150, y: 80 };
-        model.zoom = 1;
-        const routable = model.children[0].children[0] as SRoutableElement;
-        expect(routable.isVisible()).to.equal(false);
-    });
-
-    it('should return false when the viewport is zoomed away', () => {
-        const model = createModel();
-        model.scroll = { x: 80, y: 80 };
-        model.zoom = 10;
-        const routable = model.children[0].children[0] as SRoutableElement;
-        expect(routable.isVisible()).to.equal(false);
-    });
-
-    it('should return true when rendered in a hidden context', () => {
-        const model = createModel();
-        model.scroll = { x: 150, y: 80 };
-        model.zoom = 10;
-        const context = { targetKind: 'hidden' } as RenderingContext;
-        const routable = model.children[0].children[0] as SRoutableElement;
-        expect(routable.isVisible(undefined, context)).to.equal(true);
     });
 });
 

--- a/src/features/routing/model.spec.ts
+++ b/src/features/routing/model.spec.ts
@@ -1,0 +1,100 @@
+/********************************************************************************
+ * Copyright (c) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import 'mocha';
+import { expect } from "chai";
+import { SModelRoot } from '../../base/model/smodel';
+import { RenderingContext } from '../../base/views/view';
+import { SShapeElement } from '../bounds/model';
+import { ViewportRootElement } from '../viewport/viewport-root';
+import { SRoutableElement, getAbsoluteRouteBounds, isRouteVisible } from './model';
+
+describe('getAbsoluteRouteBounds', () => {
+    function createModel(): SModelRoot {
+        const root = new SModelRoot();
+        const node1 = new TestNode();
+        node1.bounds = { x: 100, y: 100, width: 100, height: 100 };
+        root.add(node1);
+        const edge1 = new TestEdge();
+        edge1.routingPoints = [
+            { x: 10, y: 30 },
+            { x: 20, y: 10 },
+            { x: 40, y: 20 }
+        ];
+        node1.add(edge1);
+        return root;
+    }
+
+    it('should compute the absolute bounds of a routable element', () => {
+        const model = createModel();
+        expect(getAbsoluteRouteBounds(model.children[0].children[0] as SRoutableElement)).to.deep.equal({
+            x: 110, y: 110, width: 30, height: 20
+        });
+    });
+});
+
+describe('isRouteVisible', () => {
+    function createModel(): ViewportRootElement {
+        const root = new ViewportRootElement();
+        root.canvasBounds = { x: 0, y: 0, width: 100, height: 100 };
+        const node1 = new TestNode();
+        node1.bounds = { x: 100, y: 100, width: 100, height: 100 };
+        root.add(node1);
+        const edge1 = new TestEdge();
+        edge1.routingPoints = [
+            { x: 10, y: 30 },
+            { x: 20, y: 10 },
+            { x: 40, y: 20 }
+        ];
+        node1.add(edge1);
+        return root;
+    }
+
+    it('should return true when an element intersects the canvas bounds', () => {
+        const model = createModel();
+        model.scroll = { x: 80, y: 80 };
+        model.zoom = 1;
+        expect(isRouteVisible(model.children[0].children[0] as SRoutableElement)).to.equal(true);
+    });
+
+    it('should return false when the viewport is panned away', () => {
+        const model = createModel();
+        model.scroll = { x: 150, y: 80 };
+        model.zoom = 1;
+        expect(isRouteVisible(model.children[0].children[0] as SRoutableElement)).to.equal(false);
+    });
+
+    it('should return false when the viewport is zoomed away', () => {
+        const model = createModel();
+        model.scroll = { x: 80, y: 80 };
+        model.zoom = 10;
+        expect(isRouteVisible(model.children[0].children[0] as SRoutableElement)).to.equal(false);
+    });
+
+    it('should return true when rendered in a hidden context', () => {
+        const model = createModel();
+        model.scroll = { x: 150, y: 80 };
+        model.zoom = 10;
+        const context = { targetKind: 'hidden' } as RenderingContext;
+        expect(isRouteVisible(model.children[0].children[0] as SRoutableElement, undefined, context)).to.equal(true);
+    });
+});
+
+class TestNode extends SShapeElement {
+}
+
+class TestEdge extends SRoutableElement {
+}

--- a/src/features/routing/model.ts
+++ b/src/features/routing/model.ts
@@ -16,7 +16,6 @@
 
 import { SChildElement, SModelElement } from '../../base/model/smodel';
 import { SModelExtension } from '../../base/model/smodel-extension';
-import { RenderingContext } from '../../base/views/view';
 import { SEdge, SGraphIndex } from '../../graph/sgraph';
 import { Point, Bounds, combine, EMPTY_BOUNDS } from '../../utils/geometry';
 import { FluentIterable } from '../../utils/iterable';
@@ -51,33 +50,6 @@ export abstract class SRoutableElement extends SChildElement {
             height: 0
         }), EMPTY_BOUNDS);
     }
-
-    /**
-     * Determine whether this routable element is visible in the current canvas.
-     */
-    isVisible(route: Point[] = this.routingPoints, context?: RenderingContext): boolean {
-        if (context && context.targetKind === 'hidden') {
-            // Don't hide any element for hidden rendering
-            return true;
-        }
-        const ab = this.getAbsoluteBounds(route);
-        const canvasBounds = this.root.canvasBounds;
-        return ab.x <= canvasBounds.width
-            && ab.x + ab.width >= 0
-            && ab.y <= canvasBounds.height
-            && ab.y + ab.height >= 0;
-    }
-
-    getAbsoluteBounds(route: Point[] = this.routingPoints): Bounds {
-        let bounds = getRouteBounds(route);
-        let current: SModelElement = this;
-        while (current instanceof SChildElement) {
-            const parent = current.parent;
-            bounds = parent.localToParent(bounds);
-            current = parent;
-        }
-        return bounds;
-    }
 }
 
 export const connectableFeature = Symbol('connectableFeature');
@@ -88,6 +60,17 @@ export interface Connectable extends SModelExtension {
 
 export function isConnectable<T extends SModelElement>(element: T): element is Connectable & T {
     return element.hasFeature(connectableFeature) && (element as any).canConnect;
+}
+
+export function getAbsoluteRouteBounds(model: Readonly<SRoutableElement>, route: Point[] = model.routingPoints): Bounds {
+    let bounds = getRouteBounds(route);
+    let current: SModelElement = model;
+    while (current instanceof SChildElement) {
+        const parent = current.parent;
+        bounds = parent.localToParent(bounds);
+        current = parent;
+    }
+    return bounds;
 }
 
 export function getRouteBounds(route: Point[]): Bounds {

--- a/src/features/routing/views.spec.ts
+++ b/src/features/routing/views.spec.ts
@@ -23,7 +23,7 @@ import { SRoutableElement } from './model';
 import { RoutableView } from './views';
 import { VNode } from 'snabbdom/vnode';
 
-describe('RoutableView.isInViewport', () => {
+describe('RoutableView.isVisible', () => {
 
     class TestNode extends SShapeElement {
     }
@@ -60,7 +60,7 @@ describe('RoutableView.isInViewport', () => {
         model.zoom = 1;
         const routable = model.children[0].children[0] as SRoutableElement;
         const context = { targetKind: 'main' } as RenderingContext;
-        expect(view.isInViewport(routable, routable.routingPoints, context)).to.equal(true);
+        expect(view.isVisible(routable, routable.routingPoints, context)).to.equal(true);
     });
 
     it('should return false when the viewport is panned away', () => {
@@ -69,7 +69,7 @@ describe('RoutableView.isInViewport', () => {
         model.zoom = 1;
         const routable = model.children[0].children[0] as SRoutableElement;
         const context = { targetKind: 'main' } as RenderingContext;
-        expect(view.isInViewport(routable, routable.routingPoints, context)).to.equal(false);
+        expect(view.isVisible(routable, routable.routingPoints, context)).to.equal(false);
     });
 
     it('should return false when the viewport is zoomed away', () => {
@@ -78,7 +78,7 @@ describe('RoutableView.isInViewport', () => {
         model.zoom = 10;
         const routable = model.children[0].children[0] as SRoutableElement;
         const context = { targetKind: 'main' } as RenderingContext;
-        expect(view.isInViewport(routable, routable.routingPoints, context)).to.equal(false);
+        expect(view.isVisible(routable, routable.routingPoints, context)).to.equal(false);
     });
 
     it('should return true when rendered in a hidden context', () => {
@@ -87,6 +87,6 @@ describe('RoutableView.isInViewport', () => {
         model.zoom = 10;
         const routable = model.children[0].children[0] as SRoutableElement;
         const context = { targetKind: 'hidden' } as RenderingContext;
-        expect(view.isInViewport(routable, routable.routingPoints, context)).to.equal(true);
+        expect(view.isVisible(routable, routable.routingPoints, context)).to.equal(true);
     });
 });

--- a/src/features/routing/views.spec.ts
+++ b/src/features/routing/views.spec.ts
@@ -1,0 +1,92 @@
+/********************************************************************************
+ * Copyright (c) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import 'mocha';
+import { expect } from "chai";
+import { RenderingContext } from '../../base/views/view';
+import { SShapeElement } from '../bounds/model';
+import { ViewportRootElement } from '../viewport/viewport-root';
+import { SRoutableElement } from './model';
+import { RoutableView } from './views';
+import { VNode } from 'snabbdom/vnode';
+
+describe('RoutableView.isInViewport', () => {
+
+    class TestNode extends SShapeElement {
+    }
+
+    class TestEdge extends SRoutableElement {
+    }
+
+    class TestView extends RoutableView {
+        render(model: Readonly<SRoutableElement>, context: RenderingContext, args?: object): VNode | undefined {
+            return undefined;
+        }
+    }
+
+    function createModel(): ViewportRootElement {
+        const root = new ViewportRootElement();
+        root.canvasBounds = { x: 0, y: 0, width: 100, height: 100 };
+        const node1 = new TestNode();
+        node1.bounds = { x: 100, y: 100, width: 100, height: 100 };
+        root.add(node1);
+        const edge1 = new TestEdge();
+        edge1.routingPoints = [
+            { x: 10, y: 30 },
+            { x: 20, y: 10 },
+            { x: 40, y: 20 }
+        ];
+        node1.add(edge1);
+        return root;
+    }
+    const view = new TestView();
+
+    it('should return true when an element intersects the canvas bounds', () => {
+        const model = createModel();
+        model.scroll = { x: 80, y: 80 };
+        model.zoom = 1;
+        const routable = model.children[0].children[0] as SRoutableElement;
+        const context = { targetKind: 'main' } as RenderingContext;
+        expect(view.isInViewport(routable, routable.routingPoints, context)).to.equal(true);
+    });
+
+    it('should return false when the viewport is panned away', () => {
+        const model = createModel();
+        model.scroll = { x: 150, y: 80 };
+        model.zoom = 1;
+        const routable = model.children[0].children[0] as SRoutableElement;
+        const context = { targetKind: 'main' } as RenderingContext;
+        expect(view.isInViewport(routable, routable.routingPoints, context)).to.equal(false);
+    });
+
+    it('should return false when the viewport is zoomed away', () => {
+        const model = createModel();
+        model.scroll = { x: 80, y: 80 };
+        model.zoom = 10;
+        const routable = model.children[0].children[0] as SRoutableElement;
+        const context = { targetKind: 'main' } as RenderingContext;
+        expect(view.isInViewport(routable, routable.routingPoints, context)).to.equal(false);
+    });
+
+    it('should return true when rendered in a hidden context', () => {
+        const model = createModel();
+        model.scroll = { x: 150, y: 80 };
+        model.zoom = 10;
+        const routable = model.children[0].children[0] as SRoutableElement;
+        const context = { targetKind: 'hidden' } as RenderingContext;
+        expect(view.isInViewport(routable, routable.routingPoints, context)).to.equal(true);
+    });
+});

--- a/src/features/routing/views.ts
+++ b/src/features/routing/views.ts
@@ -27,7 +27,7 @@ export abstract class RoutableView implements IView {
      * in your `render` implementation to skip rendering in case the element is not visible.
      * This can greatly enhance performance for large models.
      */
-    isInViewport(model: Readonly<SRoutableElement>, route: Point[], context: RenderingContext): boolean {
+    isVisible(model: Readonly<SRoutableElement>, route: Point[], context: RenderingContext): boolean {
         if (context.targetKind === 'hidden') {
             // Don't hide any element for hidden rendering
             return true;

--- a/src/features/routing/views.ts
+++ b/src/features/routing/views.ts
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (c) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { VNode } from 'snabbdom/vnode';
+import { Point } from '../../utils/geometry';
+import { IView, RenderingContext } from '../../base/views/view';
+import { SRoutableElement, getAbsoluteRouteBounds } from './model';
+
+@injectable()
+export abstract class RoutableView implements IView {
+    /**
+     * Check whether the given model element is in the current viewport. Use this method
+     * in your `render` implementation to skip rendering in case the element is not visible.
+     * This can greatly enhance performance for large models.
+     */
+    isInViewport(model: Readonly<SRoutableElement>, route: Point[], context: RenderingContext): boolean {
+        if (context.targetKind === 'hidden') {
+            // Don't hide any element for hidden rendering
+            return true;
+        }
+        if (route.length === 0) {
+            // We should hide only if we know the element's route
+            return true;
+        }
+        const ab = getAbsoluteRouteBounds(model, route);
+        const canvasBounds = model.root.canvasBounds;
+        return ab.x <= canvasBounds.width
+            && ab.x + ab.width >= 0
+            && ab.y <= canvasBounds.height
+            && ab.y + ab.height >= 0;
+    }
+
+    abstract render(model: Readonly<SRoutableElement>, context: RenderingContext, args?: object): VNode | undefined;
+}

--- a/src/graph/views.spec.tsx
+++ b/src/graph/views.spec.tsx
@@ -69,7 +69,7 @@ describe('graph views', () => {
     configureView(container, 'port', RectangularNodeView);
 
     const postprocessors = container.getAll<IVNodePostprocessor>(TYPES.IVNodePostprocessor);
-    const context = container.get<ModelRendererFactory>(TYPES.ModelRendererFactory)(postprocessors);
+    const context = container.get<ModelRendererFactory>(TYPES.ModelRendererFactory)('main', postprocessors);
     const graphFactory = container.get<SGraphFactory>(TYPES.IModelFactory);
     const viewRegistry = container.get<ViewRegistry>(TYPES.ViewRegistry);
 

--- a/src/graph/views.spec.tsx
+++ b/src/graph/views.spec.tsx
@@ -69,7 +69,7 @@ describe('graph views', () => {
     configureView(container, 'port', RectangularNodeView);
 
     const postprocessors = container.getAll<IVNodePostprocessor>(TYPES.IVNodePostprocessor);
-    const context = container.get<ModelRendererFactory>(TYPES.ModelRendererFactory)('main', postprocessors);
+    const context = container.get<ModelRendererFactory>(TYPES.ModelRendererFactory)('hidden', postprocessors);
     const graphFactory = container.get<SGraphFactory>(TYPES.IModelFactory);
     const viewRegistry = container.get<ViewRegistry>(TYPES.ViewRegistry);
 
@@ -192,6 +192,7 @@ describe('PolylineEdgeView', () => {
     const viewRegistry = container.get<ViewRegistry>(TYPES.ViewRegistry);
     const edgeView = viewRegistry.get('edge:straight');
     const context = {
+        targetKind: 'hidden',
         viewRegistry,
         decorate: function(vnode: VNode, element: SModelElement): VNode { return vnode; },
         renderElement: function(element: SModelElement): VNode { return <g></g>; },

--- a/src/graph/views.tsx
+++ b/src/graph/views.tsx
@@ -57,7 +57,7 @@ export class PolylineEdgeView extends RoutableView {
         if (route.length === 0) {
             return this.renderDanglingEdge("Cannot compute route", edge, context);
         }
-        if (!this.isInViewport(edge, route, context)) {
+        if (!this.isVisible(edge, route, context)) {
             if (edge.children.length === 0) {
                 return undefined;
             }
@@ -126,7 +126,7 @@ export class SRoutingHandleView implements IView {
 @injectable()
 export class SLabelView extends ShapeView {
     render(label: Readonly<SLabel>, context: RenderingContext): VNode | undefined {
-        if (!isEdgeLayoutable(label) && !this.isInViewport(label, context)) {
+        if (!isEdgeLayoutable(label) && !this.isVisible(label, context)) {
             return undefined;
         }
         const vnode = <text class-sprotty-label={true}>{label.text}</text>;

--- a/src/graph/views.tsx
+++ b/src/graph/views.tsx
@@ -21,10 +21,11 @@ import { VNode } from "snabbdom/vnode";
 import { getSubType } from "../base/model/smodel-utils";
 import { IView, RenderingContext } from "../base/views/view";
 import { setAttr } from '../base/views/vnode-utils';
-import { isVisible } from '../features/bounds/model';
+import { ShapeView } from '../features/bounds/views';
 import { isEdgeLayoutable } from '../features/edge-layout/model';
 import { SRoutingHandle, SRoutableElement } from '../features/routing/model';
 import { EdgeRouterRegistry, RoutedPoint } from '../features/routing/routing';
+import { RoutableView } from '../features/routing/views';
 import { Point } from '../utils/geometry';
 import { SCompartment, SEdge, SGraph, SLabel } from "./sgraph";
 
@@ -46,7 +47,7 @@ export class SGraphView implements IView {
 }
 
 @injectable()
-export class PolylineEdgeView implements IView {
+export class PolylineEdgeView extends RoutableView {
 
     @inject(EdgeRouterRegistry) edgeRouterRegistry: EdgeRouterRegistry;
 
@@ -56,7 +57,7 @@ export class PolylineEdgeView implements IView {
         if (route.length === 0) {
             return this.renderDanglingEdge("Cannot compute route", edge, context);
         }
-        if (!edge.isVisible(route, context)) {
+        if (!this.isInViewport(edge, route, context)) {
             if (edge.children.length === 0) {
                 return undefined;
             }
@@ -123,9 +124,9 @@ export class SRoutingHandleView implements IView {
 }
 
 @injectable()
-export class SLabelView implements IView {
+export class SLabelView extends ShapeView {
     render(label: Readonly<SLabel>, context: RenderingContext): VNode | undefined {
-        if (!isEdgeLayoutable(label) && !isVisible(label, context)) {
+        if (!isEdgeLayoutable(label) && !this.isInViewport(label, context)) {
             return undefined;
         }
         const vnode = <text class-sprotty-label={true}>{label.text}</text>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ export * from "./features/bounds/model";
 export * from "./features/bounds/vbox-layout";
 export * from "./features/bounds/hbox-layout";
 export * from "./features/bounds/stack-layout";
+export * from "./features/bounds/views";
 
 export * from "./features/button/button-handler";
 export * from "./features/button/model";
@@ -129,6 +130,7 @@ export * from "./features/routing/model";
 export * from "./features/routing/polyline-anchors";
 export * from "./features/routing/polyline-edge-router";
 export * from "./features/routing/routing";
+export * from "./features/routing/views";
 
 export * from "./features/select/model";
 export * from "./features/select/select";

--- a/src/lib/generic-views.tsx
+++ b/src/lib/generic-views.tsx
@@ -21,13 +21,13 @@ import virtualize from "snabbdom-virtualize/strings";
 import { VNode } from "snabbdom/vnode";
 import { IView, RenderingContext } from "../base/views/view";
 import { setNamespace, setAttr } from "../base/views/vnode-utils";
-import { isVisible } from "../features/bounds/model";
-import { ForeignObjectElement, PreRenderedElement } from "./model";
+import { ShapeView } from "../features/bounds/views";
+import { ForeignObjectElement, PreRenderedElement, ShapedPreRenderedElement } from "./model";
 
 @injectable()
-export class PreRenderedView implements IView {
-    render(model: PreRenderedElement, context: RenderingContext): VNode | undefined {
-        if (!isVisible(model, context)) {
+export class PreRenderedView extends ShapeView {
+    render(model: Readonly<PreRenderedElement>, context: RenderingContext): VNode | undefined {
+        if (model instanceof ShapedPreRenderedElement && !this.isInViewport(model, context)) {
             return undefined;
         }
         const node = virtualize(model.code);

--- a/src/lib/generic-views.tsx
+++ b/src/lib/generic-views.tsx
@@ -21,11 +21,15 @@ import virtualize from "snabbdom-virtualize/strings";
 import { VNode } from "snabbdom/vnode";
 import { IView, RenderingContext } from "../base/views/view";
 import { setNamespace, setAttr } from "../base/views/vnode-utils";
+import { isVisible } from "../features/bounds/model";
 import { ForeignObjectElement, PreRenderedElement } from "./model";
 
 @injectable()
 export class PreRenderedView implements IView {
-    render(model: PreRenderedElement, context: RenderingContext): VNode {
+    render(model: PreRenderedElement, context: RenderingContext): VNode | undefined {
+        if (!isVisible(model, context)) {
+            return undefined;
+        }
         const node = virtualize(model.code);
         this.correctNamespace(node);
         return node;

--- a/src/lib/generic-views.tsx
+++ b/src/lib/generic-views.tsx
@@ -27,7 +27,7 @@ import { ForeignObjectElement, PreRenderedElement, ShapedPreRenderedElement } fr
 @injectable()
 export class PreRenderedView extends ShapeView {
     render(model: Readonly<PreRenderedElement>, context: RenderingContext): VNode | undefined {
-        if (model instanceof ShapedPreRenderedElement && !this.isInViewport(model, context)) {
+        if (model instanceof ShapedPreRenderedElement && !this.isVisible(model, context)) {
             return undefined;
         }
         const node = virtualize(model.code);

--- a/src/lib/svg-views.tsx
+++ b/src/lib/svg-views.tsx
@@ -21,7 +21,7 @@ import { VNode } from "snabbdom/vnode";
 import { IView, RenderingContext } from "../base/views/view";
 import { SNode, SPort } from "../graph/sgraph";
 import { ViewportRootElement } from "../features/viewport/viewport-root";
-import { SShapeElement } from '../features/bounds/model';
+import { SShapeElement, isVisible } from '../features/bounds/model';
 import { Hoverable } from '../features/hover/model';
 import { Selectable } from '../features/select/model';
 import { Diamond, Point } from '../utils/geometry';
@@ -42,7 +42,10 @@ export class SvgViewportView implements IView {
 
 @injectable()
 export class CircularNodeView implements IView {
-    render(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): VNode {
+    render(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): VNode | undefined {
+        if (!isVisible(node, context)) {
+            return undefined;
+        }
         const radius = this.getRadius(node);
         return <g>
             <circle class-sprotty-node={node instanceof SNode} class-sprotty-port={node instanceof SPort}
@@ -60,7 +63,10 @@ export class CircularNodeView implements IView {
 
 @injectable()
 export class RectangularNodeView implements IView {
-    render(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): VNode {
+    render(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): VNode | undefined {
+        if (!isVisible(node, context)) {
+            return undefined;
+        }
         return <g>
             <rect class-sprotty-node={node instanceof SNode} class-sprotty-port={node instanceof SPort}
                   class-mouseover={node.hoverFeedback} class-selected={node.selected}
@@ -72,7 +78,10 @@ export class RectangularNodeView implements IView {
 
 @injectable()
 export class DiamondNodeView implements IView {
-    render(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): VNode {
+    render(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): VNode | undefined {
+        if (!isVisible(node, context)) {
+            return undefined;
+        }
         const diamond = new Diamond({ height: Math.max(node.size.height, 0), width: Math.max(node.size.width, 0), x: 0, y: 0 });
         const points = `${svgStr(diamond.topPoint)} ${svgStr(diamond.rightPoint)} ${svgStr(diamond.bottomPoint)} ${svgStr(diamond.leftPoint)}`;
         return <g>
@@ -87,9 +96,10 @@ export class DiamondNodeView implements IView {
 function svgStr(point: Point) {
     return `${point.x},${point.y}`;
 }
+
 @injectable()
 export class EmptyGroupView implements IView {
-    render(node: Readonly<SModelElement>, context: RenderingContext): VNode {
+    render(model: Readonly<SModelElement>, context: RenderingContext): VNode {
         return <g></g>;
     }
 }

--- a/src/lib/svg-views.tsx
+++ b/src/lib/svg-views.tsx
@@ -44,7 +44,7 @@ export class SvgViewportView implements IView {
 @injectable()
 export class CircularNodeView extends ShapeView {
     render(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): VNode | undefined {
-        if (!this.isInViewport(node, context)) {
+        if (!this.isVisible(node, context)) {
             return undefined;
         }
         const radius = this.getRadius(node);
@@ -65,7 +65,7 @@ export class CircularNodeView extends ShapeView {
 @injectable()
 export class RectangularNodeView extends ShapeView {
     render(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): VNode | undefined {
-        if (!this.isInViewport(node, context)) {
+        if (!this.isVisible(node, context)) {
             return undefined;
         }
         return <g>
@@ -80,7 +80,7 @@ export class RectangularNodeView extends ShapeView {
 @injectable()
 export class DiamondNodeView extends ShapeView {
     render(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): VNode | undefined {
-        if (!this.isInViewport(node, context)) {
+        if (!this.isVisible(node, context)) {
             return undefined;
         }
         const diamond = new Diamond({ height: Math.max(node.size.height, 0), width: Math.max(node.size.width, 0), x: 0, y: 0 });

--- a/src/lib/svg-views.tsx
+++ b/src/lib/svg-views.tsx
@@ -21,7 +21,8 @@ import { VNode } from "snabbdom/vnode";
 import { IView, RenderingContext } from "../base/views/view";
 import { SNode, SPort } from "../graph/sgraph";
 import { ViewportRootElement } from "../features/viewport/viewport-root";
-import { SShapeElement, isVisible } from '../features/bounds/model';
+import { SShapeElement } from '../features/bounds/model';
+import { ShapeView } from '../features/bounds/views';
 import { Hoverable } from '../features/hover/model';
 import { Selectable } from '../features/select/model';
 import { Diamond, Point } from '../utils/geometry';
@@ -41,9 +42,9 @@ export class SvgViewportView implements IView {
 }
 
 @injectable()
-export class CircularNodeView implements IView {
+export class CircularNodeView extends ShapeView {
     render(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): VNode | undefined {
-        if (!isVisible(node, context)) {
+        if (!this.isInViewport(node, context)) {
             return undefined;
         }
         const radius = this.getRadius(node);
@@ -62,9 +63,9 @@ export class CircularNodeView implements IView {
 }
 
 @injectable()
-export class RectangularNodeView implements IView {
+export class RectangularNodeView extends ShapeView {
     render(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): VNode | undefined {
-        if (!isVisible(node, context)) {
+        if (!this.isInViewport(node, context)) {
             return undefined;
         }
         return <g>
@@ -77,9 +78,9 @@ export class RectangularNodeView implements IView {
 }
 
 @injectable()
-export class DiamondNodeView implements IView {
+export class DiamondNodeView extends ShapeView {
     render(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): VNode | undefined {
-        if (!isVisible(node, context)) {
+        if (!this.isInViewport(node, context)) {
             return undefined;
         }
         const diamond = new Diamond({ height: Math.max(node.size.height, 0), width: Math.max(node.size.width, 0), x: 0, y: 0 });


### PR DESCRIPTION
This change allows views to return `undefined` instead of a VNode and adds utility functions to check whether elements are visible in the current viewport. This enables to completely skip elements that are outside of the viewport, which can greatly enhance performance.

The changes should have no effect on existing applications, but they can opt in to use the new code to improve responsiveness.

I used this code in the Circlegraph and the Multicore examples. The effect can be seen best when the initial number of nodes of the Circlegraph example is set to 8000 (`examples/circlegraph/src/standalone.ts` line 73). The view is quite unresponsive, but it gets a lot better if you pan to the side so only a part of the nodes and edges are visible.