### PR TITLE
Fix #190: Duplicate ID in model error during update if parent is changed

### DIFF
--- a/src/features/update/update-model.spec.ts
+++ b/src/features/update/update-model.spec.ts
@@ -416,6 +416,62 @@ describe('UpdateModelCommand', () => {
         }
     });
 
+    // tests regression #190
+    it('removes relocated elements before adding them', () => {
+        context.root = graphFactory.createRoot({
+            type: 'graph',
+            id: 'model',
+            children: [
+                {
+                    type: 'node',
+                    id: 'a',
+                    children: [
+                        {
+                            type: 'node',
+                            id: 'b'
+                        }
+                    ]
+                }
+            ]
+        });
+        const flattenCommand = new UpdateModelCommand({
+            kind: UpdateModelCommand.KIND,
+            animate: false,
+            matches: [
+                {
+                    right: {
+                        type: 'node',
+                        id: 'b'
+                    },
+                    rightParentId: 'model'
+                },
+                {
+                    left: {
+                        type: 'node',
+                        id: 'b'
+                    },
+                    leftParentId: 'a'
+                }
+            ]
+        });
+        const actual = flattenCommand.execute(context);
+        const expected: SModelElementSchema = {
+            type: 'graph',
+            id: 'model',
+            children: [
+                {
+                    type: 'node',
+                    id: 'a'
+                },
+                {
+                    type: 'node',
+                    id: 'b'
+                }
+            ]
+        };
+        compare(expected, actual as SModelRoot);
+    });
+
     function newModelWithEdge(edgeId: string, routingPoints: Point[]): SModelRootSchema {
         return {
             type: 'graph',

--- a/src/features/update/update-model.ts
+++ b/src/features/update/update-model.ts
@@ -122,6 +122,8 @@ export class UpdateModelCommand extends Command {
                 if (element instanceof SChildElement)
                     element.parent.remove(element);
             }
+        }
+        for (const match of matches) {
             if (match.right !== undefined) {
                 const element = context.modelFactory.createElement(match.right);
                 let parent: SModelElement | undefined;


### PR DESCRIPTION
Hi,

I intentionally moved the test to the end of the mocha spec because I had the impression that there exists the risk of mutating the model context in an undesired way. Is it okay or should the test be isolated by creating a vanilla context using a new describe() method?

Thx!