### PR TITLE
#248 Fix Codicons dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "url": "https://github.com/eclipse/sprotty.git"
   },
   "dependencies": {
+    "@vscode/codicons": "^0.0.25",
     "autocompleter": "5.1.0",
     "file-saver": "2.0.2",
     "inversify": "^5.0.1",
@@ -61,7 +62,6 @@
     "@types/mocha": "^5.2.7",
     "@typescript-eslint/eslint-plugin": "^4.25.0",
     "@typescript-eslint/parser": "^4.25.0",
-    "@vscode/codicons": "^0.0.25",
     "chai": "^4.2.0",
     "circular-dependency-plugin": "^5.2.0",
     "core-js": "^3.2.1",


### PR DESCRIPTION
Move `"@vscode/codicons"` from `devDependencies` to `dependencies`.