### PR TITLE
Text element dragging fix for firefox

### DIFF
--- a/src/features/move/move.ts
+++ b/src/features/move/move.ts
@@ -505,7 +505,7 @@ export class MoveMouseListener extends MouseListener {
     }
 
     mouseEnter(target: SModelElement, event: MouseEvent): Action[] {
-        if (target instanceof SModelRoot && event.buttons === 0)
+        if (target instanceof SModelRoot && event.buttons === 0 && !this.startDragPosition)
             this.mouseUp(target, event);
         return [];
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2073,10 +2073,10 @@ interpret@1.2.0, interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
-inversify@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/inversify/-/inversify-5.0.1.tgz#500d709b1434896ce5a0d58915c4a4210e34fb6e"
-  integrity sha512-Ieh06s48WnEYGcqHepdsJUIJUXpwH5o5vodAX+DK2JA/gjy4EbEcQZxw+uFfzysmKjiLXGYwNG3qDZsKVMcINQ==
+inversify@^5.0.1:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/inversify/-/inversify-5.0.5.tgz#bd1f8e6d8e0f739331acd8ba9bc954635aae0bbf"
+  integrity sha512-60QsfPz8NAU/GZqXu8hJ+BhNf/C/c+Hp0eDc6XMIJTxBiP36AQyyQKpBkOVTLWBFDQWYVHpbbEuIsHu9dLuJDA==
 
 invert-kv@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes #195

After the first `mouseDown` event on an text element, firefox always triggers a `mouseEnter` event as well (other browsers don't).
This will undo the state changes made by the `mouseDown` event. 

To fix this, we will simply check on `mouseEnter` whether the element is already in a dragging state before we call `mouseUp`.