### PR TITLE
Added getParent and getRoot to SModelIndex

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "style-loader": "^1.0.0",
     "ts-loader": "^6.1.0",
     "ts-node": "^8.3.0",
-    "tslint": "^5.20.0",
-    "typescript": "3.6.3",
+    "tslint": "^6.1.3",
+    "typescript": "3.8.3",
     "webpack": "^4.39.3",
     "webpack-cli": "^3.3.8"
   },

--- a/src/base/model/smodel.spec.ts
+++ b/src/base/model/smodel.spec.ts
@@ -16,7 +16,7 @@
 
 import "mocha";
 import { expect } from "chai";
-import { SChildElement, SModelIndex, SModelRoot, SModelElement } from './smodel';
+import { SChildElement, SModelIndex, SModelRoot, SModelElement, SModelElementSchema, SModelRootSchema } from './smodel';
 
 describe('SModelRoot', () => {
     function setup() {
@@ -38,6 +38,7 @@ describe('SModelRoot', () => {
         const element = setup();
         expect(element.children.map(c => c.id)).to.deep.equal(['child1', 'child2', 'child3']);
     });
+
     it('can reorder children', () => {
         const element = setup();
         element.move(element.children[1], 2);
@@ -45,11 +46,13 @@ describe('SModelRoot', () => {
         element.move(element.children[1], 0);
         expect(element.children.map(c => c.id)).to.deep.equal(['child3', 'child1', 'child2']);
     });
+
     it('can remove children', () => {
         const element = setup();
         element.remove(element.children[1]);
         expect(element.children.map(c => c.id)).to.deep.equal(['child1', 'child3']);
     });
+
     it('correctly assigns the parent to children', () => {
         const element = setup();
         expect(element.children[0].parent.id).to.equal('root');
@@ -74,9 +77,83 @@ describe('SModelIndex', () => {
         expect(ctx.index.contains(ctx.child1)).to.be.true;
         expect(ctx.index.getById('child1')!.id).to.equal('child1');
     });
+
     it('does not contain elements after removing them', () => {
         const ctx = setup();
         ctx.index.remove(ctx.child2);
+        expect(ctx.index.contains(ctx.child2)).to.be.false;
         expect(ctx.index.getById('child2')).to.be.undefined;
+    });
+
+    it('returns the parent element for an internal model', () => {
+        const index = new SModelIndex<SModelElement>();
+        const root = new SModelRoot(index);
+        const parent = new SChildElement();
+        parent.id = 'parent';
+        root.add(parent);
+        const child = new SChildElement();
+        child.id = 'child';
+        parent.add(child);
+        expect((index as any).id2parent).to.be.undefined;
+        expect(index.getParent(child.id)!.id).to.equal('parent');
+    });
+
+    it('returns the root element for an internal model', () => {
+        const index = new SModelIndex<SModelElement>();
+        const root = new SModelRoot(index);
+        root.id = 'root';
+        const parent = new SChildElement();
+        parent.id = 'parent';
+        root.add(parent);
+        const child = new SChildElement();
+        child.id = 'child';
+        parent.add(child);
+        expect((index as any).id2parent).to.be.undefined;
+        expect(index.getRoot(child).id).to.equal('root');
+    });
+
+    it('returns the parent element for an external model', () => {
+        const index = new SModelIndex<SModelElementSchema>();
+        const root: SModelRootSchema = {
+            type: 'root',
+            id: 'root',
+            children: [
+                {
+                    type: 'node',
+                    id: 'parent',
+                    children: [
+                        {
+                            type: 'node',
+                            id: 'child'
+                        }
+                    ]
+                }
+            ]
+        };
+        index.add(root);
+        expect(index.getParent('child')!.id).to.equal('parent');
+    });
+
+    it('returns the root element for an external model', () => {
+        const index = new SModelIndex<SModelElementSchema>();
+        const root: SModelRootSchema = {
+            type: 'root',
+            id: 'root',
+            children: [
+                {
+                    type: 'node',
+                    id: 'parent',
+                    children: [
+                        {
+                            type: 'node',
+                            id: 'child'
+                        }
+                    ]
+                }
+            ]
+        };
+        index.add(root);
+        const child = root.children![0].children![0];
+        expect(index.getRoot(child).id).to.equal('root');
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2739,6 +2739,11 @@ minimist@^1.1.0, minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
 minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
@@ -2789,6 +2794,13 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mkdirp@^0.5.3:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
+  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
+  dependencies:
+    minimist "^1.2.5"
 
 mocha@^6.0.0, mocha@^6.2.0:
   version "6.2.0"
@@ -4438,15 +4450,20 @@ ts-node@^8.3.0:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
-tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
-tslint@^5.20.0:
-  version "5.20.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.20.0.tgz#fac93bfa79568a5a24e7be9cdde5e02b02d00ec1"
-  integrity sha512-2vqIvkMHbnx8acMogAERQ/IuINOq6DFqgF8/VDvhEkBqQh/x6SP0Y+OHnKth9/ZcHQSroOZwUQSN18v8KKF0/g==
+tslint@^6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-6.1.3.tgz#5c23b2eccc32487d5523bd3a470e9aa31789d904"
+  integrity sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     builtin-modules "^1.1.1"
@@ -4456,10 +4473,10 @@ tslint@^5.20.0:
     glob "^7.1.1"
     js-yaml "^3.13.1"
     minimatch "^3.0.4"
-    mkdirp "^0.5.1"
+    mkdirp "^0.5.3"
     resolve "^1.3.2"
     semver "^5.3.0"
-    tslib "^1.8.0"
+    tslib "^1.13.0"
     tsutils "^2.29.0"
 
 tsutils@^2.29.0:
@@ -4503,10 +4520,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.6.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
-  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 uglify-js@^3.1.4:
   version "3.7.3"


### PR DESCRIPTION
This is a preparation for eclipse/sprotty-layout#12. There are situations where one needs a reference to a parent element, which is not available in SModelElementSchema. The new code does not add any memory overhead for the internal model (SChildElement already has a `parent` property).