### PR TITLE
Enabled eslint rule "no-prototype-builtins".

### DIFF
--- a/configs/.eslintrc.js
+++ b/configs/.eslintrc.js
@@ -91,6 +91,7 @@ module.exports = {
                 "code": 180
             }
         ],
+        "no-prototype-builtins": "error",
         "no-caller": "error",
         "no-console": "off",
         "no-debugger": "warn",

--- a/src/base/actions/action.ts
+++ b/src/base/actions/action.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { JsonAny } from '../../utils/json';
+import { hasOwnProperty } from '../../utils/object';
 
 /**
  * An action describes a change to the model declaratively.
@@ -25,8 +26,8 @@ export interface Action {
     readonly kind: string
 }
 
-export function isAction(object?: any): object is Action {
-    return object !== undefined && object.hasOwnProperty('kind') && typeof(object['kind']) === 'string';
+export function isAction(object?: unknown): object is Action {
+    return hasOwnProperty(object, 'kind') && typeof(object.kind) === 'string';
 }
 
 /**
@@ -37,9 +38,9 @@ export interface RequestAction<Res extends ResponseAction> extends Action {
     readonly requestId: string
 }
 
-export function isRequestAction(object?: any): object is RequestAction<ResponseAction> {
-    return isAction(object) && object.hasOwnProperty('requestId')
-            && typeof((object as any)['requestId']) === 'string';
+export function isRequestAction(object?: unknown): object is RequestAction<ResponseAction> {
+    return isAction(object) && hasOwnProperty(object, 'requestId')
+            && typeof(object.requestId) === 'string';
 }
 
 let nextRequestId = 1;
@@ -59,10 +60,10 @@ export interface ResponseAction extends Action {
     readonly responseId: string
 }
 
-export function isResponseAction(object?: any): object is ResponseAction {
-    return isAction(object) && object.hasOwnProperty('responseId')
-            && typeof((object as any)['responseId']) === 'string'
-            && (object as any)['responseId'] !== '';
+export function isResponseAction(object?: unknown): object is ResponseAction {
+    return isAction(object) && hasOwnProperty(object, 'responseId')
+            && typeof(object.responseId) === 'string'
+            && object.responseId !== '';
 }
 
 /**
@@ -86,7 +87,7 @@ export class LabeledAction {
     constructor(readonly label: string, readonly actions: Action[], readonly icon?: string) { }
 }
 
-export function isLabeledAction(element: any): element is LabeledAction {
+export function isLabeledAction(element: unknown): element is LabeledAction {
     return element !== undefined
         && (<LabeledAction>element).label !== undefined
         && (<LabeledAction>element).actions !== undefined;

--- a/src/base/actions/action.ts
+++ b/src/base/actions/action.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2021 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -27,7 +27,7 @@ export interface Action {
 }
 
 export function isAction(object?: unknown): object is Action {
-    return hasOwnProperty(object, 'kind') && typeof(object.kind) === 'string';
+    return hasOwnProperty<string, string>(object, 'kind', 'string');
 }
 
 /**
@@ -39,8 +39,7 @@ export interface RequestAction<Res extends ResponseAction> extends Action {
 }
 
 export function isRequestAction(object?: unknown): object is RequestAction<ResponseAction> {
-    return isAction(object) && hasOwnProperty(object, 'requestId')
-            && typeof(object.requestId) === 'string';
+    return isAction(object) && hasOwnProperty<string, string>(object, 'requestId', 'string');
 }
 
 let nextRequestId = 1;
@@ -61,8 +60,7 @@ export interface ResponseAction extends Action {
 }
 
 export function isResponseAction(object?: unknown): object is ResponseAction {
-    return isAction(object) && hasOwnProperty(object, 'responseId')
-            && typeof(object.responseId) === 'string'
+    return isAction(object) && hasOwnProperty<string, string>(object, 'responseId', 'string')
             && object.responseId !== '';
 }
 

--- a/src/base/commands/command-stack-options.ts
+++ b/src/base/commands/command-stack-options.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { Container } from "inversify";
+import { safeAssign } from "../../utils/object";
 import { TYPES } from '../types';
 
 /**
@@ -38,9 +39,6 @@ export interface CommandStackOptions {
 
 export function overrideCommandStackOptions(container: Container, options: Partial<CommandStackOptions>): CommandStackOptions {
     const defaultOptions = container.get<CommandStackOptions>(TYPES.CommandStackOptions);
-    for (const p in options) {
-        if (options.hasOwnProperty(p))
-            (defaultOptions as any)[p] = (options as any)[p];
-    }
+    safeAssign(defaultOptions, options);
     return defaultOptions;
 }

--- a/src/base/commands/command-stack-options.ts
+++ b/src/base/commands/command-stack-options.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2021 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/base/views/viewer-options.ts
+++ b/src/base/views/viewer-options.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { Container, interfaces } from "inversify";
+import { safeAssign } from "../../utils/object";
 import { TYPES } from "../types";
 
 export interface ViewerOptions {
@@ -66,9 +67,6 @@ export function configureViewerOptions(context: { bind: interfaces.Bind, isBound
  */
 export function overrideViewerOptions(container: Container, options: Partial<ViewerOptions>): ViewerOptions {
     const opt = container.get<ViewerOptions>(TYPES.ViewerOptions);
-    for (const p in options) {
-        if (options.hasOwnProperty(p))
-            (opt as any)[p] = (options as any)[p];
-    }
+    safeAssign(opt, options);
     return opt;
 }

