### PR TITLE
Fixes duplicate ID errors

### DIFF
--- a/src/base/model/smodel-utils.ts
+++ b/src/base/model/smodel-utils.ts
@@ -17,7 +17,7 @@
 import { interfaces } from "inversify";
 import { TYPES } from "../types";
 import { Point, Bounds } from "../../utils/geometry";
-import { SChildElement, SModelElement, SModelElementSchema } from "./smodel";
+import { SChildElement, SModelElement, SModelElementSchema, SModelRoot } from "./smodel";
 import { SModelElementRegistration, CustomFeatures } from "./smodel-factory";
 
 /**
@@ -148,4 +148,13 @@ export function translateBounds(bounds: Bounds, source: SModelElement, target: S
         width: lowerRight.x - upperLeft.x,
         height: lowerRight.y - upperLeft.y
     };
+}
+
+/**
+ * Tests if the given model contains an id of then given element or one of its descendants.
+ */
+export function containsSome(root: SModelRoot, element: SChildElement): boolean {
+    const test = (element: SChildElement) => root.index.getById(element.id) !== undefined;
+    const find = (elements: readonly SChildElement[]): boolean => elements.some(element => test(element) || find(element.children));
+    return find([element]);
 }

--- a/src/features/update/update-model.ts
+++ b/src/features/update/update-model.ts
@@ -33,6 +33,7 @@ import { TYPES } from "../../base/types";
 import { isViewport } from "../viewport/model";
 import { EdgeRouterRegistry, EdgeSnapshot, EdgeMemento } from "../routing/routing";
 import { SRoutableElement } from "../routing/model";
+import { containsSome } from "../../base/model/smodel-utils";
 
 /**
  * Sent from the model source to the client in order to update the model. If no model is present yet,
@@ -180,7 +181,7 @@ export class UpdateModelCommand extends Command {
                 // An element has been removed
                 const left = match.left;
                 if (isFadeable(left) && match.leftParentId !== undefined) {
-                    if (newRoot.index.getById(left.id) === undefined) {
+                    if (!containsSome(newRoot, left)) {
                         const parent = newRoot.index.getById(match.leftParentId);
                         if (parent instanceof SParentElement) {
                             const leftCopy = context.modelFactory.createElement(left) as SChildElement & Fadeable;


### PR DESCRIPTION
…by only fading out nodes if none of the children is present in the new root.

Towards #190 (needs to be re-tested)

Signed-off-by: Daniel Dietrich <daniel.dietrich@typefox.io>