### PR TITLE
Zoomactions Merged & Typescript 4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "style-loader": "^1.0.0",
     "ts-loader": "^6.1.0",
     "ts-node": "^8.3.0",
-    "typescript": "3.8.3",
+    "typescript": "^4.3.2",
     "webpack": "^4.39.3",
     "webpack-cli": "^3.3.8"
   },

--- a/src/base/model/smodel.ts
+++ b/src/base/model/smodel.ts
@@ -187,8 +187,8 @@ export class SModelRoot extends SParentElement {
 
     constructor(index = new SModelIndex<SModelElement>()) {
         super();
-          // Override the index property from SModelElement, which has a getter, with a data property
-          Object.defineProperty(this, 'index', {
+        // Override the index property from SModelElement, which has a getter, with a data property
+        Object.defineProperty(this, 'index', {
             value: index,
             writable: false
         });

--- a/src/base/views/mouse-tool.ts
+++ b/src/base/views/mouse-tool.ts
@@ -27,11 +27,15 @@ import { Point } from "../../utils/geometry";
 
 @injectable()
 export class MouseTool implements IVNodePostprocessor {
-
     @inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher;
     @inject(TYPES.DOMHelper) protected domHelper: DOMHelper;
 
     constructor(@multiInject(TYPES.MouseListener) @optional() protected mouseListeners: MouseListener[] = []) { }
+
+    delay = (ms: number) => new Promise(res => {setTimeout(res, ms);});
+    delayed = false;
+    delayedWEvents: WheelEvent[] = [];
+    delayedWModels: SModelRoot[] = [];
 
     register(mouseListener: MouseListener) {
         this.mouseListeners.push(mouseListener);
@@ -79,6 +83,32 @@ export class MouseTool implements IVNodePostprocessor {
         }
     }
 
+    protected handleEvents<K extends keyof MouseListener>(methodName: K, models: SModelRoot[], events: MouseEvent[]){
+        let elements: (SModelElement | undefined)[] = [];
+        this.focusOnMouseEvent(methodName, models[0]);
+        for(let i = 0; i < events.length; i++){
+            elements.push(this.getTargetElement(models[i], events[i]));
+        }
+
+        if (elements.length > 0){
+            const actions = this.mouseListeners
+                    .map(listener => listener[methodName].apply(listener, [elements, events]))
+                    .reduce((a, b) => a.concat(b));
+            if (actions.length > 0) {
+                events[0].preventDefault();
+                for (const actionOrPromise of actions) {
+                    if (isAction(actionOrPromise)) {                            
+                        this.actionDispatcher.dispatch(actionOrPromise);
+                    } else {
+                        actionOrPromise.then((action: Action) => {
+                            this.actionDispatcher.dispatch(action);
+                        });
+                    }
+                }
+            }
+        }        
+    }
+
     protected focusOnMouseEvent<K extends keyof MouseListener>(methodName: K, model: SModelRoot) {
         if (document) {
             const domElement = document.getElementById(this.domHelper.createUniqueDOMElementId(model));
@@ -116,7 +146,23 @@ export class MouseTool implements IVNodePostprocessor {
     }
 
     wheel(model: SModelRoot, event: WheelEvent) {
-        this.handleEvent('wheel', model, event);
+        // add a leading trailing debounce
+        if(!this.delayed){
+            this.delayed = true;
+            this.handleEvent('wheel', model, event);
+            this.delay(5).then(() => {this.delayed = false;
+                                            if(this.delayedWEvents.length > 0){
+                                                this.handleEvents('wheels', this.delayedWModels, this.delayedWEvents as any);
+                                                this.delayedWEvents = [];
+                                                this.delayedWModels = [];
+            }});
+        }else{
+            // array of wheelEvents and corresponding models
+            this.delayedWEvents.push(event);
+            this.delayedWModels.push(model);
+        }
+
+        // this.handleEvent('wheel', model, event);
     }
 
     doubleClick(model: SModelRoot, event: MouseEvent) {
@@ -187,6 +233,10 @@ export class MouseListener {
     }
 
     wheel(target: SModelElement, event: WheelEvent): (Action | Promise<Action>)[] {
+        return [];
+    }
+
+    wheels(target: SModelElement[], events: WheelEvent[]): (Action | Promise<Action>)[]{
         return [];
     }
 

--- a/src/base/views/mouse-tool.ts
+++ b/src/base/views/mouse-tool.ts
@@ -27,15 +27,11 @@ import { Point } from "../../utils/geometry";
 
 @injectable()
 export class MouseTool implements IVNodePostprocessor {
+
     @inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher;
     @inject(TYPES.DOMHelper) protected domHelper: DOMHelper;
 
     constructor(@multiInject(TYPES.MouseListener) @optional() protected mouseListeners: MouseListener[] = []) { }
-
-    delay = (ms: number) => new Promise(res => {setTimeout(res, ms);});
-    delayed = false;
-    delayedWEvents: WheelEvent[] = [];
-    delayedWModels: SModelRoot[] = [];
 
     register(mouseListener: MouseListener) {
         this.mouseListeners.push(mouseListener);
@@ -83,32 +79,6 @@ export class MouseTool implements IVNodePostprocessor {
         }
     }
 
-    protected handleEvents<K extends keyof MouseListener>(methodName: K, models: SModelRoot[], events: MouseEvent[]){
-        let elements: (SModelElement | undefined)[] = [];
-        this.focusOnMouseEvent(methodName, models[0]);
-        for(let i = 0; i < events.length; i++){
-            elements.push(this.getTargetElement(models[i], events[i]));
-        }
-
-        if (elements.length > 0){
-            const actions = this.mouseListeners
-                    .map(listener => listener[methodName].apply(listener, [elements, events]))
-                    .reduce((a, b) => a.concat(b));
-            if (actions.length > 0) {
-                events[0].preventDefault();
-                for (const actionOrPromise of actions) {
-                    if (isAction(actionOrPromise)) {                            
-                        this.actionDispatcher.dispatch(actionOrPromise);
-                    } else {
-                        actionOrPromise.then((action: Action) => {
-                            this.actionDispatcher.dispatch(action);
-                        });
-                    }
-                }
-            }
-        }        
-    }
-
     protected focusOnMouseEvent<K extends keyof MouseListener>(methodName: K, model: SModelRoot) {
         if (document) {
             const domElement = document.getElementById(this.domHelper.createUniqueDOMElementId(model));
@@ -146,23 +116,7 @@ export class MouseTool implements IVNodePostprocessor {
     }
 
     wheel(model: SModelRoot, event: WheelEvent) {
-        // add a leading trailing debounce
-        if(!this.delayed){
-            this.delayed = true;
-            this.handleEvent('wheel', model, event);
-            this.delay(5).then(() => {this.delayed = false;
-                                            if(this.delayedWEvents.length > 0){
-                                                this.handleEvents('wheels', this.delayedWModels, this.delayedWEvents as any);
-                                                this.delayedWEvents = [];
-                                                this.delayedWModels = [];
-            }});
-        }else{
-            // array of wheelEvents and corresponding models
-            this.delayedWEvents.push(event);
-            this.delayedWModels.push(model);
-        }
-
-        // this.handleEvent('wheel', model, event);
+        this.handleEvent('wheel', model, event);
     }
 
     doubleClick(model: SModelRoot, event: MouseEvent) {
@@ -233,10 +187,6 @@ export class MouseListener {
     }
 
     wheel(target: SModelElement, event: WheelEvent): (Action | Promise<Action>)[] {
-        return [];
-    }
-
-    wheels(target: SModelElement[], events: WheelEvent[]): (Action | Promise<Action>)[]{
         return [];
     }
 

--- a/src/base/views/vnode-utils.ts
+++ b/src/base/views/vnode-utils.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Attrs } from "snabbdom/modules/attributes";
 import { VNode } from "snabbdom/vnode";
 import { SModelElement } from "../model/smodel";
 
@@ -57,7 +58,7 @@ export function copyClassesFromElement(element: HTMLElement, target: VNode) {
 }
 
 export function mergeStyle(vnode: VNode, style: any) {
-    getData(vnode).style = {...(getData(vnode).style || {}), ...style};
+    getData(vnode).style = { ...(getData(vnode).style || {}), ...style };
 }
 
 export function on(vnode: VNode, event: string, listener: (model: SModelElement, event: Event) => void, element: SModelElement) {
@@ -68,7 +69,7 @@ export function on(vnode: VNode, event: string, listener: (model: SModelElement,
     (val as any)[event] = [listener, element];
 }
 
-export function getAttrs(vnode: VNode) {
+export function getAttrs(vnode: VNode): Attrs {
     const data = getData(vnode);
     if (!data.attrs)
         data.attrs = {};

--- a/src/features/edge-layout/model.ts
+++ b/src/features/edge-layout/model.ts
@@ -30,7 +30,7 @@ export function isEdgeLayoutable<T extends SModelElement>(element: T): element i
         && element.parent instanceof SRoutableElement
         && checkEdgeLayoutable(element)
         && isBoundsAware(element)
-        && element.hasFeature(edgeLayoutFeature);
+        && (element as SChildElement).hasFeature(edgeLayoutFeature);
 }
 
 function checkEdgeLayoutable(element:SChildElement): element is SChildElement& EdgeLayoutable{

--- a/src/features/routing/model.ts
+++ b/src/features/routing/model.ts
@@ -74,7 +74,7 @@ export function getAbsoluteRouteBounds(model: Readonly<SRoutableElement>, route:
 }
 
 export function getRouteBounds(route: Point[]): Bounds {
-    const bounds = { x: NaN, y: NaN, width: 0, height: 0};
+    const bounds = { x: NaN, y: NaN, width: 0, height: 0 };
     for (const point of route) {
         if (isNaN(bounds.x)) {
             bounds.x = point.x;

--- a/src/features/viewport/zoom.ts
+++ b/src/features/viewport/zoom.ts
@@ -61,6 +61,37 @@ export class ZoomMouseListener extends MouseListener {
         return [];
     }
 
+    wheels(targets: SModelElement[], events: WheelEvent[]): Action[] {
+        let vpx, vpy, vpz, newZoom, offsetFactor, i = 0;
+        let viewport;
+        let viewportOffset;
+        do {
+            viewport = findParentByFeature(targets[i], isViewport);
+            i++;
+        } while (!viewport && i < events.length);
+        if (!viewport) return [];
+        vpx = viewport.scroll.x;
+        vpy = viewport.scroll.y;
+        vpz = viewport.zoom;
+        for (i = 0; i < events.length; i++) {
+            newZoom = this.getZoomFactor(events[i]);
+            viewportOffset = this.getViewportOffset(targets[i].root, events[i]);
+            offsetFactor = 1.0 / (newZoom * vpz) - 1.0 / vpz;
+            vpx = vpx - offsetFactor * viewportOffset.x;
+            vpy = vpy - offsetFactor * viewportOffset.y;
+            vpz = vpz * newZoom;
+        }
+        const newViewport: Viewport = {
+            scroll: {
+                x: vpx,
+                y: vpy
+            },
+            zoom: vpz
+        };
+
+        return [new SetViewportAction(viewport.id, newViewport, false)];
+    }
+
     protected getViewportOffset(root: SModelRoot, event: WheelEvent): Point {
         const canvasBounds = root.canvasBounds;
         const windowScroll = getWindowScroll();

--- a/src/features/viewport/zoom.ts
+++ b/src/features/viewport/zoom.ts
@@ -61,37 +61,6 @@ export class ZoomMouseListener extends MouseListener {
         return [];
     }
 
-    wheels(targets: SModelElement[], events: WheelEvent[]):Action[] {
-        let vpx,vpy,vpz,newZoom,offsetFactor, i = 0;
-        let viewport;
-        let viewportOffset;
-        do{
-            viewport = findParentByFeature(targets[i], isViewport);
-            i++;
-        }while(!viewport && i < events.length);
-        if(!viewport)return[];
-        vpx = viewport.scroll.x;
-        vpy = viewport.scroll.y;
-        vpz = viewport.zoom;
-        for (i = 0; i < events.length; i++){
-            newZoom = this.getZoomFactor(events[i]);
-            viewportOffset = this.getViewportOffset(targets[i].root,events[i]);
-            offsetFactor =  1.0 / (newZoom * vpz) - 1.0 / vpz;
-            vpx = vpx - offsetFactor * viewportOffset.x;
-            vpy = vpy - offsetFactor * viewportOffset.y;
-            vpz = vpz * newZoom;            
-        }
-        const newViewport: Viewport = {
-            scroll: {
-                x: vpx,
-                y: vpy
-            },
-            zoom: vpz
-        };
-
-        return [new SetViewportAction(viewport.id, newViewport, false)];
-    }
-
     protected getViewportOffset(root: SModelRoot, event: WheelEvent): Point {
         const canvasBounds = root.canvasBounds;
         const windowScroll = getWindowScroll();

--- a/src/features/viewport/zoom.ts
+++ b/src/features/viewport/zoom.ts
@@ -61,6 +61,37 @@ export class ZoomMouseListener extends MouseListener {
         return [];
     }
 
+    wheels(targets: SModelElement[], events: WheelEvent[]):Action[] {
+        let vpx,vpy,vpz,newZoom,offsetFactor, i = 0;
+        let viewport;
+        let viewportOffset;
+        do{
+            viewport = findParentByFeature(targets[i], isViewport);
+            i++;
+        }while(!viewport && i < events.length);
+        if(!viewport)return[];
+        vpx = viewport.scroll.x;
+        vpy = viewport.scroll.y;
+        vpz = viewport.zoom;
+        for (i = 0; i < events.length; i++){
+            newZoom = this.getZoomFactor(events[i]);
+            viewportOffset = this.getViewportOffset(targets[i].root,events[i]);
+            offsetFactor =  1.0 / (newZoom * vpz) - 1.0 / vpz;
+            vpx = vpx - offsetFactor * viewportOffset.x;
+            vpy = vpy - offsetFactor * viewportOffset.y;
+            vpz = vpz * newZoom;            
+        }
+        const newViewport: Viewport = {
+            scroll: {
+                x: vpx,
+                y: vpy
+            },
+            zoom: vpz
+        };
+
+        return [new SetViewportAction(viewport.id, newViewport, false)];
+    }
+
     protected getViewportOffset(root: SModelRoot, event: WheelEvent): Point {
         const canvasBounds = root.canvasBounds;
         const windowScroll = getWindowScroll();

--- a/src/graph/sgraph.ts
+++ b/src/graph/sgraph.ts
@@ -15,8 +15,10 @@
  ********************************************************************************/
 
 import { SChildElement, SModelElement, SModelElementSchema, SModelIndex, SModelRootSchema } from '../base/model/smodel';
-import { Alignable, alignFeature, BoundsAware, boundsFeature, layoutableChildFeature, layoutContainerFeature,
-    ModelLayoutOptions, SShapeElement, SShapeElementSchema } from '../features/bounds/model';
+import {
+    Alignable, alignFeature, BoundsAware, boundsFeature, layoutableChildFeature, layoutContainerFeature,
+    ModelLayoutOptions, SShapeElement, SShapeElementSchema
+} from '../features/bounds/model';
 import { edgeLayoutFeature, EdgePlacement } from '../features/edge-layout/model';
 import { deletableFeature } from '../features/edit/delete';
 import { editFeature } from '../features/edit/model';
@@ -174,7 +176,7 @@ export class SCompartment extends SShapeElement implements Fadeable {
 
     children: SChildElement[];
     layout?: string;
-    layoutOptions?: {[key: string]: string | number | boolean};
+    layoutOptions?: { [key: string]: string | number | boolean };
     opacity = 1;
 
 }

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -26,7 +26,7 @@ import { RECTANGULAR_ANCHOR_KIND, DIAMOND_ANCHOR_KIND, ELLIPTIC_ANCHOR_KIND } fr
  * A node that is represented by a circle.
  */
 export class CircularNode extends SNode {
-    get anchorKind() {
+    get anchorKind(): string | undefined {
         return ELLIPTIC_ANCHOR_KIND;
     }
 }
@@ -35,7 +35,7 @@ export class CircularNode extends SNode {
  * A node that is represented by a rectangle.
  */
 export class RectangularNode extends SNode {
-    get anchorKind() {
+    get anchorKind(): string | undefined {
         return RECTANGULAR_ANCHOR_KIND;
     }
 }
@@ -44,7 +44,7 @@ export class RectangularNode extends SNode {
  * A node that is represented by a diamond.
  */
 export class DiamondNode extends SNode {
-    get anchorKind() {
+    get anchorKind(): string | undefined {
         return DIAMOND_ANCHOR_KIND;
     }
 }
@@ -53,7 +53,7 @@ export class DiamondNode extends SNode {
  * A port that is represented by a circle.
  */
 export class CircularPort extends SPort {
-    get anchorKind() {
+    get anchorKind(): string | undefined {
         return ELLIPTIC_ANCHOR_KIND;
     }
 }
@@ -62,7 +62,7 @@ export class CircularPort extends SPort {
  * A port that is represented by a rectangle.
  */
 export class RectangularPort extends SPort {
-    get anchorKind() {
+    get anchorKind(): string | undefined {
         return RECTANGULAR_ANCHOR_KIND;
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5183,10 +5183,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@^4.3.2:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 uglify-js@^3.1.4:
   version "3.13.5"


### PR DESCRIPTION
Hy i have made some addition in the MouseTool aswell as the Zoom MouseListener. The Idea was to execute one zoom action then wait 5ms afterwards with the next zoom action so pend up wheel events may be stored in a array. Then the entire array will be used as one zoom action resulting in an overall improved performance (see #25). Also i changed the typescript version to 4.3 and changed all necessary things (hopefully). 