### PR TITLE
Added ability to reject request actions

### DIFF
--- a/examples/multicore/src/chipmodel.ts
+++ b/examples/multicore/src/chipmodel.ts
@@ -17,7 +17,8 @@
 import {
     SShapeElement, SChildElement, SModelElementSchema, SModelRootSchema,
     Bounds, Direction, BoundsAware, boundsFeature, Fadeable, fadeFeature,
-    layoutContainerFeature, LayoutContainer, Selectable, selectFeature, ViewportRootElement, hoverFeedbackFeature, Hoverable, popupFeature
+    layoutContainerFeature, LayoutContainer, Selectable, selectFeature,
+    ViewportRootElement, hoverFeedbackFeature, Hoverable, popupFeature, JsonMap
 } from '../../../src';
 import { CORE_DISTANCE, CORE_WIDTH } from "./views";
 
@@ -31,7 +32,7 @@ export class Processor extends ViewportRootElement implements BoundsAware {
 
     rows: number = 0;
     columns: number = 0;
-    layoutOptions: any;
+    layoutOptions: JsonMap;
 
     get bounds(): Bounds {
         return {

--- a/src/base/actions/action-dispatcher.ts
+++ b/src/base/actions/action-dispatcher.ts
@@ -116,7 +116,10 @@ export class ActionDispatcher implements IActionDispatcher {
             if (deferred !== undefined) {
                 this.requests.delete(action.responseId);
                 if (action.kind === RejectAction.KIND) {
-                    deferred.reject(new Error((action as RejectAction).message));
+                    const rejectAction = action as RejectAction;
+                    deferred.reject(new Error(rejectAction.message));
+                    this.logger.warn(this, `Request with id ${action.responseId} failed.`,
+                            rejectAction.message, rejectAction.detail);
                 } else {
                     deferred.resolve(action);
                 }

--- a/src/base/actions/action.ts
+++ b/src/base/actions/action.ts
@@ -64,6 +64,17 @@ export function isResponseAction(object?: any): object is ResponseAction {
 }
 
 /**
+ * A reject action is fired to indicate that a request must be rejected.
+ */
+export class RejectAction implements ResponseAction {
+    static readonly KIND = 'rejectRequest';
+    readonly kind = RejectAction.KIND;
+
+    constructor(public readonly message: string,
+                public readonly responseId: string) {}
+}
+
+/**
  * A list of actions with a label.
  * Labeled actions are used to denote a group of actions in a user-interface context, e.g.,
  * to define an entry in the command palette or in the context menu.

--- a/src/base/actions/action.ts
+++ b/src/base/actions/action.ts
@@ -14,6 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { JsonAny } from '../../utils/json';
+
 /**
  * An action describes a change to the model declaratively.
  * It is a plain data structure, and as such transferable between server and client. An action must never contain actual
@@ -71,7 +73,8 @@ export class RejectAction implements ResponseAction {
     readonly kind = RejectAction.KIND;
 
     constructor(public readonly message: string,
-                public readonly responseId: string) {}
+                public readonly responseId: string,
+                public readonly detail?: JsonAny) {}
 }
 
 /**

--- a/src/base/features/set-model.ts
+++ b/src/base/features/set-model.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { inject, injectable } from "inversify";
+import { JsonPrimitive } from '../../utils/json';
 import { Action, RequestAction, ResponseAction, generateRequestId } from "../actions/action";
 import { CommandExecutionContext, ResetCommand } from "../commands/command";
 import { SModelRoot, SModelRootSchema } from "../model/smodel";
@@ -30,11 +31,11 @@ export class RequestModelAction implements RequestAction<SetModelAction> {
     static readonly KIND = 'requestModel';
     readonly kind = RequestModelAction.KIND;
 
-    constructor(public readonly options?: { [key: string]: string | number | boolean },
+    constructor(public readonly options?: { [key: string]: JsonPrimitive },
                 public readonly requestId = '') {}
 
     /** Factory function to dispatch a request with the `IActionDispatcher` */
-    static create(options?: { [key: string]: string | number | boolean }): RequestAction<SetModelAction> {
+    static create(options?: { [key: string]: JsonPrimitive }): RequestAction<SetModelAction> {
         return new RequestModelAction(options, generateRequestId());
     }
 }

--- a/src/base/views/mouse-tool.ts
+++ b/src/base/views/mouse-tool.ts
@@ -133,7 +133,7 @@ export class MouseTool implements IVNodePostprocessor {
             on(vnode, 'mouseup', this.mouseUp.bind(this), element);
             on(vnode, 'mousemove', this.mouseMove.bind(this), element);
             on(vnode, 'wheel', this.wheel.bind(this), element);
-            on(vnode, 'contextmenu', (target: SModelElement, event: any) => {
+            on(vnode, 'contextmenu', (target: SModelElement, event: Event) => {
                 event.preventDefault();
             }, element);
             on(vnode, 'dblclick', this.doubleClick.bind(this), element);

--- a/src/features/bounds/abstract-layout.ts
+++ b/src/features/bounds/abstract-layout.ts
@@ -21,7 +21,7 @@ import { ILayout, StatefulLayouter } from './layout';
 import { AbstractLayoutOptions, HAlignment, VAlignment } from './layout-options';
 import { BoundsData } from './hidden-bounds-updater';
 
-export abstract class AbstractLayout<T extends AbstractLayoutOptions & Object> implements ILayout {
+export abstract class AbstractLayout<T extends AbstractLayoutOptions> implements ILayout {
 
     layout(container: SParentElement & LayoutContainer,
            layouter: StatefulLayouter) {
@@ -63,7 +63,7 @@ export abstract class AbstractLayout<T extends AbstractLayoutOptions & Object> i
 
     protected getFixedContainerBounds(
             container: SModelElement,
-            layoutOptions: any,
+            layoutOptions: T,
             layouter: StatefulLayouter): Bounds {
         let currentContainer = container;
         while (true) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,5 +209,6 @@ export * from "./utils/browser";
 export * from "./utils/color";
 export * from "./utils/geometry";
 export * from "./utils/inversify";
+export * from "./utils/json";
 export * from "./utils/logging";
 export * from "./utils/registry";

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2020 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,19 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { JsonMap } from '../../utils/json';
+export type JsonAny =  JsonPrimitive | JsonMap | JsonArray | null;
 
-export type HAlignment = 'left' | 'center' | 'right';
+export type JsonPrimitive = string | number | boolean;
 
-export type VAlignment = 'top' | 'center' | 'bottom';
-
-export interface AbstractLayoutOptions extends JsonMap {
-    resizeContainer: boolean
-    paddingTop: number
-    paddingBottom: number
-    paddingLeft: number
-    paddingRight: number
-    paddingFactor: number
-    minWidth: number
-    minHeight: number
+export interface JsonMap {
+    [key: string]: JsonAny;
 }
+
+export interface JsonArray extends Array<JsonAny> {}


### PR DESCRIPTION
It should be possible to reject request actions. This change introduces RejectAction for this purpose.

This is particularly important for requests that are forwarded to a diagram server, e.g. RequestModelAction. We should implement the new feature in sprotty-server, too, after this is merged.