### PR TITLE
Implemented projection on horizontal and vertical bars

### DIFF
--- a/css/sprotty.css
+++ b/css/sprotty.css
@@ -19,6 +19,10 @@
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
+.sprotty-root {
+    position: relative;
+}
+
 .sprotty-hidden {
     display: block;
     position: absolute;
@@ -42,4 +46,40 @@
 
 .sprotty-popup-closed {
     display: none;
+}
+
+.sprotty-projection-bar.horizontal {
+    position: absolute;
+    width: 100%;
+    height: 20px;
+    left: 0;
+    bottom: 0;
+}
+
+.sprotty-projection-bar.vertical {
+    position: absolute;
+    width: 20px;
+    height: 100%;
+    right: 0;
+    top: 0;
+}
+
+.sprotty-viewport {
+    z-index: 1;
+    border-style: solid;
+    border-width: 2px;
+}
+
+.sprotty-projection-bar.horizontal .sprotty-projection,
+.sprotty-projection-bar.horizontal .sprotty-viewport {
+    position: absolute;
+    height: 100%;
+    top: 0;
+}
+
+.sprotty-projection-bar.vertical .sprotty-projection,
+.sprotty-projection-bar.vertical .sprotty-viewport {
+    position: absolute;
+    width: 100%;
+    left: 0;
 }

--- a/examples/svg/css/diagram.css
+++ b/examples/svg/css/diagram.css
@@ -36,3 +36,15 @@
 .foreign-object {
     user-select: none;
 }
+
+.logo-projection {
+    background-color: rgba(255, 153, 0, 0.5);
+}
+
+.tiger-projection {
+    background-color: rgba(204, 114, 38, 0.5);
+}
+
+.node-projection {
+    background-color: rgba(255, 140, 0, 0.2);
+}

--- a/examples/svg/css/page.css
+++ b/examples/svg/css/page.css
@@ -28,11 +28,20 @@
     color: #888;
 }
 