--- a/src/base/views/viewer-options.ts
+++ b/src/base/views/viewer-options.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2021 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/base/views/vnode-utils.ts
+++ b/src/base/views/vnode-utils.ts
@@ -41,10 +41,7 @@ export function setNamespace(node: VNode, ns: string) {
 
 export function copyClassesFromVNode(source: VNode, target: VNode) {
     const classList = getClass(source);
-    for (const c in classList) {
-        if (classList.hasOwnProperty(c))
-            setClass(target, c, true);
-    }
+    Object.keys(classList).forEach(c => setClass(target, c, true));
 }
 
 export function copyClassesFromElement(element: HTMLElement, target: VNode) {

--- a/src/base/views/vnode-utils.ts
+++ b/src/base/views/vnode-utils.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2021 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/features/select/select.ts
+++ b/src/features/select/select.ts
@@ -164,13 +164,11 @@ export class SelectAllCommand extends Command {
 
     undo(context: CommandExecutionContext): SModelRoot {
         const index = context.root.index;
-        for (const id in this.previousSelection) {
-            if (this.previousSelection.hasOwnProperty(id)) {
-                const element = index.getById(id);
-                if (element !== undefined && isSelectable(element))
-                    element.selected = this.previousSelection[id];
-            }
-        }
+        Object.keys(this.previousSelection).forEach(id => {
+            const element = index.getById(id);
+            if (element !== undefined && isSelectable(element))
+                element.selected = this.previousSelection[id];
+        });
         return context.root;
     }
 

--- a/src/features/select/select.ts
+++ b/src/features/select/select.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2021 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/features/update/model-matching.ts
+++ b/src/features/update/model-matching.ts
@@ -28,10 +28,7 @@ export interface MatchResult {
 }
 
 export function forEachMatch(matchResult: MatchResult, callback: (id: string, match: Match) => void): void {
-    for (const id in matchResult) {
-        if (matchResult.hasOwnProperty(id))
-            callback(id, matchResult[id]);
-    }
+    Object.keys(matchResult).forEach(id => callback(id, matchResult[id]));
 }
 
 export class ModelMatcher {

--- a/src/features/update/model-matching.ts
+++ b/src/features/update/model-matching.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2021 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/model-source/diagram-server.ts
+++ b/src/model-source/diagram-server.ts
@@ -29,6 +29,7 @@ import { RequestPopupModelAction } from "../features/hover/hover";
 import { OpenAction } from '../features/open/open';
 import { UpdateModelAction, UpdateModelCommand } from "../features/update/update-model";
 import { ILogger } from "../utils/logging";
+import { hasOwnProperty } from '../utils/object';
 import { ComputedBoundsApplicator, ModelSource } from "./model-source";
 
 /**
@@ -39,8 +40,8 @@ export interface ActionMessage {
     action: Action
 }
 
-export function isActionMessage(object: any): object is ActionMessage {
-    return object !== undefined && object.hasOwnProperty('action');
+export function isActionMessage(object: unknown): object is ActionMessage {
+    return hasOwnProperty(object, 'action');
 }
 
 /**

--- a/src/model-source/diagram-server.ts
+++ b/src/model-source/diagram-server.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2021 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/utils/inversify.ts
+++ b/src/utils/inversify.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 TypeFox and others.
+ * Copyright (c) 2019-2021 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 TypeFox and others.
+ * Copyright (c) 2017-2021 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,6 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export function isInjectable(constr: new (...args: unknown[]) => unknown): boolean {
-    return Reflect.getMetadata('inversify:paramtypes', constr) !== undefined;
+ export function isNotNullish(data: unknown): data is Record<PropertyKey, unknown> {
+    return data !== null && data !== undefined;
+}
+
+export function hasOwnProperty<K extends PropertyKey>(arg: unknown, key: K): arg is Record<K, unknown> {
+    return isNotNullish(arg) && Object.prototype.hasOwnProperty.call(arg, key);
+}
+
+export function safeAssign<T>(target: T, partial: Partial<T>): T {
+    return Object.assign(target, partial);
 }

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -14,12 +14,31 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
- export function isNotNullish(data: unknown): data is Record<PropertyKey, unknown> {
-    return data !== null && data !== undefined;
+ export function isObject(data: unknown): data is Record<PropertyKey, unknown> {
+    return typeof data === 'object' && data !== null;
 }
 
-export function hasOwnProperty<K extends PropertyKey>(arg: unknown, key: K): arg is Record<K, unknown> {
-    return isNotNullish(arg) && Object.prototype.hasOwnProperty.call(arg, key);
+export type TypeOf<T> =
+    T extends number ? 'number'
+    : T extends string ? 'string'
+    : T extends boolean ? 'boolean'
+    : T extends bigint ? 'bigint'
+    : T extends symbol ? 'symbol'
+    : T extends Function ? 'function'
+    : T extends object ? 'object'
+    : 'undefined';
+
+export function hasOwnProperty<K extends PropertyKey, T>(arg: unknown, key: K, type?: TypeOf<T> | ((v: unknown) => v is T)): arg is Record<K, T> {
+    if (!(isObject(arg) && Object.prototype.hasOwnProperty.call(arg, key))) {
+        return false;
+    }
+    if (typeof type === 'string') {
+        return typeof arg[key] === type;
+    }
+    if (typeof type === 'function') {
+        return type(arg[key]);
+    }
+    return true;
 }
 
 export function safeAssign<T>(target: T, partial: Partial<T>): T {


### PR DESCRIPTION
Eslint warns calling the hasOwnProperty method directly from object.
Where we can do without hasOwnProperty, I remove it, and use the own functions if needed.

Also, added type guard so that "as any" does not have to be used.