-svg {
+.sprotty {
     margin-top: 15px;
+}
+
+svg {
     width: 100%;
-    height: 500px;
-    border-style: solid;
-    border-width: 1px;
-    border-color: #bbb;
+    height: 650px;
+    border: 1px solid #bbb;
+}
+
+.sprotty-projection-bar {
+    background-color: rgba(205, 224, 241, 0.5);
+}
+
+.sprotty-viewport {
+    border-color: rgba(105, 162, 210, 0.8);
 }

--- a/examples/svg/src/di.config.ts
+++ b/examples/svg/src/di.config.ts
@@ -20,8 +20,7 @@ import {
     ProjectedViewportView, ViewportRootElement, ShapedPreRenderedElement, configureModelElement,
     ForeignObjectElement, ForeignObjectView, RectangularNode, RectangularNodeView, moveFeature,
     selectFeature, EditableLabel, editLabelFeature, WithEditableLabel, withEditLabelFeature,
-    isEditableLabel, Action, MoveAction, SShapeElementSchema, ViewportRootElementSchema,
-    ActionHandlerRegistry, SetBoundsAction
+    isEditableLabel
 } from '../../../src';
 
 export default () => {
@@ -32,7 +31,7 @@ export default () => {
     const svgModule = new ContainerModule((bind, unbind, isBound, rebind) => {
         rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
         rebind(TYPES.LogLevel).toConstantValue(LogLevel.log);
-        bind(TYPES.ModelSource).to(SVGModelSource).inSingletonScope();
+        bind(TYPES.ModelSource).to(LocalModelSource).inSingletonScope();
         const context = { bind, unbind, isBound, rebind };
         configureModelElement(context, 'svg', ViewportRootElement, ProjectedViewportView);
         configureModelElement(context, 'pre-rendered', ShapedPreRenderedElement, PreRenderedView);
@@ -51,61 +50,6 @@ export default () => {
     container.load(svgModule);
     return container;
 };
-
-export class SVGModelSource extends LocalModelSource {
-    initialize(registry: ActionHandlerRegistry): void {
-        super.initialize(registry);
-        registry.register(MoveAction.KIND, this);
-    }
-    
-    updateModelBounds(): Promise<void> {
-        let minX = 10000;
-        let minY = 10000;
-        let maxX = -10000;
-        let maxY = -10000;
-        for (const element of this.currentRoot.children!) {
-            const position = (element as SShapeElementSchema).position;
-            const size = (element as SShapeElementSchema).size;
-            if (position && size) {
-                minX = Math.min(minX, position.x);
-                minY = Math.min(minY, position.y);
-                maxX = Math.max(maxX, position.x + size.width);
-                maxY = Math.max(maxY, position.y + size.height);
-            }
-        }
-        if (minX < maxX && minY < maxY) {
-            const viewportRoot = this.currentRoot as ViewportRootElementSchema;
-            viewportRoot.position = { x: minX, y: minY };
-            viewportRoot.size = { width: maxX - minX, height: maxY - minY };
-            return this.actionDispatcher.dispatch(new SetBoundsAction([{
-                elementId: viewportRoot.id,
-                newPosition: viewportRoot.position,
-                newSize: viewportRoot.size
-            }]));
-        }
-        return Promise.resolve();
-    }
-
-    handle(action: Action): void {
-        switch (action.kind) {
-            case MoveAction.KIND:
-                this.handleMove(action as MoveAction);
-                break;
-            default:
-                super.handle(action);
-        }
-    }
-
-    protected handleMove(action: MoveAction): void {
-        for (const move of action.moves) {
-            const element = this.currentRoot.children?.find(c => c.id === move.elementId);
-            if (element) {
-                (element as SShapeElementSchema).position = move.toPosition;
-            }
-        }
-        this.updateModelBounds();
-    }
-}
 
 export class RectangleWithEditableLabel extends RectangularNode implements WithEditableLabel {
     get editableLabel() {

--- a/examples/svg/src/di.config.ts
+++ b/examples/svg/src/di.config.ts
@@ -14,28 +14,37 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Container, ContainerModule } from "inversify";
+import { Container, ContainerModule } from 'inversify';
 import {
     TYPES, ConsoleLogger, LogLevel, loadDefaultModules, LocalModelSource, PreRenderedView,
-    SvgViewportView, ViewportRootElement, ShapedPreRenderedElement, configureModelElement,
+    ProjectedViewportView, ViewportRootElement, ShapedPreRenderedElement, configureModelElement,
     ForeignObjectElement, ForeignObjectView, RectangularNode, RectangularNodeView, moveFeature,
-    selectFeature, EditableLabel, editLabelFeature, WithEditableLabel, withEditLabelFeature, isEditableLabel
-} from "../../../src";
+    selectFeature, EditableLabel, editLabelFeature, WithEditableLabel, withEditLabelFeature,
+    isEditableLabel, setProjection, Action, MoveAction, SShapeElementSchema, ViewportRootElementSchema, ActionHandlerRegistry, SetBoundsAction
+} from '../../../src';
 
 export default () => {
-    require("../../../css/sprotty.css");
-    require("../css/diagram.css");
-    require("../../../css/edit-label.css");
+    require('../../../css/sprotty.css');
+    require('../../../css/edit-label.css');
+    require('../css/diagram.css');
 
     const svgModule = new ContainerModule((bind, unbind, isBound, rebind) => {
         rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
         rebind(TYPES.LogLevel).toConstantValue(LogLevel.log);
-        bind(TYPES.ModelSource).to(LocalModelSource).inSingletonScope();
+        bind(TYPES.ModelSource).to(SVGModelSource).inSingletonScope();
         const context = { bind, unbind, isBound, rebind };
-        configureModelElement(context, 'svg', ViewportRootElement, SvgViewportView);
-        configureModelElement(context, 'pre-rendered', ShapedPreRenderedElement, PreRenderedView);
+        configureModelElement(context, 'svg', ViewportRootElement, ProjectedViewportView);
+        configureModelElement(context, 'pre-logo', ShapedPreRenderedElement, PreRenderedView, {
+            viewInit: setProjection('rgba(255, 153, 0, 0.5)')
+        });
+        configureModelElement(context, 'pre-tiger', ShapedPreRenderedElement, PreRenderedView, {
+            viewInit: setProjection('rgba(204, 114, 38, 0.5)')
+        });
         configureModelElement(context, 'foreign-object', ForeignObjectElement, ForeignObjectView);
-        configureModelElement(context, 'node', RectangleWithEditableLabel, RectangularNodeView, { enable: [withEditLabelFeature] });
+        configureModelElement(context, 'node', RectangleWithEditableLabel, RectangularNodeView, {
+            enable: [withEditLabelFeature],
+            viewInit: setProjection('rgba(255, 140, 0, 0.2)')
+        });
         configureModelElement(context, 'child-foreign-object', EditableForeignObjectElement, ForeignObjectView, {
             disable: [moveFeature, selectFeature], // disable move/select as we want the parent node to react to select/move
             enable: [editLabelFeature] // enable editing -- see also EditableForeignObjectElement below
@@ -47,6 +56,61 @@ export default () => {
     container.load(svgModule);
     return container;
 };
+
+export class SVGModelSource extends LocalModelSource {
+    initialize(registry: ActionHandlerRegistry): void {
+        super.initialize(registry);
+        registry.register(MoveAction.KIND, this);
+    }
+    
+    updateModelBounds(): Promise<void> {
+        let minX = 10000;
+        let minY = 10000;
+        let maxX = -10000;
+        let maxY = -10000;
+        for (const element of this.currentRoot.children!) {
+            const position = (element as SShapeElementSchema).position;
+            const size = (element as SShapeElementSchema).size;
+            if (position && size) {
+                minX = Math.min(minX, position.x);
+                minY = Math.min(minY, position.y);
+                maxX = Math.max(maxX, position.x + size.width);
+                maxY = Math.max(maxY, position.y + size.height);
+            }
+        }
+        if (minX < maxX && minY < maxY) {
+            const viewportRoot = this.currentRoot as ViewportRootElementSchema;
+            viewportRoot.position = { x: minX, y: minY };
+            viewportRoot.size = { width: maxX - minX, height: maxY - minY };
+            return this.actionDispatcher.dispatch(new SetBoundsAction([{
+                elementId: viewportRoot.id,
+                newPosition: viewportRoot.position,
+                newSize: viewportRoot.size
+            }]));
+        }
+        return Promise.resolve();
+    }
+
+    handle(action: Action): void {
+        switch (action.kind) {
+            case MoveAction.KIND:
+                this.handleMove(action as MoveAction);
+                break;
+            default:
+                super.handle(action);
+        }
+    }
+
+    protected handleMove(action: MoveAction): void {
+        for (const move of action.moves) {
+            const element = this.currentRoot.children?.find(c => c.id === move.elementId);
+            if (element) {
+                (element as SShapeElementSchema).position = move.toPosition;
+            }
+        }
+        this.updateModelBounds();
+    }
+}
 
 export class RectangleWithEditableLabel extends RectangularNode implements WithEditableLabel {
     get editableLabel() {

--- a/examples/svg/src/di.config.ts
+++ b/examples/svg/src/di.config.ts
@@ -20,7 +20,8 @@ import {
     ProjectedViewportView, ViewportRootElement, ShapedPreRenderedElement, configureModelElement,
     ForeignObjectElement, ForeignObjectView, RectangularNode, RectangularNodeView, moveFeature,
     selectFeature, EditableLabel, editLabelFeature, WithEditableLabel, withEditLabelFeature,
-    isEditableLabel, setProjection, Action, MoveAction, SShapeElementSchema, ViewportRootElementSchema, ActionHandlerRegistry, SetBoundsAction
+    isEditableLabel, Action, MoveAction, SShapeElementSchema, ViewportRootElementSchema,
+    ActionHandlerRegistry, SetBoundsAction
 } from '../../../src';
 
 export default () => {
@@ -34,16 +35,10 @@ export default () => {
         bind(TYPES.ModelSource).to(SVGModelSource).inSingletonScope();
         const context = { bind, unbind, isBound, rebind };
         configureModelElement(context, 'svg', ViewportRootElement, ProjectedViewportView);
-        configureModelElement(context, 'pre-logo', ShapedPreRenderedElement, PreRenderedView, {
-            viewInit: setProjection('rgba(255, 153, 0, 0.5)')
-        });
-        configureModelElement(context, 'pre-tiger', ShapedPreRenderedElement, PreRenderedView, {
-            viewInit: setProjection('rgba(204, 114, 38, 0.5)')
-        });
+        configureModelElement(context, 'pre-rendered', ShapedPreRenderedElement, PreRenderedView);
         configureModelElement(context, 'foreign-object', ForeignObjectElement, ForeignObjectView);
         configureModelElement(context, 'node', RectangleWithEditableLabel, RectangularNodeView, {
-            enable: [withEditLabelFeature],
-            viewInit: setProjection('rgba(255, 140, 0, 0.2)')
+            enable: [withEditLabelFeature]
         });
         configureModelElement(context, 'child-foreign-object', EditableForeignObjectElement, ForeignObjectView, {
             disable: [moveFeature, selectFeature], // disable move/select as we want the parent node to react to select/move

--- a/examples/svg/src/standalone.ts
+++ b/examples/svg/src/standalone.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import {
-    TYPES, ShapedPreRenderedElementSchema, ForeignObjectElementSchema, SShapeElementSchema, ViewportRootElementSchema
+    TYPES, ShapedPreRenderedElementSchema, ForeignObjectElementSchema, SShapeElementSchema, ViewportRootElementSchema, Projectable
 } from '../../../src';
 import createContainer, { SVGModelSource } from './di.config';
 
@@ -44,17 +44,19 @@ export default async function runSVG() {
         id: 'root',
         children: [
             {
-                type: 'pre-logo',
+                type: 'pre-rendered',
                 id: 'logo',
                 position: { x: 200, y: 200 },
-                code: svgLogo
-            } as ShapedPreRenderedElementSchema,
+                code: svgLogo,
+                projectionCssClasses: ['logo-projection']
+            } as ShapedPreRenderedElementSchema & Projectable,
             {
-                type: 'pre-tiger',
+                type: 'pre-rendered',
                 id: 'tiger',
                 position: { x: 400, y: 50 },
-                code: tiger
-            } as ShapedPreRenderedElementSchema,
+                code: tiger,
+                projectionCssClasses: ['tiger-projection']
+            } as ShapedPreRenderedElementSchema & Projectable,
             {
                 type: 'foreign-object',
                 id: 'direct-html',
@@ -79,8 +81,9 @@ export default async function runSVG() {
                         id: 'foreign-object-in-shape-contents',
                         code: '<div>This is <em>HTML</em> within <u>an SVG rectangle</u>!</div>'
                     } as ForeignObjectElementSchema
-                ]
-            } as SShapeElementSchema
+                ],
+                projectionCssClasses: ['node-projection']
+            } as SShapeElementSchema & Projectable
         ]
     };
 

--- a/examples/svg/src/standalone.ts
+++ b/examples/svg/src/standalone.ts
@@ -15,9 +15,10 @@
  ********************************************************************************/
 
 import {
-    TYPES, ShapedPreRenderedElementSchema, ForeignObjectElementSchema, SShapeElementSchema, ViewportRootElementSchema, Projectable
+    TYPES, ShapedPreRenderedElementSchema, ForeignObjectElementSchema, SShapeElementSchema, ViewportRootElementSchema,
+    Projectable, LocalModelSource
 } from '../../../src';
-import createContainer, { SVGModelSource } from './di.config';
+import createContainer from './di.config';
 
 function loadFile(path: string): Promise<string> {
     return new Promise<string>((resolve, reject) => {
@@ -88,7 +89,6 @@ export default async function runSVG() {
     };
 
     // Run
-    const modelSource = container.get<SVGModelSource>(TYPES.ModelSource);
+    const modelSource = container.get<LocalModelSource>(TYPES.ModelSource);
     await modelSource.setModel(model);
-    await modelSource.updateModelBounds();
 }

--- a/src/base/actions/action-handler.ts
+++ b/src/base/actions/action-handler.ts
@@ -85,3 +85,14 @@ export function configureActionHandler(context: { bind: interfaces.Bind, isBound
         factory: () => ctx.container.get(constr)
     }));
 }
+
+/**
+ * Utility function to register an action handler for an action kind.
+ */
+export function onAction(context: { bind: interfaces.Bind, isBound: interfaces.IsBound },
+        kind: string, handle: (action: Action) => ICommand | Action | void): void {
+    context.bind(TYPES.ActionHandlerRegistration).toConstantValue({
+        actionKind: kind,
+        factory: () => ({ handle })
+    });
+}

--- a/src/base/views/mouse-tool.ts
+++ b/src/base/views/mouse-tool.ts
@@ -57,13 +57,13 @@ export class MouseTool implements IVNodePostprocessor {
         return undefined;
     }
 
-    protected handleEvent<K extends keyof MouseListener>(methodName: K, model: SModelRoot, event: MouseEvent) {
+    protected handleEvent(methodName: MouseEventKind, model: SModelRoot, event: MouseEvent) {
         this.focusOnMouseEvent(methodName, model);
         const element = this.getTargetElement(model, event);
         if (!element)
             return;
         const actions = this.mouseListeners
-            .map(listener => listener[methodName].apply(listener, [element, event]))
+            .map(listener => listener[methodName](element, event as WheelEvent))
             .reduce((a, b) => a.concat(b));
         if (actions.length > 0) {
             event.preventDefault();
@@ -154,6 +154,8 @@ export class PopupMouseTool extends MouseTool {
         super(mouseListeners);
     }
 }
+
+export type MouseEventKind = 'mouseOver' | 'mouseOut' | 'mouseEnter' | 'mouseLeave' | 'mouseDown' | 'mouseMove' | 'mouseUp' | 'wheel' | 'doubleClick';
 
 @injectable()
 export class MouseListener {

--- a/src/base/views/view.tsx
+++ b/src/base/views/view.tsx
@@ -17,14 +17,14 @@
 /** @jsx svg */
 import { svg } from '../../lib/jsx';
 
-import { injectable, multiInject, optional, interfaces } from "inversify";
-import { VNode } from "snabbdom";
-import { TYPES } from "../types";
-import { InstanceRegistry } from "../../utils/registry";
-import { Point, ORIGIN_POINT } from "../../utils/geometry";
+import { injectable, multiInject, optional, interfaces } from 'inversify';
+import { VNode } from 'snabbdom';
+import { TYPES } from '../types';
+import { InstanceRegistry } from '../../utils/registry';
+import { Point, ORIGIN_POINT, Bounds } from '../../utils/geometry';
 import { isInjectable } from '../../utils/inversify';
-import { SModelElement, SModelRoot, SParentElement } from "../model/smodel";
-import { EMPTY_ROOT, CustomFeatures } from "../model/smodel-factory";
+import { SModelElement, SModelRoot, SParentElement } from '../model/smodel';
+import { EMPTY_ROOT, CustomFeatures } from '../model/smodel-factory';
 import { registerModelElement } from '../model/smodel-utils';
 
 /**
@@ -54,10 +54,27 @@ export function findArgValue<T>(arg: IViewArgs | undefined, key: string): T | un
  * Base interface for the components that turn GModelElements into virtual DOM elements.
  */
 export interface IView<A extends IViewArgs = {}> {
+
     render(model: Readonly<SModelElement>, context: RenderingContext, args?: A): VNode | undefined
+
+    getProjection?(model: Readonly<SModelElement>, context: RenderingContext, args?: A): ViewProjection | undefined
+
 }
 
+/**
+ * Indicates the target of the view rendering. `main` is the actually visible diagram,
+ * `popup` is the mouse hover popup, and `hidden` is for computing element bounds prior
+ * to the main rendering.
+ */
 export type RenderingTargetKind = 'main' | 'popup' | 'hidden';
+
+/**
+ * A projection can be shown in a horizontal or vertical bar to display an overview of the diagram.
+ */
+export interface ViewProjection {
+    projectedBounds: Bounds;
+    color: string;
+}
 
 /**
  * Bundles additional data that is passed to views for VNode creation.
@@ -72,6 +89,8 @@ export interface RenderingContext {
     renderElement(element: Readonly<SModelElement>): VNode | undefined
 
     renderChildren(element: Readonly<SParentElement>, args?: IViewArgs): VNode[]
+
+    getProjections(element: Readonly<SParentElement>): ViewProjection[] | undefined
 }
 
 /**
@@ -109,18 +128,20 @@ export class ViewRegistry extends InstanceRegistry<IView> {
 /**
  * Combines `registerModelElement` and `configureView`.
  */
-export function configureModelElement(context: { bind: interfaces.Bind, isBound: interfaces.IsBound },
-        type: string, modelConstr: new () => SModelElement, viewConstr: interfaces.ServiceIdentifier<IView>,
-        features?: CustomFeatures): void {
-    registerModelElement(context, type, modelConstr, features);
-    configureView(context, type, viewConstr);
+export function configureModelElement<E extends SModelElement, V extends IView>(context: { bind: interfaces.Bind, isBound: interfaces.IsBound },
+        type: string, modelConstr: new () => E, viewConstr: interfaces.ServiceIdentifier<V>,
+        options?: ModelElementOptions<E, V>): void {
+    registerModelElement(context, type, modelConstr, options);
+    configureView(context, type, viewConstr, options);
 }
+
+export type ModelElementOptions<E extends SModelElement, V extends IView> = CustomFeatures & ViewOptions<V>;
 
 /**
  * Utility function to register a view for a model element type.
  */
-export function configureView(context: { bind: interfaces.Bind, isBound: interfaces.IsBound },
-        type: string, constr: interfaces.ServiceIdentifier<IView>): void {
+export function configureView<V extends IView>(context: { bind: interfaces.Bind, isBound: interfaces.IsBound },
+        type: string, constr: interfaces.ServiceIdentifier<V>, options?: ViewOptions<V>): void {
     if (typeof constr === 'function') {
         if (!isInjectable(constr)) {
             throw new Error(`Views should be @injectable: ${constr.name}`);
@@ -129,10 +150,18 @@ export function configureView(context: { bind: interfaces.Bind, isBound: interfa
             context.bind(constr).toSelf();
         }
     }
-    context.bind(TYPES.ViewRegistration).toDynamicValue(ctx => ({
-        type,
-        factory: () => ctx.container.get(constr)
-    }));
+    context.bind(TYPES.ViewRegistration).toDynamicValue(ctx => {
+        const factory = options && options.viewInit ? () => {
+            const view = ctx.container.get(constr);
+            options.viewInit!(view);
+            return view;
+        } : () => ctx.container.get(constr);
+        return { type, factory };
+    });
+}
+
+export interface ViewOptions<V> {
+    viewInit?: (view: V) => void
 }
 
 /**

--- a/src/base/views/viewer.tsx
+++ b/src/base/views/viewer.tsx
@@ -27,7 +27,7 @@ import { SModelElement, SModelRoot, SParentElement } from '../model/smodel';
 import { EMPTY_ROOT } from '../model/smodel-factory';
 import { TYPES } from '../types';
 import { isThunk } from './thunk-view';
-import { IViewArgs, RenderingContext, RenderingTargetKind, ViewProjection, ViewRegistry } from './view';
+import { IViewArgs, RenderingContext, RenderingTargetKind, ViewRegistry } from './view';
 import { ViewerOptions } from './viewer-options';
 import { IVNodePostprocessor } from './vnode-postprocessor';
 import { copyClassesFromElement, copyClassesFromVNode, setAttr, setClass } from './vnode-utils';
@@ -81,34 +81,6 @@ export class ModelRenderer implements RenderingContext {
         return element.children
             .map(child => context.renderElement(child))
             .filter(vnode => vnode !== undefined) as VNode[];
-    }
-
-    getProjections(element: Readonly<SParentElement>): ViewProjection[] | undefined {
-        let result: ViewProjection[] | undefined;
-        for (const child of element.children) {
-            const view = this.viewRegistry.get(child.type);
-            if (view.getProjection) {
-                const p = view.getProjection(child, this);
-                if (p) {
-                    if (result) {
-                        result.push(p);
-                    } else {
-                        result = [p];
-                    }
-                }
-            }
-            if (child.children.length > 0) {
-                const childProj = this.getProjections(child);
-                if (childProj) {
-                    if (result) {
-                        result.push(...childProj);
-                    } else {
-                        result = childProj;
-                    }
-                }
-            }
-        }
-        return result;
     }
 
     postUpdate(cause?: Action) {

--- a/src/features/bounds/views.ts
+++ b/src/features/bounds/views.ts
@@ -16,18 +16,13 @@
 
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
-import { Bounds, isValidDimension } from '../../utils/geometry';
-import { IViewArgs, IView, RenderingContext, ViewProjection } from '../../base/views/view';
-import { getAbsoluteBounds, BoundsAware, isBoundsAware } from './model';
+import { isValidDimension } from '../../utils/geometry';
+import { IViewArgs, IView, RenderingContext } from '../../base/views/view';
+import { getAbsoluteBounds, BoundsAware } from './model';
 import { SChildElement } from '../../base/model/smodel';
 
 @injectable()
 export abstract class ShapeView implements IView {
-
-    /**
-     * Set this property to enable a projection for this view instance.
-     */
-    projectionColor?: string;
 
     /**
      * Check whether the given model element is in the current viewport. Use this method
@@ -52,25 +47,5 @@ export abstract class ShapeView implements IView {
     }
 
     abstract render(model: Readonly<SChildElement>, context: RenderingContext, args?: IViewArgs): VNode | undefined;
-
-    getProjection(model: Readonly<SChildElement>, context: RenderingContext, args?: IViewArgs): ViewProjection | undefined {
-        if (!this.projectionColor || !isBoundsAware(model)) {
-            return undefined;
-        }
-        return {
-            projectedBounds: this.getProjectedBounds(model),
-            color: this.projectionColor
-        };
-    }
-
-    protected getProjectedBounds(model: Readonly<SChildElement & BoundsAware>): Bounds {
-        let bounds = model.bounds;
-        let parent = model.parent;
-        while (parent instanceof SChildElement) {
-            bounds = parent.localToParent(bounds);
-            parent = parent.parent;
-        }
-        return bounds;
-    }
 
 }

--- a/src/features/move/move.ts
+++ b/src/features/move/move.ts
@@ -43,7 +43,8 @@ import { isLocateable, isMoveable, Locateable } from './model';
 import { ISnapper } from "./snap";
 
 export class MoveAction implements Action {
-    kind = MoveCommand.KIND;
+    static readonly KIND = 'move';
+    kind = MoveAction.KIND;
 
     constructor(public readonly moves: ElementMove[],
                 public readonly animate: boolean = true,
@@ -71,7 +72,7 @@ export interface ResolvedHandleMove {
 
 @injectable()
 export class MoveCommand extends MergeableCommand {
-    static readonly KIND = 'move';
+    static readonly KIND = MoveAction.KIND;
 
     @inject(EdgeRouterRegistry) @optional() edgeRouterRegistry?: EdgeRouterRegistry;
 

--- a/src/features/projection/model.ts
+++ b/src/features/projection/model.ts
@@ -37,6 +37,7 @@ export function isProjectable(arg: unknown): arg is Projectable {
  * A projection can be shown in a horizontal or vertical bar to display an overview of the diagram.
  */
 export interface ViewProjection {
+    elementId: string;
     projectedBounds: Bounds;
     cssClasses: string[];
 }
@@ -49,6 +50,7 @@ export function getProjections(parent: Readonly<SParentElement>): ViewProjection
     for (const child of parent.children) {
         if (isProjectable(child) && isBoundsAware(child) && child.projectionCssClasses.length > 0) {
             const projection: ViewProjection = {
+                elementId: child.id,
                 projectedBounds: getProjectedBounds(child),
                 cssClasses: child.projectionCssClasses
             };

--- a/src/features/projection/model.ts
+++ b/src/features/projection/model.ts
@@ -1,0 +1,85 @@
+/********************************************************************************
+ * Copyright (c) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { SChildElement, SParentElement } from '../../base/model/smodel';
+import { SModelExtension } from '../../base/model/smodel-extension';
+import { Bounds } from '../../utils/geometry';
+import { hasOwnProperty } from '../../utils/object';
+import { BoundsAware, isBoundsAware } from '../bounds/model';
+
+/**
+ * Model elements implementing this interface can be displayed on a projection bar.
+ * _Note:_ Model elements also have to be `BoundsAware` so their projections can be shown.
+ */
+export interface Projectable extends SModelExtension {
+    projectionCssClasses: string[]
+}
+
+export function isProjectable(arg: unknown): arg is Projectable {
+    return hasOwnProperty(arg, 'projectionCssClasses');
+}
+
+/**
+ * A projection can be shown in a horizontal or vertical bar to display an overview of the diagram.
+ */
+export interface ViewProjection {
+    projectedBounds: Bounds;
+    cssClasses: string[];
+}
+
+/**
+ * Gather all projections of elements contained in the given parent element.
+ */
+export function getProjections(parent: Readonly<SParentElement>): ViewProjection[] | undefined {
+    let result: ViewProjection[] | undefined;
+    for (const child of parent.children) {
+        if (isProjectable(child) && isBoundsAware(child) && child.projectionCssClasses.length > 0) {
+            const projection: ViewProjection = {
+                projectedBounds: getProjectedBounds(child),
+                cssClasses: child.projectionCssClasses
+            };
+            if (result) {
+                result.push(projection);
+            } else {
+                result = [projection];
+            }
+        }
+        if (child.children.length > 0) {
+            const childProj = getProjections(child);
+            if (childProj) {
+                if (result) {
+                    result.push(...childProj);
+                } else {
+                    result = childProj;
+                }
+            }
+        }
+    }
+    return result;
+}
+
+/**
+ * Compute the projected bounds of the given model element, that is the absolute position in the diagram.
+ */
+export function getProjectedBounds(model: Readonly<SChildElement & BoundsAware>): Bounds {
+    let bounds = model.bounds;
+    let parent = model.parent;
+    while (parent instanceof SChildElement) {
+        bounds = parent.localToParent(bounds);
+        parent = parent.parent;
+    }
+    return bounds;
+}

--- a/src/features/projection/views.tsx
+++ b/src/features/projection/views.tsx
@@ -133,7 +133,7 @@ export class ProjectedViewportView implements IView {
             top: `${projPos}px`,
             height: `${projSize}px`
         };
-        const result = <div class-sprotty-projection={true} style={style} />;
+        const result = <div id={`${params.orientation}-projection:${projection.elementId}`} class-sprotty-projection={true} style={style} />;
         projection.cssClasses.forEach(cl => setClass(result, cl, true));
         return result;
     }

--- a/src/features/projection/views.tsx
+++ b/src/features/projection/views.tsx
@@ -19,9 +19,10 @@ import { html } from '../../lib/jsx';
 
 import { injectable } from 'inversify';
 import { VNode, VNodeStyle, h } from 'snabbdom';
-import { IView, IViewArgs, RenderingContext, ViewProjection } from '../../base/views/view';
+import { IView, IViewArgs, RenderingContext } from '../../base/views/view';
+import { setClass } from '../../base/views/vnode-utils';
 import { ViewportRootElement } from '../viewport/viewport-root';
-import { ShapeView } from '../bounds/views';
+import { getProjections, ViewProjection } from './model';
 
 /**
  * Special viewport root view that renders horizontal and vertical projection bars for quick navigation.
@@ -46,7 +47,7 @@ export class ProjectedViewportView implements IView {
         if (model.bounds.width <= 0 || model.bounds.height <= 0 || model.zoom <= 0) {
             return [];
         }
-        const projections = context.getProjections(model) ?? [];
+        const projections = getProjections(model) ?? [];
         return [
             this.renderProjectionBar(projections, model, 'vertical'),
             this.renderProjectionBar(projections, model, 'horizontal')
@@ -122,14 +123,14 @@ export class ProjectedViewportView implements IView {
         }
         const style: VNodeStyle = params.orientation === 'horizontal' ? {
             left: `${projPos}px`,
-            width: `${projSize}px`,
-            backgroundColor: projection.color
+            width: `${projSize}px`
         } : {
             top: `${projPos}px`,
-            height: `${projSize}px`,
-            backgroundColor: projection.color
+            height: `${projSize}px`
         };
-        return <div class-sprotty-projection={true} style={style} />;
+        const result = <div class-sprotty-projection={true} style={style} />;
+        projection.cssClasses.forEach(cl => setClass(result, cl, true));
+        return result;
     }
 
 }
@@ -139,13 +140,3 @@ export type ProjectionParams = {
     factor: number
     zoomedFactor: number
 };
-
-/**
- * Use this as `viewInit` when configuring a model element and view with `configureModelElement`
- * to enable projection for the view.
- */
- export function setProjection(color: string): (view: ShapeView) => void {
-    return view => {
-        view.projectionColor = color;
-    };
-}

--- a/src/features/viewport/scroll.ts
+++ b/src/features/viewport/scroll.ts
@@ -14,16 +14,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Point } from "../../utils/geometry";
-import { SModelElement, SModelRoot } from "../../base/model/smodel";
-import { MouseListener } from "../../base/views/mouse-tool";
-import { Action } from "../../base/actions/action";
-import { SModelExtension } from "../../base/model/smodel-extension";
-import { findParentByFeature } from "../../base/model/smodel-utils";
-import { SetViewportAction } from "./viewport";
-import { isViewport, Viewport } from "./model";
-import { isMoveable } from "../move/model";
-import { SRoutingHandle } from "../routing/model";
+import { Point } from '../../utils/geometry';
+import { SModelElement, SModelRoot } from '../../base/model/smodel';
+import { MouseListener } from '../../base/views/mouse-tool';
+import { Action } from '../../base/actions/action';
+import { SModelExtension } from '../../base/model/smodel-extension';
+import { findParentByFeature } from '../../base/model/smodel-utils';
+import { SetViewportAction } from './viewport';
+import { isViewport, Viewport } from './model';
+import { isMoveable } from '../move/model';
+import { SRoutingHandle } from '../routing/model';
+import { BoundsAware, isBoundsAware } from '../bounds/model';
 
 export interface Scrollable extends SModelExtension {
     scroll: Point
@@ -36,49 +37,129 @@ export function isScrollable(element: SModelElement | Scrollable): element is Sc
 export class ScrollMouseListener extends MouseListener {
 
     lastScrollPosition: Point |undefined;
+    scrollbar: HTMLElement | undefined;
 
     mouseDown(target: SModelElement, event: MouseEvent): Action[] {
         const moveable = findParentByFeature(target, isMoveable);
         if (moveable === undefined && !(target instanceof SRoutingHandle)) {
             const viewport = findParentByFeature(target, isViewport);
-            if (viewport)
+            if (viewport) {
                 this.lastScrollPosition = { x: event.pageX, y: event.pageY };
-            else
+                if (isBoundsAware(viewport)) {
+                    this.scrollbar = this.getScrollbar(event);
+                    if (this.scrollbar) {
+                        return this.moveScrollBar(viewport, event, this.scrollbar);
+                    }
+                }
+            } else {
                 this.lastScrollPosition = undefined;
+                this.scrollbar = undefined;
+            }
         }
         return [];
     }
 
     mouseMove(target: SModelElement, event: MouseEvent): Action[] {
-        if (event.buttons === 0)
-            this.mouseUp(target, event);
-        else if (this.lastScrollPosition) {
+        if (event.buttons === 0) {
+            return this.mouseUp(target, event);
+        }
+        if (this.scrollbar) {
+            const viewport = findParentByFeature(target, isViewport);
+            if (viewport && isBoundsAware(viewport)) {
+                return this.moveScrollBar(viewport, event, this.scrollbar);
+            }
+        }
+        if (this.lastScrollPosition) {
             const viewport = findParentByFeature(target, isViewport);
             if (viewport) {
-                const dx = (event.pageX - this.lastScrollPosition.x) / viewport.zoom;
-                const dy = (event.pageY - this.lastScrollPosition.y) / viewport.zoom;
-                const newViewport: Viewport = {
-                    scroll: {
-                        x: viewport.scroll.x - dx,
-                        y: viewport.scroll.y - dy,
-                    },
-                    zoom: viewport.zoom
-                };
-                this.lastScrollPosition = {x: event.pageX, y: event.pageY};
-                return [new SetViewportAction(viewport.id, newViewport, false)];
+                return this.dragCanvas(viewport, event, this.lastScrollPosition);
             }
         }
         return [];
     }
 
     mouseEnter(target: SModelElement, event: MouseEvent): Action[] {
-        if (target instanceof SModelRoot && event.buttons === 0)
+        if (target instanceof SModelRoot && event.buttons === 0) {
             this.mouseUp(target, event);
+        }
         return [];
     }
 
     mouseUp(target: SModelElement, event: MouseEvent): Action[] {
         this.lastScrollPosition = undefined;
+        this.scrollbar = undefined;
         return [];
     }
+
+    protected dragCanvas(viewport: SModelRoot & Viewport, event: MouseEvent, lastScrollPosition: Point): Action[] {
+        const dx = (event.pageX - lastScrollPosition.x) / viewport.zoom;
+        const dy = (event.pageY - lastScrollPosition.y) / viewport.zoom;
+        const newViewport: Viewport = {
+            scroll: {
+                x: viewport.scroll.x - dx,
+                y: viewport.scroll.y - dy,
+            },
+            zoom: viewport.zoom
+        };
+        this.lastScrollPosition = { x: event.pageX, y: event.pageY };
+        return [new SetViewportAction(viewport.id, newViewport, false)];
+    }
+
+    protected moveScrollBar(model: SModelRoot & Viewport & BoundsAware, event: MouseEvent, scrollbar: HTMLElement): Action[] {
+        const modelBounds = model.bounds;
+        const scrollbarRect = scrollbar.getBoundingClientRect();
+        let newScroll: Point;
+        if (this.getScrollbarOrientation(scrollbar) === 'horizontal') {
+            if (modelBounds.width <= 0 || model.zoom <= 0 || scrollbarRect.width <= 0) {
+                return [];
+            }
+            const viewportSize = (model.canvasBounds.width / (model.zoom * modelBounds.width)) * scrollbarRect.width;
+            let position = event.clientX - scrollbarRect.x - viewportSize / 2;
+            if (position < 0) {
+                position = 0;
+            } else if (position > scrollbarRect.width - viewportSize) {
+                position = scrollbarRect.width - viewportSize;
+            }
+            newScroll = {
+                x: modelBounds.x + (position / scrollbarRect.width) * modelBounds.width,
+                y: model.scroll.y
+            };
+        } else {
+            if (modelBounds.height <= 0 || model.zoom <= 0 || scrollbarRect.height <= 0) {
+                return [];
+            }
+            const viewportSize = (model.canvasBounds.height / (model.zoom * modelBounds.height)) * scrollbarRect.height;
+            let position = event.clientY - scrollbarRect.y - viewportSize / 2;
+            if (position < 0) {
+                position = 0;
+            } else if (position > scrollbarRect.height - viewportSize) {
+                position = scrollbarRect.height - viewportSize;
+            }
+            newScroll = {
+                x: model.scroll.x,
+                y: modelBounds.y + (position / scrollbarRect.height) * modelBounds.height
+            };
+        }
+        return [new SetViewportAction(model.id, { scroll: newScroll, zoom: model.zoom }, false)];
+    }
+
+    protected getScrollbar(event: MouseEvent): HTMLElement | undefined {
+        let element = event.target as HTMLElement | null;
+        while (element) {
+            if (element.classList && element.classList.contains('sprotty-projection-bar')) {
+                return element;
+            }
+            element = element.parentElement;
+        }
+        return undefined;
+    }
+
+    protected getScrollbarOrientation(scrollbar: HTMLElement): 'horizontal' | 'vertical' {
+        if (scrollbar.classList.contains('horizontal')) {
+            return 'horizontal';
+        } else {
+            return 'vertical';
+        }
+    }
+
 }

--- a/src/features/viewport/viewport-root.ts
+++ b/src/features/viewport/viewport-root.ts
@@ -14,23 +14,53 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Bounds, Point, isBounds, isValidDimension } from "../../utils/geometry";
-import { SModelRoot, SModelIndex, SModelElement } from '../../base/model/smodel';
+import { Bounds, Point, isBounds, isValidDimension, EMPTY_DIMENSION, Dimension, ORIGIN_POINT } from "../../utils/geometry";
+import { SModelRoot, SModelIndex, SModelElement, SModelRootSchema } from '../../base/model/smodel';
 import { Viewport, viewportFeature } from "./model";
 import { exportFeature } from "../export/model";
+import { BoundsAware } from "../bounds/model";
+
+export interface ViewportRootElementSchema extends SModelRootSchema {
+    scroll?: Point
+    zoom?: number
+    position?: Point
+    size?: Dimension
+}
 
 /**
  * Model root element that defines a viewport, so it transforms the coordinate system with
  * a `scroll` translation and a `zoom` scaling.
  */
-export class ViewportRootElement extends SModelRoot implements Viewport {
+export class ViewportRootElement extends SModelRoot implements Viewport, BoundsAware {
     static readonly DEFAULT_FEATURES = [viewportFeature, exportFeature];
 
     scroll: Point = { x: 0, y: 0 };
     zoom: number = 1;
+    position: Point = ORIGIN_POINT;
+    size: Dimension = EMPTY_DIMENSION;
 
     constructor(index?: SModelIndex<SModelElement>) {
         super(index);
+    }
+
+    get bounds(): Bounds {
+        return {
+            x: this.position.x,
+            y: this.position.y,
+            width: this.size.width,
+            height: this.size.height
+        };
+    }
+
+    set bounds(newBounds: Bounds) {
+        this.position = {
+            x: newBounds.x,
+            y: newBounds.y
+        };
+        this.size = {
+            width: newBounds.width,
+            height: newBounds.height
+        };
     }
 
     localToParent(point: Point | Bounds): Bounds {

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,8 @@ export * from "./features/nameable/model";
 export * from "./features/open/open";
 export * from "./features/open/model";
 
+export * from "./features/projection/views";
+
 export * from "./features/routing/anchor";
 export * from "./features/routing/linear-edge-router";
 export * from "./features/routing/manhattan-anchors";

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,7 @@ export * from "./features/nameable/model";
 export * from "./features/open/open";
 export * from "./features/open/model";
 
+export * from "./features/projection/model";
 export * from "./features/projection/views";
 
 export * from "./features/routing/anchor";

--- a/src/lib/html-views.tsx
+++ b/src/lib/html-views.tsx
@@ -17,12 +17,15 @@
  /** @jsx html */
 import { html } from './jsx';
 
-import { VNode } from "snabbdom";
-import { IView, RenderingContext } from "../base/views/view";
-import { setClass } from "../base/views/vnode-utils";
-import { HtmlRoot } from "./model";
 import { injectable } from 'inversify';
+import { VNode } from 'snabbdom';
+import { IView, RenderingContext } from '../base/views/view';
+import { setClass } from '../base/views/vnode-utils';
+import { HtmlRoot } from './model';
 
+/**
+ * View for `HtmlRoot` elements. Typically this is used in hover popup boxes.
+ */
 @injectable()
 export class HtmlRootView implements IView {
     render(model: HtmlRoot, context: RenderingContext): VNode {

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -55,3 +55,12 @@ export function getWindowScroll(): Point {
         y: window.pageYOffset
     };
 }
+
+/**
+ * Checks whether the given mouse event hits the given DOM element.
+ */
+export function hitsMouseEvent(child: Element, event: MouseEvent): boolean {
+    const clientRect = child.getBoundingClientRect();
+    return event.clientX >= clientRect.left && event.clientX <= clientRect.right
+        && event.clientY >= clientRect.top && event.clientY <= clientRect.bottom;
+}


### PR DESCRIPTION
This PR adds "projection bars". These are similar to the scrollbars in IDEs like Eclipse and VS Code, where you have colored markers at interesting code regions like errors or SCM changes. The difference is that they can appear in two dimensions, so you can have a horizontal and a vertical projection.

Projection bars are added by using `ProjectedViewportView` as view of the root element and configuring marker colors for some model elements. This can be either dynamic by implementing `getProjection` (for example to show only elements with certain properties) or static with the following pattern in the diagram configuration:
```typescript
configureModelElement(context, 'pre-logo', ShapedPreRenderedElement, PreRenderedView, {
    viewInit: setProjection('rgba(255, 153, 0, 0.5)')
});
```
An additional requirement of the projection bars is that the root element needs to be BoundsAware. its position and size are used to scale the content of the bars properly.

I applied this new feature to the "SVG" example. Try zooming in and clicking / dragging the scroll bars, and see how they are updated when you move elements around.