### PR TITLE
Created new package sprotty-protocol

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,8 @@
 {
     "eslint.options": {
-      "configFile": "configs/.eslintrc.js"  
+      "configFile": "configs/.eslintrc.js"
     },
+    "eslint.packageManager": "yarn",
     "search.exclude": {
         "**/node_modules": true,
         "**/lib": true,
@@ -12,4 +13,5 @@
         "editor.tabSize": 4
     },
     "typescript.tsdk": "node_modules/typescript/lib",
+    "files.trimTrailingWhitespace": true,
 }

--- a/configs/.eslintrc.js
+++ b/configs/.eslintrc.js
@@ -100,7 +100,7 @@ module.exports = {
         "no-invalid-this": "warn",
         "no-new-wrappers": "warn",
         "no-null/no-null": "off",
-        "no-redeclare": "error",
+        "no-redeclare": "off",
         "no-restricted-imports": [
             "error",
             "..",

--- a/configs/.mocharc.json
+++ b/configs/.mocharc.json
@@ -1,0 +1,10 @@
+{
+    "require": [
+        "ts-node/register",
+        "reflect-metadata/Reflect"
+    ],
+    "extension": ["ts", "tsx"],
+    "timeout": 10000,
+    "reporter": "spec",
+    "colors": true
+}

--- a/configs/mocha.opts
+++ b/configs/mocha.opts
@@ -1,6 +1,0 @@
---require ts-node/register
---require reflect-metadata/Reflect
---reporter spec
---colors
---watch-extensions ts,tsx
---timeout 10000

--- a/examples/circlegraph/src/standalone.ts
+++ b/examples/circlegraph/src/standalone.ts
@@ -15,17 +15,17 @@
  ********************************************************************************/
 
 import {
-    TYPES, IActionDispatcher, SModelElementSchema, SEdgeSchema, SNodeSchema, SGraphSchema,
-    ElementMove, MoveAction, LocalModelSource, Bounds, SelectAction, Point, getBasicType
+    TYPES, IActionDispatcher, ElementMove, MoveAction, LocalModelSource, getBasicType
 } from 'sprotty';
+import { Bounds, Point, SEdge, SelectAction, SGraph, SModelElement, SNode } from 'sprotty-protocol';
 import createContainer from "./di.config";
 
 const NODE_SIZE = 60;
 
 export default async function runCircleGraph() {
     let count = 2;
-    function addNode(bounds: Bounds): SModelElementSchema[] {
-        const newNode: SNodeSchema = {
+    function addNode(bounds: Bounds): SModelElement[] {
+        const newNode: SNode = {
             id: 'node' + count,
             type: 'node:circle',
             position: {
@@ -37,7 +37,7 @@ export default async function runCircleGraph() {
                 height: NODE_SIZE
             }
         };
-        const newEdge: SEdgeSchema = {
+        const newEdge: SEdge = {
             id: 'edge' + count,
             type: 'edge:straight',
             sourceId: 'node0',
@@ -67,7 +67,7 @@ export default async function runCircleGraph() {
 
     // Initialize model
     const node0 = { id: 'node0', type: 'node:circle', position: { x: 100, y: 100 }, size: { width: NODE_SIZE, height: NODE_SIZE } };
-    const graph: SGraphSchema = { id: 'graph', type: 'graph', children: [node0] };
+    const graph: SGraph = { id: 'graph', type: 'graph', children: [node0] };
 
     const initialViewport = await modelSource.getViewport();
     for (let i = 0; i < 200; ++i) {
@@ -83,7 +83,7 @@ export default async function runCircleGraph() {
         const viewport = await modelSource.getViewport();
         const newElements = addNode(getVisibleBounds(viewport));
         modelSource.addElements(newElements);
-        dispatcher.dispatch(new SelectAction(newElements.map(e => e.id)));
+        dispatcher.dispatch(SelectAction.create({ selectedElementsIDs: newElements.map(e => e.id) }));
         focusGraph();
     });
 
@@ -102,7 +102,7 @@ export default async function runCircleGraph() {
                 });
             }
         });
-        dispatcher.dispatch(new MoveAction(nodeMoves, true));
+        dispatcher.dispatch(MoveAction.create(nodeMoves, { animate: true }));
         focusGraph();
     });
 
@@ -122,7 +122,7 @@ export default async function runCircleGraph() {
                 });
             }
         });
-        dispatcher.dispatch(new MoveAction(nodeMoves, true));
+        dispatcher.dispatch(MoveAction.create(nodeMoves, { animate: true }));
         focusGraph();
     });
 

--- a/examples/classdiagram/src/model-source.ts
+++ b/examples/classdiagram/src/model-source.ts
@@ -15,11 +15,11 @@
  ********************************************************************************/
 
 import { injectable } from 'inversify';
+import { ActionHandlerRegistry, LocalModelSource, Expandable } from 'sprotty';
 import {
-    Action, ActionHandlerRegistry, CollapseExpandAction, CollapseExpandAllAction, LocalModelSource,
-    SCompartmentSchema, SEdgeSchema, SGraphSchema, SLabelSchema, SModelElementSchema, SModelIndex,
-    SModelRootSchema, SNodeSchema, Expandable
-} from 'sprotty';
+    Action, CollapseExpandAction, CollapseExpandAllAction, SCompartment, SEdge, SGraph, SLabel,
+    SModelElement, SModelIndex, SModelRoot, SNode
+} from 'sprotty-protocol';
 
 @injectable()
 export class ClassDiagramModelSource extends LocalModelSource {
@@ -80,29 +80,29 @@ export class ClassDiagramModelSource extends LocalModelSource {
         }
     }
 
-    protected addExpandedChildren(element: SModelElementSchema) {
+    protected addExpandedChildren(element: SModelElement) {
         if (!element.children)
             return;
         switch (element.id) {
             case 'node0':
-                element.children.push(<SCompartmentSchema> {
+                element.children.push(<SCompartment> {
                     id: 'node0_attrs',
                     type: 'comp:comp',
                     layout: 'vbox',
                     children: [
-                        <SLabelSchema> {
+                        <SLabel> {
                             id: 'node0_op2',
                             type: 'label:text',
                             text: 'name: string'
                         }
                     ],
                 });
-                element.children.push(<SModelElementSchema> {
+                element.children.push(<SModelElement> {
                     id: 'node0_ops',
                     type: 'comp:comp',
                     layout: 'vbox',
                     children: [
-                        <SLabelSchema> {
+                        <SLabel> {
                             id: 'node0_op0',
                             type: 'label:text',
                             text: '+ foo(): integer'
@@ -115,24 +115,24 @@ export class ClassDiagramModelSource extends LocalModelSource {
                 });
                 break;
             case 'node1':
-                element.children.push(<SCompartmentSchema> {
+                element.children.push(<SCompartment> {
                     id: 'node1_attrs',
                     type: 'comp:comp',
                     layout: 'vbox',
                     children: [
-                        <SLabelSchema> {
+                        <SLabel> {
                             id: 'node1_op2',
                             type: 'label:text',
                             text: 'name: string'
                         }
                     ],
                 });
-                element.children.push(<SCompartmentSchema> {
+                element.children.push(<SCompartment> {
                     id: 'node1_ops',
                     type: 'comp:comp',
                     layout: 'vbox',
                     children: [
-                        <SLabelSchema> {
+                        <SLabel> {
                             id: 'node1_op0',
                             type: 'label:text',
                             text: '+ foo(): Foo'
@@ -143,8 +143,8 @@ export class ClassDiagramModelSource extends LocalModelSource {
         }
     }
 
-    initializeModel(): SModelRootSchema {
-        const node0: SNodeSchema & Expandable = {
+    initializeModel(): SModelRoot {
+        const node0: SNode & Expandable = {
             id: 'node0',
             type: 'node:class',
             expanded: false,
@@ -154,7 +154,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
             },
             layout: 'vbox',
             children: [
-                <SCompartmentSchema>{
+                <SCompartment>{
                     id: 'node0_header',
                     type: 'comp:header',
                     layout: 'hbox',
@@ -168,14 +168,14 @@ export class ClassDiagramModelSource extends LocalModelSource {
                                 resizeContainer: false
                             },
                             children: [
-                                <SLabelSchema>{
+                                <SLabel>{
                                     id: 'node0_ticon',
                                     type: 'label:icon',
                                     text: 'C'
                                 }
                             ]
                         },
-                        <SLabelSchema>{
+                        <SLabel>{
                             id: 'node0_classname',
                             type: 'label:heading',
                             text: 'Foo'
@@ -188,7 +188,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
                 }
             ]
         };
-        const node1: SNodeSchema & Expandable = {
+        const node1: SNode & Expandable = {
             id: 'node1',
             type: 'node:class',
             expanded: false,
@@ -198,7 +198,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
             },
             layout: 'vbox',
             children: [
-                <SCompartmentSchema>{
+                <SCompartment>{
                     id: 'node1_header',
                     type: 'comp:header',
                     layout: 'hbox',
@@ -212,14 +212,14 @@ export class ClassDiagramModelSource extends LocalModelSource {
                                 resizeContainer: false
                             },
                             children: [
-                                <SLabelSchema>{
+                                <SLabel>{
                                     id: 'node1_ticon',
                                     type: 'label:icon',
                                     text: 'C'
                                 },
                             ]
                         },
-                        <SLabelSchema>{
+                        <SLabel>{
                             id: 'node1_classname',
                             type: 'label:heading',
                             text: 'Bar'
@@ -232,7 +232,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
                 }
             ]
         };
-        const node2: SNodeSchema & Expandable = {
+        const node2: SNode & Expandable = {
             id: 'node2',
             type: 'node:class',
             expanded: false,
@@ -242,7 +242,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
             },
             layout: 'vbox',
             children: [
-                <SCompartmentSchema>{
+                <SCompartment>{
                     id: 'node2_header',
                     type: 'comp:header',
                     layout: 'hbox',
@@ -256,14 +256,14 @@ export class ClassDiagramModelSource extends LocalModelSource {
                                 resizeContainer: false
                             },
                             children: [
-                                <SLabelSchema>{
+                                <SLabel>{
                                     id: 'node2_ticon',
                                     type: 'label:icon',
                                     text: 'C'
                                 },
                             ]
                         },
-                        <SLabelSchema>{
+                        <SLabel>{
                             id: 'node2_classname',
                             type: 'label:heading',
                             text: 'Baz'
@@ -276,7 +276,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
                 }
             ]
         };
-        const node3: SNodeSchema & Expandable = {
+        const node3: SNode & Expandable = {
             id: 'node3',
             type: 'node:class',
             expanded: false,
@@ -286,7 +286,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
             },
             layout: 'vbox',
             children: [
-                <SCompartmentSchema>{
+                <SCompartment>{
                     id: 'node3_header',
                     type: 'comp:header',
                     layout: 'hbox',
@@ -300,14 +300,14 @@ export class ClassDiagramModelSource extends LocalModelSource {
                                 resizeContainer: false
                             },
                             children: [
-                                <SLabelSchema>{
+                                <SLabel>{
                                     id: 'node3_ticon',
                                     type: 'label:icon',
                                     text: 'C'
                                 },
                             ]
                         },
-                        <SLabelSchema>{
+                        <SLabel>{
                             id: 'node3_classname',
                             type: 'label:heading',
                             text: 'Ada'
@@ -320,7 +320,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
                 }
             ]
         };
-        const package0: SNodeSchema = {
+        const package0: SNode= {
             id: 'package0',
             type: 'node:package',
             position: {
@@ -332,7 +332,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
                 height: 300
             },
             children: [
-                <SLabelSchema>{
+                <SLabel>{
                     id: 'package0_pkgname',
                     type: 'label:heading',
                     text: 'com.example.package',
@@ -341,7 +341,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
                         y: 10
                     }
                 },
-                <SCompartmentSchema>{
+                <SCompartment>{
                     id: 'package0_content',
                     type: 'comp:pkgcontent',
                     children: [
@@ -356,7 +356,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
             sourceId: node0.id,
             targetId: node1.id,
             children: [
-                <SLabelSchema> {
+                <SLabel> {
                     id: 'edge0_label_on',
                     type: 'label:text',
                     text: 'on',
@@ -366,7 +366,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
                         rotate: false
                     }
                 },
-                <SLabelSchema> {
+                <SLabel> {
                     id: 'edge0_label_top',
                     type: 'label:text',
                     text: 'top',
@@ -376,7 +376,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
                         rotate: false
                     }
                 },
-                <SLabelSchema> {
+                <SLabel> {
                     id: 'edge0_label_bottom',
                     type: 'label:text',
                     text: 'bottom',
@@ -386,7 +386,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
                         rotate: false
                     }
                 },
-                <SLabelSchema> {
+                <SLabel> {
                     id: 'edge0_label_left',
                     type: 'label:text',
                     text: 'left',
@@ -396,7 +396,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
                         rotate: false
                     }
                 },
-                <SLabelSchema> {
+                <SLabel> {
                     id: 'edge0_label_right',
                     type: 'label:text',
                     text: 'right',
@@ -407,7 +407,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
                     }
                 }
             ]
-        } as SEdgeSchema;
+        } as SEdge;
         const edge1 = {
             id: 'edge1',
             type: 'edge:straight',
@@ -415,7 +415,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
             targetId: node2.id,
             routerKind: 'manhattan',
             children: [
-                <SLabelSchema> {
+                <SLabel> {
                     id: 'edge1_label_on',
                     type: 'label:text',
                     text: 'on',
@@ -425,7 +425,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
                         rotate: true
                     }
                 },
-                <SLabelSchema> {
+                <SLabel> {
                     id: 'edge1_label_top',
                     type: 'label:text',
                     text: 'top',
@@ -434,7 +434,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
                         side: 'top',
                     }
                 },
-                <SLabelSchema> {
+                <SLabel> {
                     id: 'edge1_label_bottom',
                     type: 'label:text',
                     text: 'bottom',
@@ -443,7 +443,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
                         side: 'bottom',
                     }
                 },
-                <SLabelSchema> {
+                <SLabel> {
                     id: 'edge1_label_left',
                     type: 'label:text',
                     text: 'left',
@@ -452,7 +452,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
                         side: 'left'
                     }
                 },
-                <SLabelSchema> {
+                <SLabel> {
                     id: 'edge1_label_right',
                     type: 'label:text',
                     text: 'right',
@@ -462,7 +462,7 @@ export class ClassDiagramModelSource extends LocalModelSource {
                     }
                 }
             ]
-        } as SEdgeSchema;
+        } as SEdge;
         const edge2 = {
             id: 'edge2',
             type: 'edge:bezier',
@@ -477,8 +477,8 @@ export class ClassDiagramModelSource extends LocalModelSource {
                 { x: 450, y: 40 }
             ],
             children: []
-        } as SEdgeSchema;
-        const graph: SGraphSchema = {
+        } as SEdge;
+        const graph: SGraph = {
             id: 'graph',
             type: 'graph',
             children: [node0, node2, node3, package0, edge0, edge1, edge2 ],

--- a/examples/classdiagram/src/popup.ts
+++ b/examples/classdiagram/src/popup.ts
@@ -16,9 +16,9 @@
 
 import { injectable, inject } from "inversify";
 import {
-    TYPES, IModelFactory, SModelElementSchema, SModelRootSchema, RequestPopupModelAction,
-    PreRenderedElementSchema, IPopupModelProvider
+    TYPES, IModelFactory, IPopupModelProvider
 } from 'sprotty';
+import { PreRenderedElement, RequestPopupModelAction, SModelElement, SModelRoot } from "sprotty-protocol";
 import { ClassNode } from "./model";
 
 @injectable()
@@ -26,19 +26,19 @@ export class PopupModelProvider implements IPopupModelProvider {
 
     @inject(TYPES.IModelFactory) modelFactory: IModelFactory;
 
-    getPopupModel(request: RequestPopupModelAction, element?: SModelElementSchema): SModelRootSchema | undefined {
+    getPopupModel(request: RequestPopupModelAction, element?: SModelElement): SModelRoot | undefined {
         if (element !== undefined && element.type === 'node:class') {
             const node = this.modelFactory.createElement(element) as ClassNode;
             return {
                 type: 'html',
                 id: 'popup',
                 children: [
-                    <PreRenderedElementSchema> {
+                    <PreRenderedElement> {
                         type: 'pre-rendered',
                         id: 'popup-title',
                         code: `<div class="sprotty-popup-title"><span class="fa fa-info-circle"/> Class ${node.name}</div>`
                     },
-                    <PreRenderedElementSchema> {
+                    <PreRenderedElement> {
                         type: 'pre-rendered',
                         id: 'popup-body',
                         code: '<div class="sprotty-popup-body">But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.</div>'

--- a/examples/mindmap/src/popup.ts
+++ b/examples/mindmap/src/popup.ts
@@ -16,11 +16,14 @@
 
 import { inject, injectable } from "inversify";
 import {
-    TYPES, SModelElementSchema, SModelRootSchema, RequestPopupModelAction, MouseListener,
-    SModelElement, Action, LocalModelSource, SNodeSchema, SetPopupModelAction, EMPTY_ROOT,
-    Point, Command, CommandExecutionContext, CommandReturn, SChildElement, FadeAnimation,
-    isFadeable, isLocateable, isBoundsAware, subtract, IPopupModelProvider
+    TYPES, MouseListener, SModelElement, LocalModelSource, EMPTY_ROOT, Command, CommandExecutionContext,
+    CommandReturn, SChildElement, FadeAnimation, isFadeable, isLocateable, isBoundsAware, IPopupModelProvider
 } from 'sprotty';
+import {
+    Action, Point, SetPopupModelAction, SModelElement as SModelElementSchema, SModelRoot as SModelRootSchema,
+    SNode as SNodeSchema
+} from 'sprotty-protocol';
+import { RequestPopupModelAction } from "sprotty-protocol";
 import { PopupButtonSchema, PopupButton } from "./model";
 import { PopupButtonView } from "./views";
 
@@ -52,7 +55,7 @@ export class PopupButtonMouseListener extends MouseListener {
 
     mouseDown(target: SModelElement, event: MouseEvent): Action[] {
         let actions: Action[] = [
-            new SetPopupModelAction({type: EMPTY_ROOT.type, id: EMPTY_ROOT.id})
+            SetPopupModelAction.create({ type: EMPTY_ROOT.type, id: EMPTY_ROOT.id })
         ];
         if (target instanceof PopupButton) {
             switch (target.kind) {
@@ -124,9 +127,9 @@ export class AddElementCommand extends Command {
     protected initialize(element: SModelElement) {
         if (isLocateable(element)) {
             const root = element.root;
-            const centerPos = root.parentToLocal(subtract(this.action.absolutePos, root.canvasBounds));
+            const centerPos = root.parentToLocal(Point.subtract(this.action.absolutePos, root.canvasBounds));
             const elementBounds = isBoundsAware(element) ? element.bounds : { x: 0, y: 0, width: 0, height: 0 };
-            element.position = subtract(centerPos, { x: elementBounds.width / 2, y: elementBounds.height / 2 });
+            element.position = Point.subtract(centerPos, { x: elementBounds.width / 2, y: elementBounds.height / 2 });
         }
     }
 

--- a/examples/multicore/src/chipmodel-factory.ts
+++ b/examples/multicore/src/chipmodel-factory.ts
@@ -15,9 +15,13 @@
  ********************************************************************************/
 
 import {
-    SGraphFactory, SChildElement, SModelElementSchema, SModelRoot, SModelRootSchema, SParentElement, getBasicType,
-    Direction, HtmlRootSchema, PreRenderedElementSchema, PreRenderedElement, HtmlRoot, createFeatureSet
+    SGraphFactory, SChildElement, SModelRoot, SParentElement, getBasicType, PreRenderedElement, HtmlRoot,
+    createFeatureSet, Direction
 } from 'sprotty';
+import {
+    SModelElement as SModelElementSchema, SModelRoot as SModelRootSchema, HtmlRoot as HtmlRootSchema,
+    PreRenderedElement as PreRenderedElementSchema
+} from 'sprotty-protocol';
 import {
     Channel, ChannelSchema, Core, CoreSchema, Crossbar, CrossbarSchema, Processor, ProcessorSchema
 } from "./chipmodel";

--- a/examples/multicore/src/chipmodel.ts
+++ b/examples/multicore/src/chipmodel.ts
@@ -15,14 +15,14 @@
  ********************************************************************************/
 
 import {
-    SShapeElement, SChildElement, SModelElementSchema, SModelRootSchema,
-    Bounds, Direction, BoundsAware, boundsFeature, Fadeable, fadeFeature,
+    SShapeElement, SChildElement, Direction, BoundsAware, boundsFeature, Fadeable, fadeFeature,
     layoutContainerFeature, LayoutContainer, Selectable, selectFeature,
     ViewportRootElement, hoverFeedbackFeature, Hoverable, popupFeature, JsonMap
 } from 'sprotty';
+import { Bounds, SModelElement, SModelRoot } from 'sprotty-protocol';
 import { CORE_DISTANCE, CORE_WIDTH } from "./views";
 
-export interface ProcessorSchema extends SModelRootSchema {
+export interface ProcessorSchema extends SModelRoot {
     rows: number
     columns: number
 }
@@ -49,14 +49,14 @@ export class Processor extends ViewportRootElement implements BoundsAware {
 
 }
 
-export interface CoreSchema extends SModelElementSchema {
+export interface CoreSchema extends SModelElement {
     row: number
     column: number
     kernelNr?: number
     selected?: boolean
     layout: string
     resizeContainer: boolean
-    children: SModelElementSchema[]
+    children: SModelElement[]
 }
 
 export class Core extends SShapeElement implements Selectable, Fadeable, Hoverable, LayoutContainer {
@@ -74,7 +74,7 @@ export class Core extends SShapeElement implements Selectable, Fadeable, Hoverab
 
 }
 
-export interface CrossbarSchema extends SModelElementSchema {
+export interface CrossbarSchema extends SModelElement {
     selected?: boolean
     direction: Direction
     load: number
@@ -85,7 +85,7 @@ export class Crossbar extends SChildElement {
     load: number = 0;
 }
 
-export interface ChannelSchema extends SModelElementSchema {
+export interface ChannelSchema extends SModelElement {
     row: number
     column: number
     direction: Direction
@@ -103,5 +103,3 @@ export class Channel extends SChildElement implements Selectable {
     selected: boolean = false;
 
 }
-
-

--- a/examples/multicore/src/multicore.ts
+++ b/examples/multicore/src/multicore.ts
@@ -14,7 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Direction, LocalModelSource, TYPES, UpdateModelAction, IActionDispatcher, SLabelSchema } from 'sprotty';
+import { Direction, LocalModelSource, TYPES, IActionDispatcher } from 'sprotty';
+import { SLabel, UpdateModelAction } from 'sprotty-protocol';
 import {
     ChannelSchema, CoreSchema, CrossbarSchema, ProcessorSchema
 } from './chipmodel';
@@ -42,7 +43,7 @@ export default function runMulticore() {
                     id: 'nr_' + pos,
                     type: 'label:heading',
                     text: '' + pos
-                } as SLabelSchema]
+                } as SLabel]
             });
             channels.push(createChannel(i, j, Direction.up));
             channels.push(createChannel(i, j, Direction.down));
@@ -115,7 +116,7 @@ export default function runMulticore() {
             }
         }
         // modelSource.update() would trigger hidden bounds computation, which is not necessary here
-        actionDispatcher.dispatch(new UpdateModelAction(processor));
+        actionDispatcher.dispatch(UpdateModelAction.create(processor));
     }
 
     setInterval(() => changeModel(), 300);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "workspaces": [
     "packages/sprotty",
+    "packages/sprotty-protocol",
     "examples"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "lerna": "^4.0.0"
   },
   "workspaces": [
-    "packages/sprotty",
-    "packages/sprotty-protocol",
+    "packages/*",
     "examples"
   ]
 }

--- a/packages/sprotty-protocol/.gitignore
+++ b/packages/sprotty-protocol/.gitignore
@@ -1,0 +1,2 @@
+/lib/
+/artifacts/

--- a/packages/sprotty-protocol/LICENSE
+++ b/packages/sprotty-protocol/LICENSE
@@ -1,0 +1,277 @@
+Eclipse Public License - v 2.0
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
+
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+"Contributor" means any person or entity that Distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following 
+Secondary Licenses when the conditions for such availability set forth 
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.

--- a/packages/sprotty-protocol/package.json
+++ b/packages/sprotty-protocol/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "sprotty-protocol",
+  "version": "0.10.0",
+  "description": "TypeScript declarations for Sprotty to be used both in browser and Node.js context",
+  "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
+  "keywords": [
+    "sprotty",
+    "typescript",
+    "nodejs",
+    "diagram",
+    "modeling",
+    "visualization"
+  ],
+  "homepage": "https://github.com/eclipse/sprotty",
+  "bugs": "https://github.com/eclipse/sprotty/issues",
+  "author": {
+    "name": "Eclipse Sprotty"
+  },
+  "contributors": [
+    {
+      "name": "Miro Spönemann",
+      "email": "miro.spoenemann@typefox.io",
+      "url": "https://www.typefox.io"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse/sprotty",
+    "directory": "packages/sprotty-protocol"
+  },
+  "dependencies": {
+  },
+  "devDependencies": {
+    "@types/mocha": "^7.0.2",
+    "@typescript-eslint/eslint-plugin": "^5.3.0",
+    "@typescript-eslint/parser": "^5.3.0",
+    "chai": "^4.3.4",
+    "eslint": "^8.1.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-header": "^3.1.1",
+    "eslint-plugin-no-null": "^1.0.2",
+    "mocha": "^7.2.0",
+    "rimraf": "^3.0.2",
+    "semver": "^7.3.5",
+    "typescript": "~3.8.3"
+  },
+  "scripts": {
+    "prepare": "yarn run clean && yarn run build",
+    "clean": "rimraf lib artifacts",
+    "build": "tsc -p ./tsconfig.json && yarn run lint",
+    "watch": "tsc -w -p ./tsconfig.json",
+    "lint": "eslint -c ../../configs/.eslintrc.js \"src/**/!(*.spec.ts*)\"",
+    "test": "mocha --config ../../configs/.mocharc.json \"./src/**/*.spec.?(ts|tsx)\"",
+    "prepublishOnly": "yarn run test",
+    "publish:next": "yarn publish --new-version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" --tag next",
+    "publish:latest": "yarn publish --tag latest"
+  },
+  "files": [
+    "lib",
+    "src"
+  ],
+  "main": "lib/index",
+  "types": "lib/index",
+  "eslintIgnore": [
+    "src/**/*.spec.?(ts|tsx)"
+  ]
+}

--- a/packages/sprotty-protocol/src/actions.ts
+++ b/packages/sprotty-protocol/src/actions.ts
@@ -1,0 +1,500 @@
+/********************************************************************************
+ * Copyright (c) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { SModelRoot, SModelElement, Viewport } from './model';
+import { Bounds, Point, Dimension } from './utils/geometry';
+import { JsonAny, JsonPrimitive } from './utils/json';
+import { hasOwnProperty } from './utils/object';
+
+/**
+ * Wrapper for actions when transferring them between client and server.
+ * The `clientId` is used to identify the specific diagram instance in the client.
+ */
+export interface ActionMessage {
+    clientId: string
+    action: Action
+}
+
+export function isActionMessage(object: unknown): object is ActionMessage {
+    return hasOwnProperty(object, 'action');
+}
+
+/**
+ * An action describes a change to the model declaratively.
+ * It is a plain data structure, and as such transferable between server and client.
+ */
+export interface Action {
+    kind: string;
+}
+
+export function isAction(object?: unknown): object is Action {
+    return hasOwnProperty<string, string>(object, 'kind', 'string');
+}
+
+/**
+ * A request action is tied to the expectation of receiving a corresponding response action.
+ * The `requestId` property is used to match the received response with the original request.
+ */
+export interface RequestAction<Res extends ResponseAction> extends Action {
+    requestId: string
+}
+
+export function isRequestAction(object?: Action): object is RequestAction<ResponseAction> {
+    return hasOwnProperty<string, string>(object, 'requestId', 'string');
+}
+
+let nextRequestId = 1;
+/**
+ * Generate a unique `requestId` for a request action.
+ */
+export function generateRequestId(): string {
+    return (nextRequestId++).toString();
+}
+
+/**
+ * A response action is sent to respond to a request action. The `responseId` must match
+ * the `requestId` of the preceding request. In case the `responseId` is empty or undefined,
+ * the action is handled as standalone, i.e. it was fired without a preceding request.
+ */
+export interface ResponseAction extends Action {
+    responseId: string;
+}
+
+/**
+ * A response action is sent to respond to a request action. The `responseId` must match
+ * the `requestId` of the preceding request. In case the `responseId` is empty or undefined,
+ * the action is handled as standalone, i.e. it was fired without a preceding request.
+ */
+
+export function isResponseAction(object?: Action): object is ResponseAction {
+    return hasOwnProperty<string, string>(object, 'responseId', 'string');
+}
+
+/**
+ * A reject action is fired to indicate that a request must be rejected.
+ */
+export interface RejectAction extends ResponseAction {
+    kind: typeof RejectAction.KIND
+    message: string
+    detail?: JsonAny
+}
+export namespace RejectAction {
+    export const KIND = 'rejectRequest';
+
+    export function create(options: { message: string, detail?: JsonAny, requestId: string }): RejectAction {
+        return {
+            kind: KIND,
+            message: options.message,
+            detail: options.detail,
+            responseId: options.requestId
+        };
+    }
+}
+
+/**
+ * Sent from the client to the model source (e.g. a DiagramServer) in order to request a model. Usually this
+ * is the first message that is sent to the source, so it is also used to initiate the communication.
+ * The response is a SetModelAction or an UpdateModelAction.
+ */
+export interface RequestModelAction extends RequestAction<SetModelAction> {
+    kind: typeof RequestModelAction.KIND
+    options?: { [key: string]: string | number | boolean }
+}
+export namespace RequestModelAction {
+    export const KIND = 'requestModel';
+
+    export function create(options?: { [key: string]: JsonPrimitive }): RequestModelAction {
+        return {
+            kind: KIND,
+            options,
+            requestId: generateRequestId()
+        };
+    }
+}
+
+/**
+ * Sent from the model source to the client in order to set the model. If a model is already present, it is replaced.
+ */
+export interface SetModelAction extends ResponseAction {
+    kind: typeof SetModelAction.KIND
+    newRoot: SModelRoot
+}
+export namespace SetModelAction {
+    export const KIND = 'setModel';
+
+    export function create(newRoot: SModelRoot, requestId?: string): SetModelAction {
+        return {
+            kind: KIND,
+            newRoot,
+            responseId: requestId!
+        };
+    }
+}
+
+/**
+ * Sent from the model source to the client in order to update the model. If no model is present yet,
+ * this behaves the same as a SetModelAction. The transition from the old model to the new one can be animated.
+ */
+export interface UpdateModelAction {
+    kind: typeof UpdateModelAction.KIND
+    newRoot?: SModelRoot
+    matches?: Match[]
+    animate?: boolean
+    cause?: Action
+}
+export namespace UpdateModelAction {
+    export const KIND = 'updateModel';
+
+    export function create(input: SModelRoot | Match[], options: { animate?: boolean, cause?: Action } = {}): UpdateModelAction {
+        if (Array.isArray(input)) {
+            return {
+                kind: KIND,
+                matches: input,
+                animate: options.animate,
+                cause: options.cause
+            };
+        } else {
+            return {
+                kind: KIND,
+                newRoot: input,
+                animate: options.animate,
+                cause: options.cause
+            };
+        }
+    }
+}
+
+export interface Match {
+    left?: SModelElement
+    right?: SModelElement
+    leftParentId?: string
+    rightParentId?: string
+}
+
+/**
+ * Triggered when the user hovers the mouse pointer over an element to get a popup with details on
+ * that element. This action is sent from the client to the model source, e.g. a DiagramServer.
+ * The response is a SetPopupModelAction.
+ */
+export interface RequestPopupModelAction extends RequestAction<SetPopupModelAction> {
+    kind: typeof RequestPopupModelAction.KIND
+    elementId: string
+    bounds: Bounds
+}
+export namespace RequestPopupModelAction {
+    export const KIND = 'requestPopupModel';
+
+    export function create(options: { elementId: string, bounds: Bounds }): RequestPopupModelAction {
+        return {
+            kind: KIND,
+            elementId: options.elementId,
+            bounds: options.bounds,
+            requestId: generateRequestId()
+        };
+    }
+}
+
+/**
+ * Sent from the model source to the client to display a popup in response to a RequestPopupModelAction.
+ * This action can also be used to remove any existing popup by choosing EMPTY_ROOT as root element.
+ */
+export interface SetPopupModelAction extends ResponseAction {
+    kind: typeof SetPopupModelAction.KIND
+    newRoot: SModelRoot
+}
+export namespace SetPopupModelAction {
+    export const KIND = 'setPopupModel';
+
+    export function create(newRoot: SModelRoot, requestId?: string): SetPopupModelAction {
+        return {
+            kind: KIND,
+            newRoot,
+            responseId: requestId!
+        };
+    }
+}
+
+/**
+ * Sent from the model source (e.g. a DiagramServer) to the client to update the bounds of some
+ * (or all) model elements.
+ */
+export interface SetBoundsAction extends Action {
+    kind: typeof SetBoundsAction.KIND
+    bounds: ElementAndBounds[]
+}
+export namespace SetBoundsAction {
+    export const KIND = 'setBounds';
+
+    export function create(bounds: ElementAndBounds[]): SetBoundsAction {
+        return {
+            kind: KIND,
+            bounds
+        };
+    }
+}
+
+/**
+ * Sent from the model source to the client to request bounds for the given model. The model is
+ * rendered invisibly so the bounds can derived from the DOM. The response is a ComputedBoundsAction.
+ * This hidden rendering round-trip is necessary if the client is responsible for parts of the layout
+ * (see `needsClientLayout` viewer option).
+ */
+export interface RequestBoundsAction extends RequestAction<ComputedBoundsAction> {
+    kind: typeof RequestBoundsAction.KIND
+    newRoot: SModelRoot
+}
+export namespace RequestBoundsAction {
+    export const KIND = 'requestBounds';
+
+    export function create(newRoot: SModelRoot): RequestBoundsAction {
+        return {
+            kind: KIND,
+            newRoot,
+            requestId: generateRequestId()
+        };
+    }
+}
+
+/**
+ * Sent from the client to the model source (e.g. a DiagramServer) to transmit the result of bounds
+ * computation as a response to a RequestBoundsAction. If the server is responsible for parts of
+ * the layout (see `needsServerLayout` viewer option), it can do so after applying the computed bounds
+ * received with this action. Otherwise there is no need to send the computed bounds to the server,
+ * so they can be processed locally by the client.
+ */
+export interface ComputedBoundsAction extends ResponseAction {
+    kind: typeof ComputedBoundsAction.KIND
+    bounds: ElementAndBounds[]
+    revision?: number
+    alignments?: ElementAndAlignment[]
+}
+export namespace ComputedBoundsAction {
+    export const KIND = 'computedBounds';
+
+    export function create(bounds: ElementAndBounds[], options: { revision?: number, alignments?: ElementAndAlignment[], requestId: string }): ComputedBoundsAction {
+        return {
+            kind: KIND,
+            bounds,
+            revision: options.revision,
+            alignments: options.alignments,
+            responseId: options.requestId
+        };
+    }
+}
+
+/**
+ * Associates new bounds with a model element, which is referenced via its id.
+ */
+ export interface ElementAndBounds {
+    elementId: string
+    newPosition?: Point
+    newSize: Dimension
+}
+
+/**
+ * Associates a new alignment with a model element, which is referenced via its id.
+ */
+ export interface ElementAndAlignment {
+    elementId: string
+    newAlignment: Point
+}
+
+/**
+ * Triggered when the user changes the selection, e.g. by clicking on a selectable element. The resulting
+ * SelectCommand changes the `selected` state accordingly, so the elements can be rendered differently.
+ * This action is also forwarded to the diagram server, if present, so it may react on the selection change.
+ * Furthermore, the server can send such an action to the client in order to change the selection programmatically.
+ */
+export interface SelectAction {
+    kind: typeof SelectAction.KIND
+    selectedElementsIDs: string[]
+    deselectedElementsIDs: string[]
+}
+export namespace SelectAction {
+    export const KIND = 'elementSelected';
+
+    export function create(options: { selectedElementsIDs?: string[], deselectedElementsIDs?: string[] }): SelectAction {
+        return {
+            kind: KIND,
+            selectedElementsIDs: options.selectedElementsIDs ?? [],
+            deselectedElementsIDs: options.deselectedElementsIDs ?? []
+        };
+    }
+}
+
+/**
+ * Programmatic action for selecting or deselecting all elements.
+ * If `select` is true, all elements are selected, otherwise they are deselected.
+ */
+export interface SelectAllAction {
+    kind: typeof SelectAllAction.KIND
+    select: boolean
+}
+export namespace SelectAllAction {
+    export const KIND = 'allSelected';
+
+    export function create(options: { select?: boolean } = {}): SelectAllAction {
+        return {
+            kind: KIND,
+            select: options.select ?? true
+        };
+    }
+}
+
+/**
+ * Sent from the client to the model source to recalculate a diagram when elements
+ * are collapsed/expanded by the client.
+ */
+ export interface CollapseExpandAction {
+    kind: typeof CollapseExpandAction.KIND
+    expandIds: string[]
+    collapseIds: string[]
+}
+export namespace CollapseExpandAction {
+    export const KIND = 'collapseExpand';
+
+    export function create(options: { expandIds?: string[], collapseIds?: string[] }): CollapseExpandAction {
+        return {
+            kind: KIND,
+            expandIds: options.expandIds ?? [],
+            collapseIds: options.collapseIds ?? []
+        };
+    }
+}
+
+/**
+ * Programmatic action for expanding or collapsing all elements.
+ * If `expand` is true, all elements are expanded, otherwise they are collapsed.
+ */
+ export interface CollapseExpandAllAction {
+    kind: typeof CollapseExpandAllAction.KIND
+    expand: boolean
+}
+export namespace CollapseExpandAllAction {
+    export const KIND = 'collapseExpandAll';
+
+    export function create(options: { expand?: boolean } = {}): CollapseExpandAllAction {
+        return {
+            kind: KIND,
+            expand: options.expand ?? true
+        };
+    }
+}
+
+export interface OpenAction {
+    kind: typeof OpenAction.KIND
+    elementId: string
+}
+export namespace OpenAction {
+    export const KIND = 'open';
+}
+
+/**
+ * Request a layout of the diagram or the selected elements only.
+ */
+export interface LayoutAction {
+    kind: typeof LayoutAction.KIND
+    layoutType?: string
+    elementIds?: string[]
+}
+export namespace LayoutAction {
+    export const KIND = 'layout';
+
+    export function create(options: { layoutType?: string, elementIds?: string[] } = {}): LayoutAction {
+        return {
+            kind: KIND,
+            layoutType: options.layoutType,
+            elementIds: options.elementIds
+        };
+    }
+}
+
+/**
+ * Triggered when the user requests the viewer to center on the current model. The resulting
+ * CenterCommand changes the scroll setting of the viewport accordingly.
+ * It also resets the zoom to its default if retainZoom is false.
+ * This action can also be sent from the model source to the client in order to perform such a
+ * viewport change programmatically.
+ */
+export interface CenterAction extends Action {
+    kind: typeof CenterAction.KIND
+    elementIds: string[]
+    animate: boolean
+    retainZoom: boolean
+}
+export namespace CenterAction {
+    export const KIND = 'center';
+
+    export function create(elementIds: string[], options: { animate?: boolean, retainZoom?: boolean } = {}): CenterAction {
+        return {
+            kind: KIND,
+            elementIds,
+            animate: options.animate ?? true,
+            retainZoom: options.retainZoom ?? false
+        };
+    }
+}
+
+/**
+ * Triggered when the user requests the viewer to fit its content to the available drawing area.
+ * The resulting FitToScreenCommand changes the zoom and scroll settings of the viewport so the model
+ * can be shown completely. This action can also be sent from the model source to the client in order
+ * to perform such a viewport change programmatically.
+ */
+export interface FitToScreenAction extends Action {
+    kind: typeof FitToScreenAction.KIND;
+    elementIds: string[]
+    padding?: number
+    maxZoom?: number
+    animate: boolean
+}
+export namespace FitToScreenAction {
+    export const KIND = 'fit';
+
+    export function create(elementIds: string[], options: { padding?: number, maxZoom?: number, animate?: boolean }): FitToScreenAction {
+        return {
+            kind: KIND,
+            elementIds,
+            padding: options.padding,
+            maxZoom: options.maxZoom,
+            animate: options.animate ?? true
+        };
+    }
+}
+
+/**
+ * Directly set the diagram viewport to the given scroll and zoom values.
+ * The ID of the viewport element to manipulate must be given with the action
+ * (usually it is the root element's ID).
+ */
+export interface SetViewportAction extends Action {
+    kind: typeof SetViewportAction.KIND;
+    elementId: string
+    newViewport: Viewport
+    animate: boolean
+}
+export namespace SetViewportAction {
+    export const KIND = 'viewport';
+
+    export function create(newViewport: Viewport, options: { elementId: string, animate?: boolean }): SetViewportAction {
+        return {
+            kind: KIND,
+            newViewport,
+            elementId: options.elementId,
+            animate: options.animate ?? true
+        };
+    }
+}

--- a/packages/sprotty-protocol/src/actions.ts
+++ b/packages/sprotty-protocol/src/actions.ts
@@ -16,7 +16,7 @@
 
 import { SModelRoot, SModelElement, Viewport } from './model';
 import { Bounds, Point, Dimension } from './utils/geometry';
-import { JsonAny, JsonPrimitive } from './utils/json';
+import { JsonAny, JsonMap } from './utils/json';
 import { hasOwnProperty } from './utils/object';
 
 /**
@@ -80,7 +80,7 @@ export interface ResponseAction extends Action {
  */
 
 export function isResponseAction(object?: Action): object is ResponseAction {
-    return hasOwnProperty<string, string>(object, 'responseId', 'string');
+    return hasOwnProperty<string, string>(object, 'responseId', 'string') && object.responseId !== '';
 }
 
 /**
@@ -111,12 +111,12 @@ export namespace RejectAction {
  */
 export interface RequestModelAction extends RequestAction<SetModelAction> {
     kind: typeof RequestModelAction.KIND
-    options?: { [key: string]: string | number | boolean }
+    options?: JsonMap
 }
 export namespace RequestModelAction {
     export const KIND = 'requestModel';
 
-    export function create(options?: { [key: string]: JsonPrimitive }): RequestModelAction {
+    export function create(options?: JsonMap): RequestModelAction {
         return {
             kind: KIND,
             options,
@@ -135,11 +135,11 @@ export interface SetModelAction extends ResponseAction {
 export namespace SetModelAction {
     export const KIND = 'setModel';
 
-    export function create(newRoot: SModelRoot, requestId?: string): SetModelAction {
+    export function create(newRoot: SModelRoot, requestId: string = ''): SetModelAction {
         return {
             kind: KIND,
             newRoot,
-            responseId: requestId!
+            responseId: requestId
         };
     }
 }
@@ -218,11 +218,11 @@ export interface SetPopupModelAction extends ResponseAction {
 export namespace SetPopupModelAction {
     export const KIND = 'setPopupModel';
 
-    export function create(newRoot: SModelRoot, requestId?: string): SetPopupModelAction {
+    export function create(newRoot: SModelRoot, requestId: string = ''): SetPopupModelAction {
         return {
             kind: KIND,
             newRoot,
-            responseId: requestId!
+            responseId: requestId
         };
     }
 }
@@ -284,13 +284,13 @@ export interface ComputedBoundsAction extends ResponseAction {
 export namespace ComputedBoundsAction {
     export const KIND = 'computedBounds';
 
-    export function create(bounds: ElementAndBounds[], options: { revision?: number, alignments?: ElementAndAlignment[], requestId: string }): ComputedBoundsAction {
+    export function create(bounds: ElementAndBounds[], options: { revision?: number, alignments?: ElementAndAlignment[], requestId?: string } = {}): ComputedBoundsAction {
         return {
             kind: KIND,
             bounds,
             revision: options.revision,
             alignments: options.alignments,
-            responseId: options.requestId
+            responseId: options.requestId ?? ''
         };
     }
 }
@@ -464,7 +464,7 @@ export interface FitToScreenAction extends Action {
 export namespace FitToScreenAction {
     export const KIND = 'fit';
 
-    export function create(elementIds: string[], options: { padding?: number, maxZoom?: number, animate?: boolean }): FitToScreenAction {
+    export function create(elementIds: string[], options: { padding?: number, maxZoom?: number, animate?: boolean } = {}): FitToScreenAction {
         return {
             kind: KIND,
             elementIds,
@@ -489,11 +489,11 @@ export interface SetViewportAction extends Action {
 export namespace SetViewportAction {
     export const KIND = 'viewport';
 
-    export function create(newViewport: Viewport, options: { elementId: string, animate?: boolean }): SetViewportAction {
+    export function create(elementId: string, newViewport: Viewport, options: { animate?: boolean } = {}): SetViewportAction {
         return {
             kind: KIND,
+            elementId,
             newViewport,
-            elementId: options.elementId,
             animate: options.animate ?? true
         };
     }

--- a/packages/sprotty-protocol/src/diagram-server.spec.ts
+++ b/packages/sprotty-protocol/src/diagram-server.spec.ts
@@ -1,0 +1,170 @@
+/********************************************************************************
+ * Copyright (c) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import 'mocha';
+import { expect } from 'chai';
+import { Action, ComputedBoundsAction, RequestBoundsAction, RequestModelAction, SetModelAction } from './actions';
+import { DiagramServer } from './diagram-server';
+import { BoundsAware, SModelRoot } from './model';
+
+declare function setImmediate(callback: () => void): void;
+
+async function condition(cb: () => boolean): Promise<void> {
+    return new Promise((resolve, reject) => {
+        let attempts = 0;
+        const next = () => {
+            if (cb()) {
+                resolve();
+            } else if (attempts++ > 10) {
+                reject();
+            } else {
+                setImmediate(next);
+            }
+        }
+        next();
+    });
+}
+
+describe('DiagramServer', () => {
+    function createServer(): { server: DiagramServer, dispatched: Action[] } {
+        const dispatched: Action[] = [];
+        const server = new DiagramServer(
+            async a => {
+                dispatched.push(a)
+            }, {
+            diagramGenerator: {
+                generate: () => {
+                    return {
+                        type: 'root',
+                        id: 'root',
+                    };
+                }
+            },
+            layoutEngine: {
+                layout: model => {
+                    (model as SModelRoot & BoundsAware).position = { x: 10, y: 10 };
+                    return model;
+                }
+            }
+        });
+        return { server, dispatched };
+    }
+
+    it('sets the model without client or server layout', async () => {
+        const { server, dispatched } = createServer();
+        await server.accept(<RequestModelAction>{
+            kind: RequestModelAction.KIND,
+            options: {
+                needsClientLayout: false,
+                needsServerLayout: false
+            },
+            requestId: 'req1'
+        });
+        expect(dispatched).to.have.lengthOf(1);
+        expect(dispatched[0]).to.deep.equal({
+            kind: SetModelAction.KIND,
+            newRoot: {
+                type: 'root',
+                id: 'root',
+                revision: 1
+            },
+            responseId: 'req1'
+        });
+    });
+
+    it('sets the model with server layout, but without client layout', async () => {
+        const { server, dispatched } = createServer();
+        await server.accept(<RequestModelAction>{
+            kind: RequestModelAction.KIND,
+            options: {
+                needsClientLayout: false,
+                needsServerLayout: true
+            },
+            requestId: 'req1'
+        });
+        expect(dispatched).to.have.lengthOf(1);
+        expect(dispatched[0]).to.deep.equal({
+            kind: SetModelAction.KIND,
+            newRoot: {
+                type: 'root',
+                id: 'root',
+                revision: 1,
+                position: { x: 10, y: 10 }
+            },
+            responseId: 'req1'
+        });
+    });
+
+    it('requests bounds with client layout, but without server layout', async () => {
+        const { server, dispatched } = createServer();
+        await server.accept(<RequestModelAction>{
+            kind: RequestModelAction.KIND,
+            options: {
+                needsClientLayout: true,
+                needsServerLayout: false
+            },
+            requestId: 'req1'
+        });
+        expect(dispatched).to.have.lengthOf(1);
+        expect(dispatched[0]).to.deep.equal({
+            kind: RequestBoundsAction.KIND,
+            newRoot: {
+                type: 'root',
+                id: 'root',
+                revision: 1
+            }
+        });
+    });
+
+    it('requests bounds with client and server layout, then processes the bounds', async () => {
+        const { server, dispatched } = createServer();
+        server.accept(<RequestModelAction>{
+            kind: RequestModelAction.KIND,
+            options: {
+                needsClientLayout: true,
+                needsServerLayout: true
+            },
+            requestId: 'req1'
+        });
+        await condition(() => dispatched.length > 0);
+        expect(dispatched).to.have.lengthOf(1);
+        expect(dispatched[0].kind).to.equal(RequestBoundsAction.KIND);
+        await server.accept(<ComputedBoundsAction>{
+            kind: ComputedBoundsAction.KIND,
+            bounds: [
+                {
+                    elementId: 'root',
+                    newSize: { width: 100, height: 100 }
+                }
+            ],
+            revision: (dispatched[0] as RequestBoundsAction).newRoot.revision,
+            responseId: (dispatched[0] as RequestBoundsAction).requestId
+        });
+        await condition(() => dispatched.length > 1);
+        expect(dispatched).to.have.lengthOf(2);
+        expect(dispatched[1]).to.deep.equal({
+            kind: SetModelAction.KIND,
+            newRoot: {
+                type: 'root',
+                id: 'root',
+                revision: 1,
+                position: { x: 10, y: 10 },
+                size: { width: 100, height: 100 }
+            },
+            responseId: 'req1'
+        });
+    });
+});

--- a/packages/sprotty-protocol/src/diagram-server.ts
+++ b/packages/sprotty-protocol/src/diagram-server.ts
@@ -20,6 +20,7 @@ import {
 } from './actions';
 import { SModelRoot } from './model';
 import { Deferred } from './utils/async';
+import { JsonMap } from './utils/json';
 import { applyBounds, cloneModel, SModelIndex } from './utils/model-utils';
 
 /**
@@ -203,7 +204,7 @@ export class DiagramServer {
 
 }
 
-export type DiagramOptions = { [key: string]: string | number | boolean };
+export type DiagramOptions = JsonMap;
 
 export interface IModelLayoutEngine {
     layout(model: SModelRoot, index?: SModelIndex): SModelRoot | Promise<SModelRoot>;

--- a/packages/sprotty-protocol/src/diagram-server.ts
+++ b/packages/sprotty-protocol/src/diagram-server.ts
@@ -1,0 +1,219 @@
+/********************************************************************************
+ * Copyright (c) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import {
+    Action, isResponseAction, ResponseAction, RequestModelAction, ComputedBoundsAction, LayoutAction, RequestBoundsAction,
+    RequestAction, generateRequestId, SetModelAction, UpdateModelAction, RejectAction, isRequestAction
+} from './actions';
+import { SModelRoot } from './model';
+import { Deferred } from './utils/async';
+import { applyBounds, cloneModel, SModelIndex } from './utils/model-utils';
+
+/**
+ * An instance of this class is responsible for handling a single diagram client. It holds the current
+ * state of the diagram and manages communication with the client via actions.
+ */
+export class DiagramServer {
+
+    protected readonly requests = new Map<string, Deferred<ResponseAction>>();
+    protected options: DiagramOptions | undefined;
+    protected currentRoot: SModelRoot;
+
+    private revision = 0;
+    private lastSubmittedModelType?: string;
+
+    constructor(readonly dispatch: <A extends Action>(action: A) => Promise<void>,
+                readonly services: DiagramServices) {
+        this.currentRoot = {
+            type: 'NONE',
+            id: 'ROOT'
+        };
+    }
+
+    setModel(newRoot: SModelRoot): Promise<void> {
+        newRoot.revision = ++this.revision;
+        this.currentRoot = newRoot;
+        return this.submitModel(newRoot, false);
+    }
+
+    updateModel(newRoot: SModelRoot): Promise<void> {
+        newRoot.revision = ++this.revision;
+        this.currentRoot = newRoot;
+        return this.submitModel(newRoot, true);
+    }
+
+    get needsClientLayout(): boolean {
+        if (this.options) {
+            return !!this.options.needsClientLayout;
+        }
+        return true;
+    }
+
+    get needsServerLayout(): boolean {
+        if (this.options) {
+            return !!this.options.needsServerLayout;
+        }
+        return false;
+    }
+
+    accept(action: Action): Promise<void> {
+        if (isResponseAction(action)) {
+            const id = action.responseId;
+            const future = this.requests.get(id);
+            if (future) {
+                this.requests.delete(id);
+                if (action.kind === RejectAction.KIND) {
+                    const rejectAction: RejectAction = action as any;
+                    future.reject(new Error(rejectAction.message));
+                    console.warn(`Request with id ${action.responseId} failed: ${rejectAction.message}`, rejectAction.detail);
+                } else {
+                    future.resolve(action);
+                }
+                return Promise.resolve();
+            }
+            console.info('No matching request for response:', action);
+        }
+        return this.handleAction(action);
+    }
+
+    request<Res extends ResponseAction>(action: RequestAction<Res>): Promise<Res> {
+        if (!action.requestId) {
+            action.requestId = 'server_' + generateRequestId();
+        }
+        const future = new Deferred<Res>();
+        this.requests.set(action.requestId, future as any);
+        this.dispatch(action).catch(err => {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            this.requests.delete(action.requestId!);
+            future.reject(err);
+        });
+        return future.promise;
+    }
+
+    protected rejectRemoteRequest(action: Action | undefined, error: Error): void {
+        if (action && isRequestAction(action)) {
+            this.dispatch({
+                kind: RejectAction.KIND,
+                responseId: action.requestId,
+                message: error.message,
+                detail: error.stack
+            });
+        }
+    }
+
+    protected handleAction(action: Action): Promise<void> {
+        switch (action.kind) {
+            case RequestModelAction.KIND:
+                return this.handleRequestModel(action as RequestModelAction);
+            case ComputedBoundsAction.KIND:
+                return this.handleComputedBounds(action as ComputedBoundsAction);
+            case LayoutAction.KIND:
+                return this.handleLayout(action as LayoutAction);
+            default:
+                console.warn(`Unhandled action from client: ${action.kind}`);
+        }
+        return Promise.resolve();
+    }
+
+    protected async handleRequestModel(action: RequestModelAction): Promise<void> {
+        this.options = action.options;
+        try {
+            const newRoot = await this.services.diagramGenerator.generate({
+                options: this.options ?? {}
+            });
+            newRoot.revision = ++this.revision;
+            this.currentRoot = newRoot;
+            await this.submitModel(this.currentRoot, false, action);
+        } catch (err) {
+            this.rejectRemoteRequest(action, err as Error);
+            console.error('Failed to generate diagram:', err);
+        }
+    }
+
+    protected async submitModel(newRoot: SModelRoot, update: boolean, cause?: Action): Promise<void> {
+        if (this.needsClientLayout) {
+            if (!this.needsServerLayout) {
+                // In this case the client won't send us the computed bounds
+                this.dispatch({ kind: RequestBoundsAction.KIND, newRoot });
+            } else {
+                const request = RequestBoundsAction.create(newRoot);
+                const response = await this.request<ComputedBoundsAction>(request);
+                if (response.revision === this.currentRoot.revision) {
+                    applyBounds(this.currentRoot, response);
+                    await this.doSubmitModel(this.currentRoot, update, cause);
+                } else {
+                    this.rejectRemoteRequest(cause, new Error(`Model revision does not match: ${response.revision}`));
+                }
+            }
+        } else {
+            await this.doSubmitModel(newRoot, update, cause);
+        }
+    }
+
+    private async doSubmitModel(newRoot: SModelRoot, update: boolean, cause?: Action): Promise<void> {
+        if (newRoot.revision !== this.revision) {
+            return;
+        }
+        if (this.needsServerLayout) {
+            newRoot = await this.services.layoutEngine.layout(newRoot);
+        }
+        const modelType = newRoot.type;
+        if (cause && cause.kind === RequestModelAction.KIND) {
+            const requestId = (cause as RequestModelAction).requestId;
+            const response = SetModelAction.create(newRoot, requestId);
+            await this.dispatch(response);
+        } else if (update && modelType === this.lastSubmittedModelType) {
+            await this.dispatch({ kind: UpdateModelAction.KIND, newRoot, cause });
+        } else {
+            await this.dispatch({ kind: SetModelAction.KIND, newRoot });
+        }
+        this.lastSubmittedModelType = modelType;
+    }
+
+    protected handleComputedBounds(action: ComputedBoundsAction): Promise<void> {
+        if (action.revision !== this.currentRoot.revision) {
+            return Promise.reject();
+        }
+        applyBounds(this.currentRoot, action);
+        return Promise.resolve();
+    }
+
+    protected handleLayout(action: LayoutAction): Promise<void> {
+        if (!this.needsServerLayout) {
+            return Promise.resolve();
+        }
+        const newRoot = cloneModel(this.currentRoot);
+        newRoot.revision = ++this.revision;
+        this.currentRoot = newRoot;
+        return this.doSubmitModel(newRoot, true, action);
+    }
+
+}
+
+export type DiagramOptions = { [key: string]: string | number | boolean };
+
+export interface IModelLayoutEngine {
+    layout(model: SModelRoot, index?: SModelIndex): SModelRoot | Promise<SModelRoot>;
+}
+
+export interface IDiagramGenerator {
+    generate(args: { options: DiagramOptions }): SModelRoot | Promise<SModelRoot>
+}
+
+export interface DiagramServices {
+    readonly diagramGenerator: IDiagramGenerator
+    readonly layoutEngine: IModelLayoutEngine;
+}

--- a/packages/sprotty-protocol/src/index.ts
+++ b/packages/sprotty-protocol/src/index.ts
@@ -1,0 +1,24 @@
+/********************************************************************************
+ * Copyright (c) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export * from './actions';
+export * from './diagram-server';
+export * from './model';
+export * from './utils/async';
+export * from './utils/geometry';
+export * from './utils/json';
+export * from './utils/model-utils';
+export * from './utils/object';

--- a/packages/sprotty-protocol/src/model.spec.ts
+++ b/packages/sprotty-protocol/src/model.spec.ts
@@ -1,0 +1,67 @@
+/********************************************************************************
+ * Copyright (c) 2017-2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import "mocha";
+import { expect } from "chai";
+import { SModelRoot } from './model';
+import { SModelIndex } from './utils/model-utils';
+
+describe('SModelIndex', () => {
+    it('returns the parent element for an external model', () => {
+        const index = new SModelIndex();
+        const root: SModelRoot = {
+            type: 'root',
+            id: 'root',
+            children: [
+                {
+                    type: 'node',
+                    id: 'parent',
+                    children: [
+                        {
+                            type: 'node',
+                            id: 'child'
+                        }
+                    ]
+                }
+            ]
+        };
+        index.add(root);
+        expect(index.getParent('child')!.id).to.equal('parent');
+    });
+
+    it('returns the root element for an external model', () => {
+        const index = new SModelIndex();
+        const root: SModelRoot = {
+            type: 'root',
+            id: 'root',
+            children: [
+                {
+                    type: 'node',
+                    id: 'parent',
+                    children: [
+                        {
+                            type: 'node',
+                            id: 'child'
+                        }
+                    ]
+                }
+            ]
+        };
+        index.add(root);
+        const child = root.children![0].children![0];
+        expect(index.getRoot(child).id).to.equal('root');
+    });
+});

--- a/packages/sprotty-protocol/src/model.ts
+++ b/packages/sprotty-protocol/src/model.ts
@@ -1,0 +1,199 @@
+/********************************************************************************
+ * Copyright (c) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Bounds, Point, Dimension } from './utils/geometry';
+import { hasOwnProperty } from './utils/object';
+
+/**
+ * Base type for all elements of the diagram model.
+ * Each model element must have a unique ID and a type that is used to look up its view.
+ */
+export interface SModelElement {
+    type: string
+    id: string
+    children?: SModelElement[]
+    cssClasses?: string[]
+}
+
+/**
+ * Base type for the root element of the diagram model tree.
+ */
+export interface SModelRoot extends SModelElement {
+    canvasBounds?: Bounds
+    revision?: number
+}
+
+/**
+ * Model elements that implement this interface have a position and a size.
+ */
+export interface BoundsAware {
+    position: Point
+    size: Dimension
+}
+
+/**
+ * Used to adjust elements whose bounding box is not at the origin, e.g. labels
+ * or pre-rendered SVG figures.
+ */
+export interface Alignable {
+    alignment: Point
+}
+
+/**
+ * A viewport has a scroll position and a zoom factor. Usually these properties are
+ * applied to the root element to enable navigating through the diagram.
+ */
+export interface Viewport extends Scrollable, Zoomable {
+}
+
+/**
+ * A scrollable element has a scroll position, which indicates the top left corner of the
+ * visible area.
+ */
+export interface Scrollable {
+    scroll: Point
+}
+
+export function isScrollable(element: SModelElement | Scrollable): element is Scrollable {
+    return hasOwnProperty(element, 'scroll');
+}
+
+/**
+ * A zoomable element can be scaled so it appears smaller or larger than its actual size.
+ * The zoom value 1 is the default scale where the content is drawn with its actual size.
+ */
+export interface Zoomable {
+    zoom: number
+}
+
+export function isZoomable(element: SModelElement | Zoomable): element is Zoomable {
+    return hasOwnProperty(element, 'zoom');
+}
+
+/**
+ * Root element for graph-like models.
+ */
+export interface SGraph extends SModelRoot {
+    children: SModelElement[]
+    bounds?: Bounds
+    scroll?: Point
+    zoom?: number
+    layoutOptions?: ModelLayoutOptions
+}
+
+/**
+ * Options to control the "micro layout" of a model element, i.e. the arrangement of its content
+ * using simple algorithms such as horizontal or vertical box layout.
+ */
+export type ModelLayoutOptions = { [key: string]: string | number | boolean };
+
+export interface SShapeElement extends SModelElement {
+    position?: Point
+    size?: Dimension
+    layoutOptions?: ModelLayoutOptions
+}
+
+/**
+ * Model element class for nodes, which are the main entities in a graph. A node can be connected to
+ * another node via an SEdge. Such a connection can be direct, i.e. the node is the source or target of
+ * the edge, or indirect through a port, i.e. it contains an SPort which is the source or target of the edge.
+ */
+export interface SNode extends SShapeElement {
+    layout?: string
+    selected?: boolean
+    hoverFeedback?: boolean
+    opacity?: number
+    anchorKind?: string
+}
+
+/**
+ * A port is a connection point for edges. It should always be contained in an SNode.
+ */
+export interface SPort extends SShapeElement {
+    selected?: boolean
+    hoverFeedback?: boolean
+    opacity?: number
+    anchorKind?: string
+}
+
+/**
+ * Model element class for edges, which are the connectors in a graph. An edge has a source and a target,
+ * each of which can be either a node or a port. The source and target elements are referenced via their ids.
+ */
+export interface SEdge extends SModelElement {
+    sourceId: string
+    targetId: string
+    routerKind?: string
+    routingPoints?: Point[]
+    selected?: boolean
+    hoverFeedback?: boolean
+    opacity?: number
+}
+
+/**
+ * A label can be attached to a node, edge, or port, and contains some text to be rendered in its view.
+ */
+export interface SLabel extends SShapeElement {
+    text: string
+    selected?: boolean
+}
+
+/**
+ * A compartment is used to group multiple child elements such as labels of a node. Usually a `vbox`
+ * or `hbox` layout is used to arrange these children.
+ */
+export interface SCompartment extends SShapeElement {
+    layout?: string
+}
+
+/**
+ * Root model element class for HTML content. Usually this is rendered with a `div` DOM element.
+ */
+export interface HtmlRoot extends SModelRoot {
+    classes?: string[]
+}
+
+/**
+ * Pre-rendered elements contain HTML or SVG code to be transferred to the DOM. This can be useful to
+ * render complex figures or to compute the view on the server instead of the client code.
+ */
+export interface PreRenderedElement extends SModelElement {
+    code: string
+}
+
+/**
+ * Same as PreRenderedElement, but with a position and a size.
+ */
+export interface ShapedPreRenderedElement extends PreRenderedElement {
+    position?: Point
+    size?: Dimension
+}
+
+/**
+ * A `foreignObject` element to be transferred to the DOM within the SVG.
+ *
+ * This can be useful to to benefit from e.g. HTML rendering features, such as line wrapping, inside of
+ * the SVG diagram.  Note that `foreignObject` is not supported by all browsers and SVG viewers may not
+ * support rendering the `foreignObject` content.
+ *
+ * If no dimensions are specified in the schema element, this element will obtain the dimension of
+ * its parent to fill the entire available room. Thus, this element requires specified bounds itself
+ * or bounds to be available for its parent.
+ */
+export interface ForeignObjectElement extends ShapedPreRenderedElement {
+    /** The namespace to be assigned to the elements inside of the `foreignObject`. */
+    namespace: string
+}

--- a/packages/sprotty-protocol/src/utils/async.ts
+++ b/packages/sprotty-protocol/src/utils/async.ts
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (c) 2017-2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/**
+ * Simple implementation of the deferred pattern.
+ * An object that exposes a promise and functions to resolve and reject it.
+ */
+export class Deferred<T> {
+    resolve: (value?: T | PromiseLike<T>) => void;
+    reject: (reason?: any) => void;
+    readonly promise: Promise<T>;
+
+    constructor() {
+        this.promise = new Promise<T>((resolve, reject) => {
+            this.resolve = resolve;
+            this.reject = reject;
+        });
+    }
+}

--- a/packages/sprotty-protocol/src/utils/geometry.spec.ts
+++ b/packages/sprotty-protocol/src/utils/geometry.spec.ts
@@ -1,0 +1,69 @@
+/********************************************************************************
+ * Copyright (c) 2017-2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import "mocha";
+import { expect } from "chai";
+import { almostEquals, Bounds, angleBetweenPoints, Point } from "./geometry";
+
+describe('almostEquals', () => {
+    it('returns false for clearly different values', () => {
+        expect(almostEquals(3, 17)).to.be.false;
+    });
+    it('returns true for almost equal values', () => {
+        expect(almostEquals(3.12895, 3.12893)).to.be.true;
+    });
+});
+
+describe('Point', () => {
+    describe('euclideanDistance', () => {
+        it('works as expected', () => {
+            expect(Point.euclideanDistance({x: 0, y: 0}, {x: 3, y: 4})).to.equal(5);
+        });
+    });
+
+    describe('manhattanDistance', () => {
+        it('works as expected', () => {
+            expect(Point.manhattanDistance({x: 0, y: 0}, {x: 3, y: 4})).to.equal(7);
+        });
+    });
+});
+
+describe('Bounds', () => {
+    describe('combine', () => {
+        it('includes all corner points of the input bounds', () => {
+            const b0: Bounds = { x: 2, y: 2, width: 4, height: 6 };
+            const b1: Bounds = { x: 5, y: 3, width: 5, height: 10 };
+            const b2 = Bounds.combine(b0, b1);
+            expect(Bounds.includes(b2, b0)).to.be.true;
+            expect(Bounds.includes(b2, b1)).to.be.true;
+            expect(Bounds.includes(b2, { x: b0.x + b0.width, y: b0.y + b0.height })).to.be.true;
+            expect(Bounds.includes(b2, { x: b1.x + b1.width, y: b1.y + b1.height })).to.be.true;
+            expect(Bounds.includes(b2, Point.ORIGIN)).to.be.false;
+            expect(Bounds.includes(b2, { x: 100, y: 100 })).to.be.false;
+        });
+    });
+});
+
+describe('angleBetweenPoints', () => {
+    it('computes a 90° angle correctly', () => {
+        expect(angleBetweenPoints({ x: 2, y: 0 }, { x: 0, y: 3 })).to.equal(Math.PI / 2);
+        expect(angleBetweenPoints({ x: 2, y: 0 }, { x: 0, y: -3 })).to.equal(Math.PI / 2);
+    });
+    it('computes a 180° angle correctly', () => {
+        expect(angleBetweenPoints({ x: 2, y: 0 }, { x: -3, y: 0 })).to.equal(Math.PI);
+        expect(angleBetweenPoints({ x: 0, y: 2 }, { x: 0, y: -3 })).to.equal(Math.PI);
+    });
+});

--- a/packages/sprotty-protocol/src/utils/geometry.ts
+++ b/packages/sprotty-protocol/src/utils/geometry.ts
@@ -1,0 +1,320 @@
+/********************************************************************************
+ * Copyright (c) 2017-2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { hasOwnProperty } from "./object";
+
+/**
+ * A Point is composed of the (x,y) coordinates of an object.
+ */
+export interface Point {
+    readonly x: number
+    readonly y: number
+}
+
+export namespace Point {
+    /**
+     * (x,y) coordinates of the origin.
+     */
+    export const ORIGIN: Point = Object.freeze({
+        x: 0,
+        y: 0
+    });
+
+    /**
+     * Adds two points.
+     * @param {Point} p1 - First point
+     * @param {Point} p2 - Second point
+     * @returns {Point} The sum of the two points
+     */
+    export function add(p1: Point, p2: Point): Point {
+        return {
+            x: p1.x + p2.x,
+            y: p1.y + p2.y
+        };
+    }
+
+    /**
+     * Subtracts two points.
+     * @param {Point} p1 - First point
+     * @param {Point} p2 - Second point
+     * @returns {Point} The difference of the two points
+     */
+    export function subtract(p1: Point, p2: Point): Point {
+        return {
+            x: p1.x - p2.x,
+            y: p1.y - p2.y
+        };
+    }
+
+    /**
+     * Specifies whether a point has exactly the same coordinates as another point.
+     * @param {Point} point1 a point
+     * @param {Point} point2 another point
+     * @returns {boolean} `true` if `point1` has exactly the same `x` and `y` values as `point2`, `false` otherwise.
+     */
+    export function equals(point1: Point, point2: Point): boolean {
+        return point1.x === point2.x && point1.y === point2.y;
+    }
+
+    /**
+     * Computes a point that is the original `point` shifted towards `refPoint` by the given `distance`.
+     * @param {Point} point - Point to shift
+     * @param {Point} refPoint - Point to shift towards
+     * @param {Point} distance - Distance to shift
+     */
+    export function shiftTowards(point: Point, refPoint: Point, distance: number): Point {
+        const diff = subtract(refPoint, point);
+        const normalized = normalize(diff);
+        const shift = { x: normalized.x * distance, y: normalized.y * distance };
+        return add(point, shift);
+    }
+
+    /**
+     * Computes the normalized vector from the vector given in `point`; that is, computing its unit vector.
+     * @param {Point} point - Point representing the vector to be normalized
+     * @returns {Point} The normalized point
+     */
+    export function normalize(point: Point): Point {
+        const mag = magnitude(point);
+        if (mag === 0 || mag === 1) {
+            return ORIGIN;
+        }
+        return {
+            x: point.x / mag,
+            y: point.y / mag
+        };
+    }
+
+    /**
+     * Computes the magnitude of the vector given in `point`.
+     * @param {Point} point - Point representing the vector to compute the magnitude for
+     * @returns {number} The magnitude or also known as length of the `point`
+     */
+    export function magnitude(point: Point): number {
+        return Math.sqrt(Math.pow(point.x, 2) + Math.pow(point.y, 2));
+    }
+
+    /**
+     * Calculates a linear combination of p0 and p1 using lambda, i.e.
+     *   (1-lambda) * p0 + lambda * p1
+     */
+    export function linear(p0: Point, p1: Point, lambda: number): Point {
+        return {
+            x: (1 - lambda) * p0.x + lambda * p1.x,
+            y: (1 - lambda) * p0.y + lambda * p1.y
+        };
+    }
+
+    /**
+     * Returns the "straight line" distance between two points.
+     * @param {Point} a - First point
+     * @param {Point} b - Second point
+     * @returns {number} The Eucledian distance
+     */
+    export function euclideanDistance(a: Point, b: Point): number {
+        const dx = b.x - a.x;
+        const dy = b.y - a.y;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    /**
+     * Returns the distance between two points in a grid, using a
+     * strictly vertical and/or horizontal path (versus straight line).
+     * @param {Point} a - First point
+     * @param {Point} b - Second point
+     * @returns {number} The Manhattan distance
+     */
+    export function manhattanDistance(a: Point, b: Point): number {
+        return Math.abs(b.x - a.x) + Math.abs(b.y - a.y);
+    }
+
+    /**
+     * Returns the maximum of the horizontal and the vertical distance.
+     * @param {Point} a - First point
+     * @param {Point} b - Second point
+     * @returns {number} The maximum distance
+     */
+    export function maxDistance(a: Point, b: Point): number {
+        return Math.max(Math.abs(b.x - a.x), Math.abs(b.y - a.y));
+    }
+}
+
+/**
+ * Computes the angle in radians of the given point to the x-axis of the coordinate system.
+ * The result is in the range [-pi, pi].
+ * @param {Point} p - A point in the Eucledian plane
+ */
+export function angleOfPoint(p: Point): number {
+    return Math.atan2(p.y, p.x);
+}
+
+/**
+ * Computes the angle in radians between the two given points (relative to the origin of the coordinate system).
+ * The result is in the range [0, pi]. Returns NaN if the points are equal.
+ * @param {Point} a - First point
+ * @param {Point} b - Second point
+ */
+export function angleBetweenPoints(a: Point, b: Point): number {
+    const lengthProduct = Math.sqrt((a.x * a.x + a.y * a.y) * (b.x * b.x + b.y * b.y));
+    if (isNaN(lengthProduct) || lengthProduct === 0)
+        return NaN;
+    const dotProduct = a.x * b.x + a.y * b.y;
+    return Math.acos(dotProduct / lengthProduct);
+}
+
+/**
+ * Computes the center of the line segment spanned by the two given points.
+ * @param {Point} s - Start point of the line
+ * @param {Point} e - End point of the line
+ */
+export function centerOfLine(s: Point, e: Point): Point {
+    const b: Bounds = {
+        x: s.x > e.x ? e.x : s.x,
+        y: s.y > e.y ? e.y : s.y,
+        width: Math.abs(e.x - s.x),
+        height: Math.abs(e.y - s.y)
+    };
+    return Bounds.center(b);
+}
+
+/**
+ * The Dimension of an object is composed of its width and height.
+ */
+export interface Dimension {
+    readonly width: number
+    readonly height: number
+}
+
+export namespace Dimension {
+    /**
+     * A dimension with both width and height set to a negative value, which is considered as undefined.
+     */
+    export const EMPTY: Dimension = Object.freeze({
+        width: -1,
+        height: -1
+    });
+
+    /**
+     * Checks whether the given dimention is valid, i.e. the width and height are non-zero.
+     * @param {Dimension} b - Dimension object
+     * @returns {boolean} `true` if the dimension is valid
+     */
+    export function isValid(d: Dimension): boolean {
+        return d.width >= 0 && d.height >= 0;
+    }
+}
+
+/**
+ * The bounds are the position (x, y) and dimension (width, height) of an object.
+ */
+export interface Bounds extends Point, Dimension {
+}
+
+export function isBounds(element: unknown): element is Bounds {
+    return hasOwnProperty(element, ['x', 'y', 'width', 'height']);
+}
+
+export namespace Bounds {
+    export const EMPTY: Bounds = Object.freeze({
+        x: 0,
+        y: 0,
+        width: -1,
+        height: -1
+    });
+
+    /**
+     * Combines the bounds of two objects into one, so that the new bounds
+     * are the minimum bounds that covers both of the original bounds.
+     * @param {Bounds} b0 - First bounds object
+     * @param {Bounds} b1 - Second bounds object
+     * @returns {Bounds} The combined bounds
+     */
+    export function combine(b0: Bounds, b1: Bounds): Bounds {
+        if (!Dimension.isValid(b0))
+            return Dimension.isValid(b1) ? b1 : EMPTY;
+        if (!Dimension.isValid(b1))
+            return b0;
+        const minX = Math.min(b0.x, b1.x);
+        const minY = Math.min(b0.y, b1.y);
+        const maxX = Math.max(b0.x + (b0.width >= 0 ? b0.width : 0), b1.x + (b1.width >= 0 ? b1.width : 0));
+        const maxY = Math.max(b0.y + (b0.height >= 0 ? b0.height : 0), b1.y + (b1.height >= 0 ? b1.height : 0));
+        return {
+            x: minX, y: minY, width: maxX - minX, height: maxY - minY
+        };
+    }
+
+    /**
+     * Translates the given bounds.
+     * @param {Bounds} b - Bounds object
+     * @param {Point} p - Vector by which to translate the bounds
+     * @returns {Bounds} The translated bounds
+     */
+    export function translate(b: Bounds, p: Point): Bounds {
+        return {
+            x: b.x + p.x,
+            y: b.y + p.y,
+            width: b.width,
+            height: b.height
+        };
+    }
+
+    /**
+     * Returns the center point of the bounds of an object
+     * @param {Bounds} b - Bounds object
+     * @returns {Point} the center point
+     */
+    export function center(b: Bounds): Point {
+        return {
+            x: b.x + (b.width >= 0 ? 0.5 * b.width : 0),
+            y: b.y + (b.height >= 0 ? 0.5 * b.height : 0)
+        };
+    }
+
+    /**
+    * Checks whether the point p is included in the bounds b.
+    */
+    export function includes(b: Bounds, p: Point): boolean {
+        return p.x >= b.x && p.x <= b.x + b.width && p.y >= b.y && p.y <= b.y + b.height;
+    }
+}
+
+/**
+ * Converts from radians to degrees
+ * @param {number} a - A value in radians
+ * @returns {number} The converted value
+ */
+export function toDegrees(a: number): number {
+    return a * 180 / Math.PI;
+}
+
+/**
+ * Converts from degrees to radians
+ * @param {number} a - A value in degrees
+ * @returns {number} The converted value
+ */
+export function toRadians(a: number): number {
+    return a * Math.PI / 180;
+}
+
+/**
+ * Returns whether two numbers are almost equal, within a small margin (0.001)
+ * @param {number} a - First number
+ * @param {number} b - Second number
+ * @returns {boolean} True if the two numbers are almost equal
+ */
+export function almostEquals(a: number, b: number): boolean {
+    return Math.abs(a - b) < 1e-3;
+}

--- a/packages/sprotty-protocol/src/utils/json.ts
+++ b/packages/sprotty-protocol/src/utils/json.ts
@@ -1,0 +1,25 @@
+/********************************************************************************
+ * Copyright (c) 2020-2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export type JsonAny =  JsonPrimitive | JsonMap | JsonArray | null;
+
+export type JsonPrimitive = string | number | boolean;
+
+export interface JsonMap {
+    [key: string]: JsonAny;
+}
+
+export type JsonArray = Array<JsonAny>;

--- a/packages/sprotty-protocol/src/utils/model-utils.ts
+++ b/packages/sprotty-protocol/src/utils/model-utils.ts
@@ -1,0 +1,116 @@
+/********************************************************************************
+ * Copyright (c) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Alignable, BoundsAware, SModelElement, SModelRoot } from '../model';
+import { ComputedBoundsAction } from '../actions';
+
+/**
+ * Clone a given model. This function requires that the model is serializable, so it's
+ * free of cycles and functions.
+ */
+export function cloneModel<T extends SModelElement>(model: T): T {
+    return JSON.parse(JSON.stringify(model));
+}
+
+/**
+ * Apply the computed bounds to the given model. This ensures that the model has complete
+ * information about positions and sizes derived from its actual rendering in the frontend.
+ */
+export function applyBounds(root: SModelRoot, action: ComputedBoundsAction) {
+    const index = new SModelIndex();
+    index.add(root);
+    for (const b of action.bounds) {
+        const element = index.getById(b.elementId);
+        if (element) {
+            const bae = element as SModelElement & BoundsAware;
+            if (b.newPosition) {
+                bae.position = { x: b.newPosition.x, y: b.newPosition.y };
+            }
+            if (b.newSize) {
+                bae.size = { width: b.newSize.width, height: b.newSize.height };
+            }
+        }
+    }
+    if (action.alignments) {
+        for (const a of action.alignments) {
+            const element = index.getById(a.elementId);
+            if (element) {
+                const alignable = element as SModelElement & Alignable;
+                alignable.alignment = { x: a.newAlignment.x, y: a.newAlignment.y };
+            }
+        }
+    }
+}
+
+/**
+ * Used to speed up model element lookup by id.
+ * This index implementation is for the serializable _external model_ defined in `sprotty-protocol`.
+ */
+export class SModelIndex {
+
+    private readonly id2element: Map<string, SModelElement> = new Map();
+    private id2parent: Map<string, SModelElement> = new Map();
+
+    add(element: SModelElement): void {
+        if (!element.id) {
+            throw new Error("Model element has no ID.");
+        } else if (this.contains(element)) {
+            throw new Error("Duplicate ID in model: " + element.id);
+        }
+        this.id2element.set(element.id, element);
+        if (Array.isArray(element.children)) {
+            for (const child of element.children) {
+                this.add(child as any);
+                this.id2parent.set(child.id, element);
+            }
+        }
+    }
+
+    remove(element: SModelElement): void {
+        this.id2element.delete(element.id);
+        if (Array.isArray(element.children)) {
+            for (const child of element.children) {
+                this.id2parent.delete(child.id);
+                this.remove(child as any);
+            }
+        }
+    }
+
+    contains(element: SModelElement): boolean {
+        return this.id2element.has(element.id);
+    }
+
+    getById(id: string): SModelElement | undefined {
+        return this.id2element.get(id);
+    }
+
+    getParent(id: string): SModelElement | undefined {
+        return this.id2parent.get(id);
+    }
+
+    getRoot(element: SModelElement): SModelRoot {
+        let current: SModelElement | undefined = element;
+        while (current) {
+            const parent = this.id2parent.get(current.id);
+            if (parent === undefined) {
+                return current;
+            }
+            current = parent;
+        }
+        throw new Error("Element has no root");
+    }
+
+}

--- a/packages/sprotty-protocol/src/utils/object.ts
+++ b/packages/sprotty-protocol/src/utils/object.ts
@@ -1,0 +1,62 @@
+/********************************************************************************
+ * Copyright (c) 2017-2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export function isObject(data: unknown): data is Record<PropertyKey, unknown> {
+    return typeof data === 'object' && data !== null;
+}
+
+export type TypeOf<T> =
+    T extends number ? 'number'
+    : T extends string ? 'string'
+    : T extends boolean ? 'boolean'
+    : T extends bigint ? 'bigint'
+    : T extends symbol ? 'symbol'
+    : T extends Function ? 'function'
+    : T extends object ? 'object'
+    : 'undefined';
+
+export function hasOwnProperty<K extends PropertyKey, T>(arg: unknown, key: K | K[], type?: TypeOf<T> | ((v: unknown) => v is T)): arg is Record<K, T> {
+    if (!isObject(arg)) {
+        return false;
+    }
+    if (Array.isArray(key)) {
+        for (const k of key) {
+            if (!Object.prototype.hasOwnProperty.call(arg, k)) {
+                return false;
+            }
+            if (typeof type === 'string' && typeof arg[k] !== type) {
+                return false;
+            } else if (typeof type === 'function' && !type(arg[k])) {
+                return false;
+            }
+        }
+    } else {
+        if (!Object.prototype.hasOwnProperty.call(arg, key)) {
+            return false;
+        }
+        if (typeof type === 'string') {
+            return typeof arg[key] === type;
+        }
+        if (typeof type === 'function') {
+            return type(arg[key]);
+        }
+    }
+    return true;
+}
+
+export function safeAssign<T>(target: T, partial: Partial<T>): T {
+    return Object.assign(target, partial);
+}

--- a/packages/sprotty-protocol/tsconfig.json
+++ b/packages/sprotty-protocol/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../configs/base.tsconfig.json",
+  "compilerOptions": {
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "**/*.spec.ts", "**/*.spec.tsx"
+  ]
+}

--- a/packages/sprotty/CHANGELOG.md
+++ b/packages/sprotty/CHANGELOG.md
@@ -2,25 +2,29 @@
 
 This change log covers only the client part of Sprotty. See also the change logs of [sprotty-server](https://github.com/eclipse/sprotty-server/blob/master/CHANGELOG.md), [sprotty-theia](https://github.com/eclipse/sprotty-theia/blob/master/CHANGELOG.md) and [sprotty-layout](https://github.com/eclipse/sprotty-layout/blob/master/CHANGELOG.md).
 
+### v0.11.0 (Nov. 2020)
+
+This version introduces a dependency to the new package `sprotty-protocol`. Many definitions have been copied to the new package and the original definitions are marked as deprecated, so you need to update your imports to stay compatible with future versions.
+
+Breaking API changes:
+ * Actions are consistently declared as interfaces, not as classes, to emphasize that they must be serializable to enable transfer between client and server. Instead of a constructor, use the `create` function defined in the namespace with the same name as the corresponding action interface.
+ * `SModelIndex` was renamed to `ModelIndexImpl` and is usable only for the internal model that is used for rendering. If you want to apply an index to an external model (defined via `sprotty-protocol`), you should use the new `SModelIndex` from `sprotty-protocol` instead.
+ * A few geometry functions were moved into namespaces in order to clarify their meaning.
+
+-----
+
 ### v0.10.0 (Oct. 2021)
 
 New features:
-
  * Line jumps (`JumpingPolylineEdgeView`) or gaps (`PolylineEdgeViewWithGapsOnIntersections`) to visually clarify intersecting edges ([#226](https://github.com/eclipse/sprotty/pull/226))
-
  * `TYPES.IEdgeRoutePostprocessor` can be registered to analyse and/or change computed routes ([#226](https://github.com/eclipse/sprotty/pull/226))
-
  * `EdgeRouterRegistry` can route all edges contained in a parent element at once. These pre-computed routes are then added to the `args` that are passed on to the views. This allows `IView` and `IEdgeRoutePostprocessor` implementations to consider all computed routes before the routed edges have been rendered. ([#226](https://github.com/eclipse/sprotty/pull/226))
-
  * Added "projection bars" that can serve as scroll bars and display horizontal / vertical projections of model elements. Use `ProjectedViewportView` as root element view to enable this feature. ([#240](https://github.com/eclipse/sprotty/pull/240))
-
  * Added support for Codicons ([#248](https://github.com/eclipse/sprotty/issues/248))
 
 Breaking API changes:
-
  * It is recommended that implementations of the `IView` for `SGraph` instances compute the routes of its children with `edgeRouterRegistry.routeAllChildren(model)` and pass on the routes as arguments to its child views. See implementation of `SGraphView` ([#226](https://github.com/eclipse/sprotty/pull/226))
-
-* Upgrade to snabbdom 3.0.3. The imports of snabbdom functions have changed. The main snabbdom package exports all of the public API.This means consumers of the snabbdom package need to update their imports.
+ * Upgrade to snabbdom 3.0.3. The imports of snabbdom functions have changed. The main snabbdom package exports all of the public API.This means consumers of the snabbdom package need to update their imports.
 
 before
 
@@ -35,7 +39,7 @@ after
 import { h, VNode } from 'snabbdom'
 ```
 
-* snabbdom now supports jsx, so snabbdom-jsx has been removed. On the other hand, to maintain the ability to treat attribute prefixes as data keys, it is used via a wrapper called lib/jsx.
+ * snabbdom now supports jsx, so snabbdom-jsx has been removed. On the other hand, to maintain the ability to treat attribute prefixes as data keys, it is used via a wrapper called lib/jsx.
 
 before
 
@@ -51,7 +55,7 @@ after
 import { svg } from 'sprotty';
 ```
 
-* The `on` function API of `vnode-utils` has been changed due to the API change of snabbdom's event listner. Listners must `bind` elements. (see https://github.com/snabbdom/snabbdom/issues/802)
+ * The `on` function API of `vnode-utils` has been changed due to the API change of Snabbdom's event listener. Listeners must `bind` elements. (see [snabbdom#802](https://github.com/snabbdom/snabbdom/issues/802))
 
 Fixed issues: https://github.com/eclipse/sprotty/milestone/5?closed=1
 
@@ -72,14 +76,14 @@ Fixed issues: https://github.com/eclipse/sprotty/milestone/4?closed=1
 New features:
  * CenterAction retains zoom level ([#138](https://github.com/eclipse/sprotty/pull/138))
  * Cycling through command palettes ([#141](https://github.com/eclipse/sprotty/pull/141))
- * Context menus ([#139](https://github.com/eclipse/sprotty/pull/139)[#144](https://github.com/eclipse/sprotty/pull/144)) 
+ * Context menus ([#139](https://github.com/eclipse/sprotty/pull/139)[#144](https://github.com/eclipse/sprotty/pull/144))
  * Use element subtype as css style ([#145](https://github.com/eclipse/sprotty/pull/145))
  * Improve loading indicator of command palette ([#148](https://github.com/eclipse/sprotty/pull/148), [#151](https://github.com/eclipse/sprotty/pull/151))
- * Reset previous hover feedback on mouseover ([#153](https://github.com/eclipse/sprotty/pull/153)) 
- * Edge changes are animated ([#158](https://github.com/eclipse/sprotty/pull/158)) 
+ * Reset previous hover feedback on mouseover ([#153](https://github.com/eclipse/sprotty/pull/153))
+ * Edge changes are animated ([#158](https://github.com/eclipse/sprotty/pull/158))
  * Fix scrolling on all browsers ([#163](https://github.com/eclipse/sprotty/pull/163))
  * Multi-line Label editing and ForeignObjects ([#171](https://github.com/eclipse/sprotty/pull/171), [#173](https://github.com/eclipse/sprotty/pull/173))
- 
+
 Fixed issues: https://github.com/eclipse/sprotty/milestone/3?closed=1
 
 Breaking API changes:

--- a/packages/sprotty/package.json
+++ b/packages/sprotty/package.json
@@ -28,7 +28,7 @@
     {
       "name": "Jan Köhnlein",
       "email": "jan.koehnlein@typefox.io",
-      "url": "http://typefox.io"
+      "url": "https://www.typefox.io"
     },
     {
       "name": "Philip Langer",
@@ -43,7 +43,7 @@
     {
       "name": "Miro Spönemann",
       "email": "miro.spoenemann@typefox.io",
-      "url": "http://typefox.io"
+      "url": "https://www.typefox.io"
     }
   ],
   "repository": {
@@ -57,6 +57,7 @@
     "file-saver": "^2.0.2",
     "inversify": "^5.0.1",
     "snabbdom": "^3.0.3",
+    "sprotty-protocol": "0.10.0",
     "tinyqueue": "^2.0.3"
   },
   "devDependencies": {
@@ -89,7 +90,7 @@
     "watch": "tsc -w -p ./tsconfig.json",
     "lint": "eslint -c ../../configs/.eslintrc.js \"src/**/!(*.spec.ts*|test-helper.ts)\"",
     "test:cli": "ts-mocha \"./src/**/*.spec.?(ts|tsx)\"",
-    "test": "jenkins-mocha --opts ../../configs/mocha.opts \"./src/**/*.spec.?(ts|tsx)\"",
+    "test": "jenkins-mocha --config ../../configs/.mocharc.json \"./src/**/*.spec.?(ts|tsx)\"",
     "prepublishOnly": "yarn run test",
     "publish:next": "yarn publish --new-version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" --tag next",
     "publish:latest": "yarn publish --tag latest"

--- a/packages/sprotty/src/base/actions/action-dispatcher.ts
+++ b/packages/sprotty/src/base/actions/action-dispatcher.ts
@@ -15,15 +15,14 @@
  ********************************************************************************/
 
 import { inject, injectable } from "inversify";
+import { Action, isAction, isRequestAction, isResponseAction, RejectAction, RequestAction, ResponseAction, SetModelAction } from "sprotty-protocol/lib/actions";
+import { Deferred } from "sprotty-protocol/lib/utils/async";
 import { TYPES } from "../types";
 import { ILogger } from "../../utils/logging";
-import { Deferred } from "../../utils/async";
 import { EMPTY_ROOT } from '../model/smodel-factory';
 import { ICommandStack } from "../commands/command-stack";
 import { AnimationFrameSyncer } from "../animations/animation-frame-syncer";
-import { SetModelAction } from '../features/set-model';
 import { RedoAction, UndoAction } from "../../features/undo-redo/undo-redo";
-import { Action, isAction, RequestAction, ResponseAction, isResponseAction, RejectAction, isRequestAction } from './action';
 import { ActionHandlerRegistry } from "./action-handler";
 import { IDiagramLocker } from "./diagram-locker";
 
@@ -57,7 +56,7 @@ export class ActionDispatcher implements IActionDispatcher {
         if (!this.initialized) {
             this.initialized = this.actionHandlerRegistryProvider().then(registry => {
                 this.actionHandlerRegistry = registry;
-                this.handleAction(new SetModelAction(EMPTY_ROOT)).catch(() => { /* Logged in handleAction method */ });
+                this.handleAction(SetModelAction.create(EMPTY_ROOT)).catch(() => { /* Logged in handleAction method */ });
             });
         }
         return this.initialized;

--- a/packages/sprotty/src/base/actions/action.ts
+++ b/packages/sprotty/src/base/actions/action.ts
@@ -14,18 +14,24 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { JsonAny } from '../../utils/json';
-import { hasOwnProperty } from '../../utils/object';
+import { generateRequestId as generateRequestId2 } from 'sprotty-protocol/lib/actions';
+import { JsonAny } from 'sprotty-protocol/lib/utils/json';
+import { hasOwnProperty } from 'sprotty-protocol/lib/utils/object';
 
 /**
  * An action describes a change to the model declaratively.
  * It is a plain data structure, and as such transferable between server and client. An action must never contain actual
  * SModelElement instances, but either refer to them via their ids or contain serializable schema for model elements.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export interface Action {
     readonly kind: string
 }
 
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
 export function isAction(object?: unknown): object is Action {
     return hasOwnProperty<string, string>(object, 'kind', 'string');
 }
@@ -33,32 +39,41 @@ export function isAction(object?: unknown): object is Action {
 /**
  * A request action is tied to the expectation of receiving a corresponding response action.
  * The `requestId` property is used to match the received response with the original request.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export interface RequestAction<Res extends ResponseAction> extends Action {
     readonly requestId: string
 }
 
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
 export function isRequestAction(object?: unknown): object is RequestAction<ResponseAction> {
     return isAction(object) && hasOwnProperty<string, string>(object, 'requestId', 'string');
 }
 
-let nextRequestId = 1;
 /**
  * Generate a unique `requestId` for a request action.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
-export function generateRequestId(): string {
-    return (nextRequestId++).toString();
-}
+export const generateRequestId: () => string = generateRequestId2;
 
 /**
  * A response action is sent to respond to a request action. The `responseId` must match
  * the `requestId` of the preceding request. In case the `responseId` is empty or undefined,
  * the action is handled as standalone, i.e. it was fired without a preceding request.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export interface ResponseAction extends Action {
     readonly responseId: string
 }
 
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
 export function isResponseAction(object?: unknown): object is ResponseAction {
     return isAction(object) && hasOwnProperty<string, string>(object, 'responseId', 'string')
             && object.responseId !== '';
@@ -66,6 +81,8 @@ export function isResponseAction(object?: unknown): object is ResponseAction {
 
 /**
  * A reject action is fired to indicate that a request must be rejected.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export class RejectAction implements ResponseAction {
     static readonly KIND = 'rejectRequest';

--- a/packages/sprotty/src/base/actions/diagram-locker.ts
+++ b/packages/sprotty/src/base/actions/diagram-locker.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { injectable } from "inversify";
-import { Action } from "./action";
+import { Action } from "sprotty-protocol/lib/actions";
 
 /**
  * Allows to lock the diagram by preventing certain actions from being

--- a/packages/sprotty/src/base/commands/command-registration.ts
+++ b/packages/sprotty/src/base/commands/command-registration.ts
@@ -14,10 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Action } from "../actions/action";
-import { ActionHandlerRegistry, IActionHandler, IActionHandlerInitializer } from "../actions/action-handler";
 import { injectable, multiInject, optional, interfaces, Container } from "inversify";
+import { Action } from "sprotty-protocol/lib/actions";
 import { isInjectable } from "../../utils/inversify";
+import { ActionHandlerRegistry, IActionHandler, IActionHandlerInitializer } from "../actions/action-handler";
 import { ICommand } from "./command";
 import { TYPES } from "../types";
 

--- a/packages/sprotty/src/base/commands/command-stack-options.ts
+++ b/packages/sprotty/src/base/commands/command-stack-options.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { Container } from "inversify";
-import { safeAssign } from "../../utils/object";
+import { safeAssign } from "sprotty-protocol/lib/utils/object";
 import { TYPES } from '../types';
 
 /**

--- a/packages/sprotty/src/base/commands/command-stack.ts
+++ b/packages/sprotty/src/base/commands/command-stack.ts
@@ -15,11 +15,11 @@
  ********************************************************************************/
 
 import { inject, injectable, postConstruct } from "inversify";
+import { Action } from "sprotty-protocol/lib/actions";
 import { TYPES } from "../types";
 import { ILogger } from "../../utils/logging";
 import { EMPTY_ROOT, IModelFactory } from "../model/smodel-factory";
 import { SModelRoot } from "../model/smodel";
-import { Action } from "../actions/action";
 import { AnimationFrameSyncer } from "../animations/animation-frame-syncer";
 import { IViewer, IViewerProvider } from "../views/viewer";
 import { CommandStackOptions } from './command-stack-options';

--- a/packages/sprotty/src/base/commands/command.ts
+++ b/packages/sprotty/src/base/commands/command.ts
@@ -15,8 +15,8 @@
  ********************************************************************************/
 
 import { injectable } from "inversify";
+import { Action } from "sprotty-protocol/lib/actions";
 import { ILogger } from "../../utils/logging";
-import { Action } from "../actions/action";
 import { AnimationFrameSyncer } from "../animations/animation-frame-syncer";
 import { SModelRoot } from "../model/smodel";
 import { IModelFactory } from "../model/smodel-factory";

--- a/packages/sprotty/src/base/commands/request-command.ts
+++ b/packages/sprotty/src/base/commands/request-command.ts
@@ -15,9 +15,9 @@
  ********************************************************************************/
 
 import { injectable, inject } from "inversify";
+import { ResponseAction } from "sprotty-protocol/lib/actions";
 import { TYPES } from "../types";
 import { SystemCommand, CommandExecutionContext, CommandReturn } from "./command";
-import { ResponseAction } from "../actions/action";
 import { IActionDispatcher } from "../actions/action-dispatcher";
 
 /**

--- a/packages/sprotty/src/base/features/initialize-canvas.spec.ts
+++ b/packages/sprotty/src/base/features/initialize-canvas.spec.ts
@@ -32,7 +32,7 @@ describe('InitializeCanvasBoundsCommand', () => {
     };
 
     const root = new SModelRoot();
-    const command = new InitializeCanvasBoundsCommand(new InitializeCanvasBoundsAction(bounds));
+    const command = new InitializeCanvasBoundsCommand(InitializeCanvasBoundsAction.create(bounds));
 
     const context: CommandExecutionContext = {
         root: root,

--- a/packages/sprotty/src/base/features/set-model.ts
+++ b/packages/sprotty/src/base/features/set-model.ts
@@ -15,10 +15,11 @@
  ********************************************************************************/
 
 import { inject, injectable } from "inversify";
-import { JsonPrimitive } from '../../utils/json';
-import { Action, RequestAction, ResponseAction, generateRequestId } from "../actions/action";
+import { Action, generateRequestId, RequestAction, ResponseAction } from "sprotty-protocol/lib/actions";
+import { SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
+import { JsonPrimitive } from "sprotty-protocol/lib/utils/json";
 import { CommandExecutionContext, ResetCommand } from "../commands/command";
-import { SModelRoot, SModelRootSchema } from "../model/smodel";
+import { SModelRoot } from "../model/smodel";
 import { TYPES } from "../types";
 import { InitializeCanvasBoundsCommand } from './initialize-canvas';
 
@@ -26,6 +27,8 @@ import { InitializeCanvasBoundsCommand } from './initialize-canvas';
  * Sent from the client to the model source (e.g. a DiagramServer) in order to request a model. Usually this
  * is the first message that is sent to the source, so it is also used to initiate the communication.
  * The response is a SetModelAction or an UpdateModelAction.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export class RequestModelAction implements RequestAction<SetModelAction> {
     static readonly KIND = 'requestModel';
@@ -42,6 +45,8 @@ export class RequestModelAction implements RequestAction<SetModelAction> {
 
 /**
  * Sent from the model source to the client in order to set the model. If a model is already present, it is replaced.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export class SetModelAction implements ResponseAction {
     static readonly KIND = 'setModel';

--- a/packages/sprotty/src/base/model/smodel-factory.spec.ts
+++ b/packages/sprotty/src/base/model/smodel-factory.spec.ts
@@ -19,7 +19,7 @@ import 'mocha';
 import { expect } from "chai";
 import { Container } from 'inversify';
 import { TYPES } from '../types';
-import { SModelElementSchema, SModelIndex, SChildElement } from './smodel';
+import { SModelElementSchema, ModelIndexImpl, SChildElement } from './smodel';
 import { SModelFactory } from "./smodel-factory";
 import { registerModelElement } from './smodel-utils';
 import { selectFeature, Selectable } from '../../features/select/model';
@@ -123,7 +123,7 @@ describe('model factory', () => {
         expect(element1.parent).to.equal(root);
         expect(element1.children).to.deep.equal([]);
         expect(element1.root).to.equal(root);
-        expect(root.index).to.be.instanceOf(SModelIndex);
+        expect(root.index).to.be.instanceOf(ModelIndexImpl);
     });
 
     it('gets default features for registered element', () => {

--- a/packages/sprotty/src/base/model/smodel-factory.ts
+++ b/packages/sprotty/src/base/model/smodel-factory.ts
@@ -15,12 +15,10 @@
  ********************************************************************************/
 
 import { injectable, multiInject, optional, inject } from 'inversify';
+import { SModelElement as SModelElementSchema, SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
 import { TYPES } from "../types";
 import { FactoryRegistry } from '../../utils/registry';
-import {
-    SChildElement, SModelElement, SModelElementSchema, SModelRoot, SModelRootSchema, SParentElement,
-    isParent, FeatureSet
-} from './smodel';
+import { SChildElement, SModelElement, SModelRoot, SParentElement, isParent, FeatureSet } from './smodel';
 
 /**
  * A model factory transforms a serializable model schema into the model representation that is used

--- a/packages/sprotty/src/base/model/smodel-utils.ts
+++ b/packages/sprotty/src/base/model/smodel-utils.ts
@@ -15,9 +15,10 @@
  ********************************************************************************/
 
 import { interfaces } from "inversify";
+import { SModelElement as SModelElementSchema } from 'sprotty-protocol/lib/model';
+import { Bounds, Point } from "sprotty-protocol/lib/utils/geometry";
 import { TYPES } from "../types";
-import { Point, Bounds } from "../../utils/geometry";
-import { SChildElement, SModelElement, SModelElementSchema, SModelRoot } from "./smodel";
+import { SChildElement, SModelElement, SModelRoot } from "./smodel";
 import { SModelElementRegistration, CustomFeatures } from "./smodel-factory";
 
 /**

--- a/packages/sprotty/src/base/model/smodel.spec.ts
+++ b/packages/sprotty/src/base/model/smodel.spec.ts
@@ -16,7 +16,7 @@
 
 import "mocha";
 import { expect } from "chai";
-import { SChildElement, SModelIndex, SModelRoot, SModelElement, SModelElementSchema, SModelRootSchema } from './smodel';
+import { SChildElement, ModelIndexImpl, SModelRoot } from './smodel';
 
 describe('SModelRoot', () => {
     function setup() {
@@ -60,9 +60,9 @@ describe('SModelRoot', () => {
     });
 });
 
-describe('SModelIndex', () => {
+describe('ModelIndexImpl', () => {
     function setup() {
-        const index = new SModelIndex<SModelElement>();
+        const index = new ModelIndexImpl();
         const child1 = new SChildElement();
         child1.id = 'child1';
         index.add(child1);
@@ -83,77 +83,5 @@ describe('SModelIndex', () => {
         ctx.index.remove(ctx.child2);
         expect(ctx.index.contains(ctx.child2)).to.be.false;
         expect(ctx.index.getById('child2')).to.be.undefined;
-    });
-
-    it('returns the parent element for an internal model', () => {
-        const index = new SModelIndex<SModelElement>();
-        const root = new SModelRoot(index);
-        const parent = new SChildElement();
-        parent.id = 'parent';
-        root.add(parent);
-        const child = new SChildElement();
-        child.id = 'child';
-        parent.add(child);
-        expect((index as any).id2parent).to.be.undefined;
-        expect(index.getParent(child.id)!.id).to.equal('parent');
-    });
-
-    it('returns the root element for an internal model', () => {
-        const index = new SModelIndex<SModelElement>();
-        const root = new SModelRoot(index);
-        root.id = 'root';
-        const parent = new SChildElement();
-        parent.id = 'parent';
-        root.add(parent);
-        const child = new SChildElement();
-        child.id = 'child';
-        parent.add(child);
-        expect((index as any).id2parent).to.be.undefined;
-        expect(index.getRoot(child).id).to.equal('root');
-    });
-
-    it('returns the parent element for an external model', () => {
-        const index = new SModelIndex<SModelElementSchema>();
-        const root: SModelRootSchema = {
-            type: 'root',
-            id: 'root',
-            children: [
-                {
-                    type: 'node',
-                    id: 'parent',
-                    children: [
-                        {
-                            type: 'node',
-                            id: 'child'
-                        }
-                    ]
-                }
-            ]
-        };
-        index.add(root);
-        expect(index.getParent('child')!.id).to.equal('parent');
-    });
-
-    it('returns the root element for an external model', () => {
-        const index = new SModelIndex<SModelElementSchema>();
-        const root: SModelRootSchema = {
-            type: 'root',
-            id: 'root',
-            children: [
-                {
-                    type: 'node',
-                    id: 'parent',
-                    children: [
-                        {
-                            type: 'node',
-                            id: 'child'
-                        }
-                    ]
-                }
-            ]
-        };
-        index.add(root);
-        const child = root.children![0].children![0];
-        expect(index.getRoot(child).id).to.equal('root');
     });
 });

--- a/packages/sprotty/src/base/tool-manager/tool-manager.ts
+++ b/packages/sprotty/src/base/tool-manager/tool-manager.ts
@@ -14,10 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { inject, injectable } from "inversify";
+import { Action } from "sprotty-protocol/lib/actions";
 import { TYPES } from "../types";
 import { EnableDefaultToolsAction, EnableToolsAction, Tool } from "./tool";
 import { IActionHandler } from "../actions/action-handler";
-import { Action } from "../actions/action";
 import { ICommand } from "../commands/command";
 import { KeyListener } from "../views/key-tool";
 import { SModelElement } from "../model/smodel";
@@ -139,7 +139,7 @@ export class ToolManagerActionHandler implements IActionHandler {
 export class DefaultToolsEnablingKeyListener extends KeyListener {
     keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
         if (matchesKeystroke(event, 'Escape')) {
-            return [new EnableDefaultToolsAction()];
+            return [EnableDefaultToolsAction.create()];
         }
         return [];
     }

--- a/packages/sprotty/src/base/tool-manager/tool.ts
+++ b/packages/sprotty/src/base/tool-manager/tool.ts
@@ -13,23 +13,41 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Action } from "../actions/action";
+
+import { Action } from "sprotty-protocol/lib/actions";
 
 /**
  * Action to enable the tools of the specified `toolIds`.
  */
-export class EnableToolsAction implements Action {
-    static KIND = "enable-tools";
-    readonly kind = EnableToolsAction.KIND;
-    constructor(public readonly toolIds: string[]) { }
+export interface EnableToolsAction extends Action {
+    kind: typeof EnableToolsAction.KIND
+    toolIds: string[]
+}
+export namespace EnableToolsAction {
+    export const KIND = "enable-tools";
+
+    export function create(toolIds: string[]): EnableToolsAction {
+        return {
+            kind: KIND,
+            toolIds
+        };
+    }
 }
 
 /**
  * Action to disable the currently active tools and enable the default tools instead.
  */
-export class EnableDefaultToolsAction implements Action {
-    static KIND = "enable-default-tools";
-    readonly kind = EnableDefaultToolsAction.KIND;
+export interface EnableDefaultToolsAction extends Action {
+    kind: typeof EnableDefaultToolsAction.KIND;
+}
+export namespace EnableDefaultToolsAction {
+    export const KIND = "enable-default-tools";
+
+    export function create(): EnableDefaultToolsAction {
+        return {
+            kind: KIND
+        };
+    }
 }
 
 /** A tool that can be managed by a `ToolManager`. */

--- a/packages/sprotty/src/base/ui-extensions/ui-extension-registry.ts
+++ b/packages/sprotty/src/base/ui-extensions/ui-extension-registry.ts
@@ -14,8 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { inject, injectable, multiInject, optional } from "inversify";
+import { Action } from "sprotty-protocol/lib/actions";
 import { InstanceRegistry } from "../../utils/registry";
-import { Action } from "../actions/action";
 import { CommandExecutionContext, SystemCommand, CommandReturn } from "../commands/command";
 import { TYPES } from "../types";
 import { IUIExtension } from "./ui-extension";
@@ -34,13 +34,23 @@ export class UIExtensionRegistry extends InstanceRegistry<IUIExtension>  {
 /**
  * Action to set the visibility state of the UI extension with the specified `id`.
  */
-export class SetUIExtensionVisibilityAction implements Action {
-    static readonly KIND = "setUIExtensionVisibility";
-    readonly kind = SetUIExtensionVisibilityAction.KIND;
+export interface SetUIExtensionVisibilityAction extends Action {
+    kind: typeof SetUIExtensionVisibilityAction.KIND;
+    extensionId: string
+    visible: boolean
+    contextElementsId: string[]
+}
+export namespace SetUIExtensionVisibilityAction {
+    export const KIND = "setUIExtensionVisibility";
 
-    constructor(public readonly extensionId: string,
-                public readonly visible: boolean,
-                public readonly contextElementsId: string[] = []) {}
+    export function create(options: { extensionId: string, visible: boolean, contextElementsId?: string[] }): SetUIExtensionVisibilityAction {
+        return {
+            kind: KIND,
+            extensionId: options.extensionId,
+            visible: options.visible,
+            contextElementsId: options.contextElementsId ?? []
+        };
+    }
 }
 
 @injectable()

--- a/packages/sprotty/src/base/views/key-tool.ts
+++ b/packages/sprotty/src/base/views/key-tool.ts
@@ -16,10 +16,10 @@
 
 import { inject, injectable, multiInject, optional } from "inversify";
 import { VNode } from "snabbdom";
+import { Action } from "sprotty-protocol/lib/actions";
 import { TYPES } from "../types";
 import { IActionDispatcher } from "../actions/action-dispatcher";
 import { SModelElement, SModelRoot } from "../model/smodel";
-import { Action } from "../actions/action";
 import { IVNodePostprocessor } from "./vnode-postprocessor";
 import { on } from "./vnode-utils";
 

--- a/packages/sprotty/src/base/views/mouse-tool.ts
+++ b/packages/sprotty/src/base/views/mouse-tool.ts
@@ -16,14 +16,14 @@
 
 import { inject, injectable, multiInject, optional } from "inversify";
 import { VNode } from "snabbdom";
-import { Action, isAction } from "../actions/action";
+import { Action, isAction } from "sprotty-protocol/lib/actions";
+import { Point } from "sprotty-protocol/lib/utils/geometry";
 import { IActionDispatcher } from "../actions/action-dispatcher";
 import { SModelElement, SModelRoot } from "../model/smodel";
 import { TYPES } from "../types";
 import { DOMHelper } from "./dom-helper";
 import { IVNodePostprocessor } from "./vnode-postprocessor";
 import { on } from "./vnode-utils";
-import { Point } from "../../utils/geometry";
 
 @injectable()
 export class MouseTool implements IVNodePostprocessor {

--- a/packages/sprotty/src/base/views/view.tsx
+++ b/packages/sprotty/src/base/views/view.tsx
@@ -21,11 +21,11 @@ import { injectable, multiInject, optional, interfaces } from 'inversify';
 import { VNode } from 'snabbdom';
 import { TYPES } from '../types';
 import { InstanceRegistry } from '../../utils/registry';
-import { Point, ORIGIN_POINT } from '../../utils/geometry';
 import { isInjectable } from '../../utils/inversify';
 import { SModelElement, SModelRoot, SParentElement } from '../model/smodel';
 import { EMPTY_ROOT, CustomFeatures } from '../model/smodel-factory';
 import { registerModelElement } from '../model/smodel-utils';
+import { Point } from 'sprotty-protocol';
 
 /**
  * Arguments for `IView` rendering.
@@ -156,7 +156,7 @@ export class EmptyView implements IView {
 @injectable()
 export class MissingView implements IView {
     render(model: Readonly<SModelElement>, context: RenderingContext): VNode {
-        const position: Point = (model as any).position || ORIGIN_POINT;
+        const position: Point = (model as any).position || Point.ORIGIN;
         return <text class-sprotty-missing={true} x={position.x} y={position.y}>?{model.id}?</text>;
     }
 }

--- a/packages/sprotty/src/base/views/viewer-cache.ts
+++ b/packages/sprotty/src/base/views/viewer-cache.ts
@@ -15,9 +15,9 @@
  ********************************************************************************/
 
 import { inject, injectable } from "inversify";
+import { Action } from "sprotty-protocol/lib/actions";
 import { SModelRoot } from "../model/smodel";
 import { TYPES } from "../types";
-import { Action } from "../actions/action";
 import { AnimationFrameSyncer } from "../animations/animation-frame-syncer";
 import { IViewer } from "./viewer";
 

--- a/packages/sprotty/src/base/views/viewer-options.ts
+++ b/packages/sprotty/src/base/views/viewer-options.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { Container, interfaces } from "inversify";
-import { safeAssign } from "../../utils/object";
+import { safeAssign } from "sprotty-protocol/lib/utils/object";
 import { TYPES } from "../types";
 
 export interface ViewerOptions {

--- a/packages/sprotty/src/base/views/viewer.tsx
+++ b/packages/sprotty/src/base/views/viewer.tsx
@@ -17,10 +17,10 @@
 /** @jsx html */
 import { inject, injectable, multiInject, optional } from 'inversify';
 import { attributesModule, classModule, eventListenersModule, init, Module, propsModule, styleModule, VNode } from 'snabbdom';
+import { Action } from 'sprotty-protocol/lib/actions';
 import { html } from '../../lib/jsx'; // must be html here, as we're creating a div
 import { getWindowScroll } from '../../utils/browser';
 import { ILogger } from '../../utils/logging';
-import { Action } from '../actions/action';
 import { IActionDispatcher } from '../actions/action-dispatcher';
 import { InitializeCanvasBoundsAction } from '../features/initialize-canvas';
 import { SModelElement, SModelRoot, SParentElement } from '../model/smodel';
@@ -194,7 +194,7 @@ export class ModelViewer implements IViewer {
         const baseDiv = document.getElementById(this.options.baseDiv);
         if (baseDiv !== null) {
             const newBounds = this.getBoundsInPage(baseDiv as Element);
-            this.actiondispatcher.dispatch(new InitializeCanvasBoundsAction(newBounds));
+            this.actiondispatcher.dispatch(InitializeCanvasBoundsAction.create(newBounds));
         }
     }
 

--- a/packages/sprotty/src/base/views/vnode-postprocessor.ts
+++ b/packages/sprotty/src/base/views/vnode-postprocessor.ts
@@ -16,8 +16,8 @@
 
 import { injectable } from "inversify";
 import { VNode } from "snabbdom";
+import { Action } from "sprotty-protocol/lib/actions";
 import { SModelElement } from "../model/smodel";
-import { Action } from "../actions/action";
 import { setAttr } from "./vnode-utils";
 
 /**

--- a/packages/sprotty/src/features/bounds/abstract-layout.ts
+++ b/packages/sprotty/src/features/bounds/abstract-layout.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Bounds, EMPTY_BOUNDS, isValidDimension, Dimension, Point } from "../../utils/geometry";
+import { Bounds, Dimension, Point } from "sprotty-protocol/lib/utils/geometry";
 import { SParentElement, SModelElement, SChildElement } from "../../base/model/smodel";
 import { isLayoutContainer, isLayoutableChild, LayoutContainer, isBoundsAware } from "./model";
 import { ILayout, StatefulLayouter } from './layout';
@@ -73,14 +73,14 @@ export abstract class AbstractLayout<T extends AbstractLayoutOptions> implements
                 const bounds = currentContainer.bounds;
                 if (isLayoutContainer(currentContainer) && layoutOptions.resizeContainer)
                     layouter.log.error(currentContainer, 'Resizable container found while detecting fixed bounds');
-                if (isValidDimension(bounds))
+                if (Dimension.isValid(bounds))
                     return bounds;
             }
             if (currentContainer instanceof SChildElement) {
                 currentContainer = currentContainer.parent;
             } else {
                 layouter.log.error(currentContainer, 'Cannot detect fixed bounds');
-                return EMPTY_BOUNDS;
+                return Bounds.EMPTY;
             }
         }
     }
@@ -103,7 +103,7 @@ export abstract class AbstractLayout<T extends AbstractLayoutOptions> implements
                     const boundsData = layouter.getBoundsData(child);
                     const bounds = boundsData.bounds;
                     const childOptions = this.getChildLayoutOptions(child, containerOptions);
-                    if (bounds !== undefined && isValidDimension(bounds)) {
+                    if (bounds !== undefined && Dimension.isValid(bounds)) {
                         currentOffset = this.layoutChild(child, boundsData, bounds,
                             childOptions, containerOptions, currentOffset,
                             maxWidth, maxHeight);

--- a/packages/sprotty/src/features/bounds/bounds-manipulation.ts
+++ b/packages/sprotty/src/features/bounds/bounds-manipulation.ts
@@ -15,16 +15,19 @@
  ********************************************************************************/
 
 import { inject, injectable } from "inversify";
-import { Action, generateRequestId, RequestAction, ResponseAction } from "../../base/actions/action";
+import { Action, generateRequestId, RequestAction, ResponseAction } from 'sprotty-protocol/lib/actions';
+import { SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
+import { Bounds, Dimension, Point } from "sprotty-protocol/lib/utils/geometry";
 import { CommandExecutionContext, CommandResult, CommandReturn, HiddenCommand, SystemCommand } from "../../base/commands/command";
-import { SModelElement, SModelRootSchema } from "../../base/model/smodel";
+import { SModelElement } from "../../base/model/smodel";
 import { TYPES } from "../../base/types";
-import { Bounds, Dimension, Point } from "../../utils/geometry";
 import { Alignable, BoundsAware, isBoundsAware } from './model';
 
 /**
  * Sent from the model source (e.g. a DiagramServer) to the client to update the bounds of some
  * (or all) model elements.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export class SetBoundsAction implements Action {
     static readonly KIND: string  = 'setBounds';
@@ -39,6 +42,8 @@ export class SetBoundsAction implements Action {
  * rendered invisibly so the bounds can derived from the DOM. The response is a ComputedBoundsAction.
  * This hidden rendering round-trip is necessary if the client is responsible for parts of the layout
  * (see `needsClientLayout` viewer option).
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export class RequestBoundsAction implements RequestAction<ComputedBoundsAction> {
     static readonly KIND: string  = 'requestBounds';
@@ -59,6 +64,8 @@ export class RequestBoundsAction implements RequestAction<ComputedBoundsAction> 
  * the layout (see `needsServerLayout` viewer option), it can do so after applying the computed bounds
  * received with this action. Otherwise there is no need to send the computed bounds to the server,
  * so they can be processed locally by the client.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export class ComputedBoundsAction implements ResponseAction {
     static readonly KIND = 'computedBounds';
@@ -72,6 +79,8 @@ export class ComputedBoundsAction implements ResponseAction {
 
 /**
  * Associates new bounds with a model element, which is referenced via its id.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export interface ElementAndBounds {
     elementId: string
@@ -81,6 +90,8 @@ export interface ElementAndBounds {
 
 /**
  * Associates a new alignment with a model element, which is referenced via its id.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export interface ElementAndAlignment {
     elementId: string
@@ -89,6 +100,8 @@ export interface ElementAndAlignment {
 
 /**
  * Request a layout of the diagram or the selected elements only.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export class LayoutAction implements Action {
     static readonly KIND = 'layout';

--- a/packages/sprotty/src/features/bounds/hbox-layout.ts
+++ b/packages/sprotty/src/features/bounds/hbox-layout.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { injectable } from 'inversify';
-import { Bounds, Point, isValidDimension } from '../../utils/geometry';
+import { Bounds, Dimension, Point } from 'sprotty-protocol/lib/utils/geometry';
 import { SParentElement, SChildElement } from "../../base/model/smodel";
 import { AbstractLayout } from './abstract-layout';
 import { AbstractLayoutOptions, VAlignment } from './layout-options';
@@ -46,7 +46,7 @@ export class HBoxLayouter extends AbstractLayout<HBoxLayoutOptions> {
             child => {
                 if (isLayoutableChild(child)) {
                     const bounds = layouter.getBoundsData(child).bounds;
-                    if (bounds !== undefined && isValidDimension(bounds)) {
+                    if (bounds !== undefined && Dimension.isValid(bounds)) {
                         if (isFirst)
                             isFirst = false;
                         else

--- a/packages/sprotty/src/features/bounds/layout-options.ts
+++ b/packages/sprotty/src/features/bounds/layout-options.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { JsonMap } from '../../utils/json';
+import { JsonMap } from 'sprotty-protocol/lib/utils/json';
 
 export type HAlignment = 'left' | 'center' | 'right';
 

--- a/packages/sprotty/src/features/bounds/layout.ts
+++ b/packages/sprotty/src/features/bounds/layout.ts
@@ -15,10 +15,10 @@
  ********************************************************************************/
 
 import { inject, injectable, interfaces, multiInject, optional } from "inversify";
+import { Bounds } from "sprotty-protocol/lib/utils/geometry";
 import { TYPES } from "../../base/types";
 import { ILogger } from '../../utils/logging';
 import { InstanceRegistry } from "../../utils/registry";
-import { Bounds, EMPTY_BOUNDS } from "../../utils/geometry";
 import { SParentElement, SModelElement } from "../../base/model/smodel";
 import { isLayoutContainer, LayoutContainer } from "./model";
 import { BoundsData } from "./hidden-bounds-updater";
@@ -108,7 +108,7 @@ export class StatefulLayouter {
             return boundsData.bounds;
         } else {
             this.log.error(element, 'Layout failed');
-            return EMPTY_BOUNDS;
+            return Bounds.EMPTY;
         }
     }
 }

--- a/packages/sprotty/src/features/bounds/model.ts
+++ b/packages/sprotty/src/features/bounds/model.ts
@@ -14,14 +14,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { SChildElement, SModelElement, SModelElementSchema, SModelRoot, SParentElement } from "../../base/model/smodel";
+import { Bounds, Dimension, isBounds, Point } from "sprotty-protocol/lib/utils/geometry";
+import { SModelElement as SModelElementSchema } from 'sprotty-protocol/lib/model';
+import { SChildElement, SModelElement, SModelRoot, SParentElement } from "../../base/model/smodel";
 import { SModelExtension } from "../../base/model/smodel-extension";
 import { findParentByFeature } from '../../base/model/smodel-utils';
 import { DOMHelper } from "../../base/views/dom-helper";
 import { ViewerOptions } from "../../base/views/viewer-options";
-import {
-    Bounds, Dimension, EMPTY_BOUNDS, EMPTY_DIMENSION, includes, isBounds, ORIGIN_POINT, Point
-} from "../../utils/geometry";
 import { Locateable } from '../move/model';
 import { getWindowScroll } from "../../utils/browser";
 
@@ -32,6 +31,8 @@ export const alignFeature = Symbol('alignFeature');
 
 /**
  * Model elements that implement this interface have a position and a size.
+ * Note that this definition differs from the one in `sprotty-protocol` because this is
+ * used in the _internal model_, while the other is used in the _external model_.
  */
 export interface BoundsAware extends SModelExtension {
     bounds: Bounds
@@ -97,7 +98,7 @@ export function getAbsoluteBounds(element: SModelElement): Bounds {
         const canvasBounds = element.canvasBounds;
         return { x: 0, y: 0, width: canvasBounds.width, height: canvasBounds.height };
     } else {
-        return EMPTY_BOUNDS;
+        return Bounds.EMPTY;
     }
 }
 
@@ -147,7 +148,7 @@ export function findChildrenAtPosition(parent: SParentElement, point: Point): SM
 
 function doFindChildrenAtPosition(parent: SParentElement, point: Point, matches: SModelElement[]) {
     parent.children.forEach(child => {
-        if (isBoundsAware(child) && includes(child.bounds, point))
+        if (isBoundsAware(child) && Bounds.includes(child.bounds, point))
             matches.push(child);
         if (child instanceof SParentElement) {
             const newPoint = child.parentToLocal(point);
@@ -158,11 +159,12 @@ function doFindChildrenAtPosition(parent: SParentElement, point: Point, matches:
 
 /**
  * Serializable schema for SShapeElement.
+ *
+ * @deprecated Use `SShapeElement` from `sprotty-protocol` instead.
  */
 export interface SShapeElementSchema extends SModelElementSchema {
     position?: Point
     size?: Dimension
-    children?: SModelElementSchema[]
     layoutOptions?: ModelLayoutOptions
 }
 
@@ -170,8 +172,8 @@ export interface SShapeElementSchema extends SModelElementSchema {
  * Abstract class for elements with a position and a size.
  */
 export abstract class SShapeElement extends SChildElement implements BoundsAware, Locateable, LayoutableChild {
-    position: Point = ORIGIN_POINT;
-    size: Dimension = EMPTY_DIMENSION;
+    position: Point = Point.ORIGIN;
+    size: Dimension = Dimension.EMPTY;
     layoutOptions?: ModelLayoutOptions;
 
     get bounds(): Bounds {

--- a/packages/sprotty/src/features/bounds/resize.ts
+++ b/packages/sprotty/src/features/bounds/resize.ts
@@ -14,11 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Dimension } from "sprotty-protocol/lib/utils/geometry";
 import { Animation } from "../../base/animations/animation";
 import { SModelRoot, SModelElement } from "../../base/model/smodel";
 import { CommandExecutionContext } from "../../base/commands/command";
 import { BoundsAware } from './model';
-import { Dimension } from '../../utils/geometry';
 
 export interface ResolvedElementResize {
     element: SModelElement & BoundsAware

--- a/packages/sprotty/src/features/bounds/stack-layout.ts
+++ b/packages/sprotty/src/features/bounds/stack-layout.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { injectable } from 'inversify';
-import { Bounds, Point, isValidDimension } from '../../utils/geometry';
+import { Bounds, Dimension, Point } from 'sprotty-protocol/lib/utils/geometry';
 import { SParentElement, SChildElement } from "../../base/model/smodel";
 import { AbstractLayout } from './abstract-layout';
 import { AbstractLayoutOptions, HAlignment, VAlignment } from './layout-options';
@@ -43,7 +43,7 @@ export class StackLayouter extends AbstractLayout<StackLayoutOptions> {
             child => {
                 if (isLayoutableChild(child)) {
                     const bounds = layouter.getBoundsData(child).bounds;
-                    if (bounds !== undefined && isValidDimension(bounds)) {
+                    if (bounds !== undefined && Dimension.isValid(bounds)) {
                         maxWidth = Math.max(maxWidth, bounds.width);
                         maxHeight = Math.max(maxHeight, bounds.height);
                     }

--- a/packages/sprotty/src/features/bounds/vbox-layout.ts
+++ b/packages/sprotty/src/features/bounds/vbox-layout.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { injectable } from 'inversify';
-import { Bounds, Point, isValidDimension } from '../../utils/geometry';
+import { Bounds, Dimension, Point } from 'sprotty-protocol/lib/utils/geometry';
 import { SParentElement, SChildElement } from "../../base/model/smodel";
 import { AbstractLayout } from './abstract-layout';
 import { AbstractLayoutOptions, HAlignment } from './layout-options';
@@ -46,7 +46,7 @@ export class VBoxLayouter extends AbstractLayout<VBoxLayoutOptions> {
             child => {
                 if (isLayoutableChild(child)) {
                     const bounds = layouter.getBoundsData(child).bounds;
-                    if (bounds !== undefined && isValidDimension(bounds)) {
+                    if (bounds !== undefined && Dimension.isValid(bounds)) {
                         maxHeight += bounds.height;
                         if (isFirst)
                             isFirst = false;

--- a/packages/sprotty/src/features/bounds/views.ts
+++ b/packages/sprotty/src/features/bounds/views.ts
@@ -16,7 +16,7 @@
 
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
-import { isValidDimension } from '../../utils/geometry';
+import { Dimension } from 'sprotty-protocol/lib/utils/geometry';
 import { IViewArgs, IView, RenderingContext } from '../../base/views/view';
 import { getAbsoluteBounds, BoundsAware } from './model';
 import { SChildElement } from '../../base/model/smodel';
@@ -34,7 +34,7 @@ export abstract class ShapeView implements IView {
             // Don't hide any element for hidden rendering
             return true;
         }
-        if (!isValidDimension(model.bounds)) {
+        if (!Dimension.isValid(model.bounds)) {
             // We should hide only if we know the element's bounds
             return true;
         }

--- a/packages/sprotty/src/features/button/button-handler.ts
+++ b/packages/sprotty/src/features/button/button-handler.ts
@@ -14,11 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { InstanceRegistry } from '../../utils/registry';
-import { SButton } from './model';
-import { Action } from '../../base/actions/action';
 import { injectable, multiInject, optional } from 'inversify';
+import { Action } from 'sprotty-protocol/lib/actions';
+import { InstanceRegistry } from '../../utils/registry';
 import { TYPES } from '../../base/types';
+import { SButton } from './model';
 
 export interface IButtonHandler {
     buttonPressed(button: SButton): Action[]

--- a/packages/sprotty/src/features/command-palette/action-providers.ts
+++ b/packages/sprotty/src/features/command-palette/action-providers.ts
@@ -13,16 +13,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+
 import { inject, injectable, multiInject, optional } from "inversify";
+import { CenterAction, SelectAction, SelectAllAction } from "sprotty-protocol/lib/actions";
+import { Point } from "sprotty-protocol/lib/utils/geometry";
 import { LabeledAction } from "../../base/actions/action";
 import { SModelRoot } from "../../base/model/smodel";
 import { TYPES } from "../../base/types";
 import { toArray } from "../../utils/iterable";
 import { ILogger } from "../../utils/logging";
 import { isNameable, name } from "../nameable/model";
-import { SelectAction, SelectAllAction } from "../select/select";
-import { CenterAction } from "../viewport/center-fit";
-import { Point } from "../../utils/geometry";
 
 export interface ICommandPaletteActionProvider {
     getActions(root: Readonly<SModelRoot>, text: string, lastMousePosition?: Point, index?: number): Promise<LabeledAction[]>;
@@ -49,12 +49,12 @@ export class RevealNamedElementActionProvider implements ICommandPaletteActionPr
         if (index !== undefined && index % 2 === 0)
             return Promise.resolve(this.createSelectActions(root));
         else
-            return Promise.resolve([new LabeledAction("Select all", [new SelectAllAction()])]);
+            return Promise.resolve([new LabeledAction("Select all", [SelectAllAction.create()])]);
     }
 
     createSelectActions(modelRoot: SModelRoot): LabeledAction[] {
         const nameables = toArray(modelRoot.index.all().filter(element => isNameable(element)));
         return nameables.map(nameable => new LabeledAction(`Reveal ${name(nameable)}`,
-            [new SelectAction([nameable.id]), new CenterAction([nameable.id])], 'eye'));
+            [SelectAction.create({ selectedElementsIDs: [nameable.id] }), CenterAction.create([nameable.id])], 'eye'));
     }
 }

--- a/packages/sprotty/src/features/command-palette/command-palette.ts
+++ b/packages/sprotty/src/features/command-palette/command-palette.ts
@@ -15,7 +15,8 @@
  ********************************************************************************/
 import { AutocompleteResult, AutocompleteSettings } from "autocompleter";
 import { inject, injectable } from "inversify";
-import { Action, isAction, LabeledAction, isLabeledAction } from "../../base/actions/action";
+import { Action, isAction } from 'sprotty-protocol/lib/actions';
+import { LabeledAction, isLabeledAction } from "../../base/actions/action";
 import { IActionDispatcherProvider } from "../../base/actions/action-dispatcher";
 import { SModelElement, SModelRoot } from "../../base/model/smodel";
 import { TYPES } from "../../base/types";
@@ -237,10 +238,10 @@ function espaceForRegExp(value: string): string {
 export class CommandPaletteKeyListener extends KeyListener {
     keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
         if (matchesKeystroke(event, 'Escape')) {
-            return [new SetUIExtensionVisibilityAction(CommandPalette.ID, false, [])];
+            return [SetUIExtensionVisibilityAction.create({ extensionId: CommandPalette.ID, visible: false, contextElementsId: [] })];
         } else if (CommandPalette.isInvokePaletteKey(event)) {
             const selectedElements = toArray(element.index.all().filter(e => isSelectable(e) && e.selected).map(e => e.id));
-            return [new SetUIExtensionVisibilityAction(CommandPalette.ID, true, selectedElements)];
+            return [SetUIExtensionVisibilityAction.create({ extensionId: CommandPalette.ID, visible: true, contextElementsId: selectedElements })];
         }
         return [];
     }

--- a/packages/sprotty/src/features/context-menu/menu-providers.ts
+++ b/packages/sprotty/src/features/context-menu/menu-providers.ts
@@ -13,11 +13,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { injectable, multiInject, optional } from "inversify";
 
+import { injectable, multiInject, optional } from "inversify";
+import { Point } from "sprotty-protocol/lib/utils/geometry";
 import { MenuItem } from "./context-menu-service";
 import { SModelRoot } from "../../base/model/smodel";
-import { Point } from "../../utils/geometry";
 import { LabeledAction } from "../../base/actions/action";
 import { TYPES } from "../../base/types";
 import { isDeletable, DeleteElementAction } from "../edit/delete";
@@ -74,7 +74,7 @@ export class DeleteContextMenuItemProvider implements IContextMenuItemProvider {
                 label: "Delete",
                 sortString: "d",
                 group: "edit",
-                actions: [new DeleteElementAction(selectedElements.map(e => e.id))],
+                actions: [DeleteElementAction.create(selectedElements.map(e => e.id))],
                 isEnabled: () => selectedElements.length > 0
             }
         ]);

--- a/packages/sprotty/src/features/context-menu/mouse-listener.ts
+++ b/packages/sprotty/src/features/context-menu/mouse-listener.ts
@@ -15,12 +15,12 @@
  ********************************************************************************/
 
 import { inject } from "inversify";
+import { Action } from "sprotty-protocol/lib/actions";
 import { IContextMenuServiceProvider, IContextMenuService } from "./context-menu-service";
 import { ContextMenuProviderRegistry } from "./menu-providers";
 import { MouseListener } from "../../base/views/mouse-tool";
 import { TYPES } from "../../base/types";
 import { SModelElement } from "../../base/model/smodel";
-import { Action } from "../../base/actions/action";
 import { isSelectable } from "../select/model";
 import { findParentByFeature } from "../../base/model/smodel-utils";
 

--- a/packages/sprotty/src/features/decoration/decoration-placer.ts
+++ b/packages/sprotty/src/features/decoration/decoration-placer.ts
@@ -20,10 +20,10 @@ import { SModelElement, SChildElement } from "../../base/model/smodel";
 import { IVNodePostprocessor } from "../../base/views/vnode-postprocessor";
 import { isDecoration, Decoration } from "./model";
 import { setAttr } from "../../base/views/vnode-utils";
-import { Point, ORIGIN_POINT } from "../../utils/geometry";
 import { isSizeable } from "../bounds/model";
 import { SRoutableElement } from "../routing/model";
 import { EdgeRouterRegistry } from "../routing/routing";
+import { Point } from "sprotty-protocol";
 
 @injectable()
 export class DecorationPlacer implements IVNodePostprocessor {
@@ -49,7 +49,7 @@ export class DecorationPlacer implements IVNodePostprocessor {
                         x: - 0.5 * element.bounds.width,
                         y: - 0.5 * element.bounds.width
                     }
-                    : ORIGIN_POINT;
+                    : Point.ORIGIN;
                 return {
                     x: 0.5 * (route[index].x + route[index + 1].x) + offset.x,
                     y: 0.5 * (route[index].y + route[index + 1].y) + offset.y
@@ -61,7 +61,7 @@ export class DecorationPlacer implements IVNodePostprocessor {
                 x: -0.666 * element.bounds.width,
                 y: -0.666 * element.bounds.height
             };
-        return ORIGIN_POINT;
+        return Point.ORIGIN;
     }
 
     postUpdate(): void {

--- a/packages/sprotty/src/features/edge-intersection/intersection-finder.ts
+++ b/packages/sprotty/src/features/edge-intersection/intersection-finder.ts
@@ -15,8 +15,8 @@
  ********************************************************************************/
 
 import { injectable } from "inversify";
+import { Point } from "sprotty-protocol/lib/utils/geometry";
 import TinyQueue from "tinyqueue";
-import { Point } from "../../utils/geometry";
 import { EdgeRouting, IEdgeRoutePostprocessor, RoutedPoint } from "../routing/routing";
 import { addRoute, checkWhichEventIsLeft, runSweep, SweepEvent } from "./sweepline";
 

--- a/packages/sprotty/src/features/edge-intersection/sweepline.ts
+++ b/packages/sprotty/src/features/edge-intersection/sweepline.ts
@@ -16,7 +16,8 @@
 // Based on the sweepline implementation at https://github.com/rowanwins/sweepline-intersections
 // which is published under the terms of MIT, but has been adapted to the use case of sprotty.
 import TinyQueue from "tinyqueue";
-import { Point, PointToPointLine } from "../../utils/geometry";
+import { Point } from "sprotty-protocol/lib/utils/geometry";
+import { PointToPointLine } from "../../utils/geometry";
 import { Intersection } from "./intersection-finder";
 import { RoutedPoint } from "../routing/routing";
 

--- a/packages/sprotty/src/features/edge-layout/edge-layout.ts
+++ b/packages/sprotty/src/features/edge-layout/edge-layout.ts
@@ -16,11 +16,12 @@
 
 import { injectable, inject } from "inversify";
 import { VNode } from "snabbdom";
+import { Bounds, Point, toDegrees } from "sprotty-protocol/lib/utils/geometry";
 import { SModelElement, SChildElement } from "../../base/model/smodel";
 import { IVNodePostprocessor } from "../../base/views/vnode-postprocessor";
 import { setAttr } from "../../base/views/vnode-utils";
 import { SEdge } from "../../graph/sgraph";
-import { EMPTY_BOUNDS, linear, Orientation, Point, toDegrees } from "../../utils/geometry";
+import { Orientation } from "../../utils/geometry";
 import { isAlignable, BoundsAware } from "../bounds/model";
 import { DEFAULT_EDGE_PLACEMENT, isEdgeLayoutable, EdgeLayoutable, EdgePlacement } from "./model";
 import { EdgeRouterRegistry } from "../routing/routing";
@@ -32,7 +33,7 @@ export class EdgeLayoutPostprocessor implements IVNodePostprocessor {
 
     decorate(vnode: VNode, element: SModelElement): VNode {
         if (isEdgeLayoutable(element) && element.parent instanceof SEdge) {
-            if (element.bounds !== EMPTY_BOUNDS) {
+            if (element.bounds !== Bounds.EMPTY) {
                 const placement = this.getEdgePlacement(element);
                 const edge = element.parent;
                 const position = Math.min(1, Math.max(0, placement.position));
@@ -140,35 +141,35 @@ export class EdgeLayoutPostprocessor implements IVNodePostprocessor {
             case 'left':
                 switch (quadrant.orientation) {
                     case 'west':
-                        return linear(topLeft, topRight, quadrant.position);
+                        return Point.linear(topLeft, topRight, quadrant.position);
                     case 'north':
-                        return linear(topRight, bottomRight, quadrant.position);
+                        return Point.linear(topRight, bottomRight, quadrant.position);
                     case 'east':
-                        return linear(bottomRight, bottomLeft, quadrant.position);
+                        return Point.linear(bottomRight, bottomLeft, quadrant.position);
                     case 'south':
-                        return linear(bottomLeft, topLeft, quadrant.position);
+                        return Point.linear(bottomLeft, topLeft, quadrant.position);
                 }
                 break;
             case 'right':
                 switch (quadrant.orientation) {
                     case 'west':
-                        return linear(bottomRight, bottomLeft, quadrant.position);
+                        return Point.linear(bottomRight, bottomLeft, quadrant.position);
                     case 'north':
-                        return linear(bottomLeft, topLeft, quadrant.position);
+                        return Point.linear(bottomLeft, topLeft, quadrant.position);
                     case 'east':
-                        return linear(topLeft, topRight, quadrant.position);
+                        return Point.linear(topLeft, topRight, quadrant.position);
                     case 'south':
-                        return linear(topRight, bottomRight, quadrant.position);
+                        return Point.linear(topRight, bottomRight, quadrant.position);
                 }
                 break;
             case 'top':
                 switch (quadrant.orientation) {
                     case 'west':
-                        return linear(bottomRight, bottomLeft, quadrant.position);
+                        return Point.linear(bottomRight, bottomLeft, quadrant.position);
                     case 'north':
                         return this.linearFlip(bottomLeft, midLeft, midRight, bottomRight, quadrant.position);
                     case 'east':
-                        return linear(bottomRight, bottomLeft, quadrant.position);
+                        return Point.linear(bottomRight, bottomLeft, quadrant.position);
                     case 'south':
                         return this.linearFlip(bottomLeft, midLeft, midRight, bottomRight, quadrant.position);
                 }
@@ -176,11 +177,11 @@ export class EdgeLayoutPostprocessor implements IVNodePostprocessor {
             case 'bottom':
                 switch (quadrant.orientation) {
                     case 'west':
-                        return linear(topLeft, topRight, quadrant.position);
+                        return Point.linear(topLeft, topRight, quadrant.position);
                     case 'north':
                         return this.linearFlip(topRight, midRight, midLeft, topLeft, quadrant.position);
                     case 'east':
-                        return linear(topLeft, topRight, quadrant.position);
+                        return Point.linear(topLeft, topRight, quadrant.position);
                     case 'south':
                         return this.linearFlip(topRight, midRight, midLeft, topLeft, quadrant.position);
                 }
@@ -201,7 +202,7 @@ export class EdgeLayoutPostprocessor implements IVNodePostprocessor {
     }
 
     protected linearFlip(p0: Point, p1: Point, p2: Point, p3: Point, position: number) {
-        return position < 0.5 ? linear(p0, p1, 2 * position) : linear(p2, p3, 2 * position - 1);
+        return position < 0.5 ? Point.linear(p0, p1, 2 * position) : Point.linear(p2, p3, 2 * position - 1);
     }
 
     postUpdate(): void {}

--- a/packages/sprotty/src/features/edit/create-on-drag.ts
+++ b/packages/sprotty/src/features/edit/create-on-drag.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Action } from "../../base/actions/action";
+import { Action } from "sprotty-protocol/lib/actions";
 import { SModelElement } from "../../base/model/smodel";
 import { SModelExtension } from "../../base/model/smodel-extension";
 
@@ -27,4 +27,3 @@ export interface CreatingOnDrag extends SModelExtension {
 export function isCreatingOnDrag<T extends SModelElement>(element: T): element is T & CreatingOnDrag {
     return element.hasFeature(creatingOnDragFeature) && (element as any).createAction !== undefined;
 }
-

--- a/packages/sprotty/src/features/edit/create.ts
+++ b/packages/sprotty/src/features/edit/create.ts
@@ -14,17 +14,31 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Action } from "../../base/actions/action";
-import { Command, CommandExecutionContext, CommandReturn } from "../../base/commands/command";
-import { SParentElement, SChildElement, SModelElementSchema } from "../../base/model/smodel";
 import { inject, injectable } from "inversify";
+import { Action } from "sprotty-protocol/lib/actions";
+import { SModelElement as SModelElementSchema } from 'sprotty-protocol/lib/model';
+import { Command, CommandExecutionContext, CommandReturn } from "../../base/commands/command";
+import { SParentElement, SChildElement } from "../../base/model/smodel";
 import { TYPES } from "../../base/types";
 
-export class CreateElementAction implements Action {
-    static readonly KIND = "createElement";
-    readonly kind = CreateElementAction.KIND;
+/**
+ * Create an element with the given schema and add it to the diagram.
+ */
+ export interface CreateElementAction extends Action {
+    kind: typeof CreateElementAction.KIND
+    containerId: string
+    elementSchema: SModelElementSchema
+}
+export namespace CreateElementAction {
+    export const KIND = "createElement";
 
-    constructor(readonly containerId: string, readonly elementSchema: SModelElementSchema) {}
+    export function create(elementSchema: SModelElementSchema, options: { containerId: string }): CreateElementAction {
+        return {
+            kind: KIND,
+            elementSchema,
+            containerId: options.containerId
+        };
+    }
 }
 
 @injectable()

--- a/packages/sprotty/src/features/edit/delete.ts
+++ b/packages/sprotty/src/features/edit/delete.ts
@@ -14,12 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { inject, injectable } from "inversify";
+import { Action } from "sprotty-protocol/lib/actions";
 import { Command, CommandExecutionContext, CommandReturn } from "../../base/commands/command";
-import { Action } from "../../base/actions/action";
 import { SModelElement, SParentElement, SChildElement } from "../../base/model/smodel";
 import { SModelExtension } from "../../base/model/smodel-extension";
 import { TYPES } from "../../base/types";
-import { inject, injectable } from "inversify";
 
 export const deletableFeature = Symbol('deletableFeature');
 
@@ -30,11 +30,22 @@ export function isDeletable<T extends SModelElement>(element: T): element is T &
     return element instanceof SChildElement && element.hasFeature(deletableFeature);
 }
 
-export class DeleteElementAction implements Action {
-    static readonly KIND = 'delete';
-    kind = DeleteElementAction.KIND;
+/**
+ * Delete a set of elements identified by their IDs.
+ */
+ export interface DeleteElementAction extends Action {
+    kind: typeof DeleteElementAction.KIND
+    elementIds: string[]
+}
+export namespace DeleteElementAction {
+    export const KIND = 'delete';
 
-    constructor(readonly elementIds: string[]) {}
+    export function create(elementIds: string[]): DeleteElementAction {
+        return {
+            kind: KIND,
+            elementIds
+        };
+    }
 }
 
 export class ResolvedDelete {

--- a/packages/sprotty/src/features/edit/edit-label-ui.ts
+++ b/packages/sprotty/src/features/edit/edit-label-ui.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { inject, injectable, optional } from "inversify";
-import { Action } from "../../base/actions/action";
+import { Action } from "sprotty-protocol/lib/actions";
 import { IActionDispatcherProvider } from "../../base/actions/action-dispatcher";
 import { IActionHandler } from "../../base/actions/action-handler";
 import { ICommand } from "../../base/commands/command";
@@ -38,7 +38,7 @@ import { EditableLabel, isEditableLabel } from "./model";
 export class EditLabelActionHandler implements IActionHandler {
     handle(action: Action): void | Action | ICommand {
         if (isEditLabelAction(action)) {
-            return new SetUIExtensionVisibilityAction(EditLabelUI.ID, true, [action.labelId]);
+            return SetUIExtensionVisibilityAction.create({ extensionId: EditLabelUI.ID, visible: true, contextElementsId: [action.labelId] });
         }
     }
 }
@@ -132,7 +132,7 @@ export class EditLabelUI extends AbstractUIExtension {
             }
         }
         this.actionDispatcherProvider()
-            .then((actionDispatcher) => actionDispatcher.dispatchAll([new ApplyLabelEditAction(this.labelId, this.editControl.value), new CommitModelAction()]))
+            .then((actionDispatcher) => actionDispatcher.dispatchAll([new ApplyLabelEditAction(this.labelId, this.editControl.value), CommitModelAction.create()]))
             .catch((reason) => this.logger.error(this, 'No action dispatcher available to execute apply label edit action', reason));
         this.hide();
     }

--- a/packages/sprotty/src/features/edit/edit-label.ts
+++ b/packages/sprotty/src/features/edit/edit-label.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { inject } from "inversify";
-import { Action, isAction } from "../../base/actions/action";
+import { Action, isAction } from "sprotty-protocol/lib/actions";
 import { CommandExecutionContext, CommandReturn, Command } from "../../base/commands/command";
 import { SModelElement } from "../../base/model/smodel";
 import { TYPES } from "../../base/types";
@@ -26,10 +26,19 @@ import { isSelectable } from "../select/model";
 import { toArray } from "../../utils/iterable";
 import { EditableLabel, isEditableLabel, isWithEditableLabel } from "./model";
 
-export class EditLabelAction implements Action {
-    static KIND = 'EditLabel';
-    kind = EditLabelAction.KIND;
-    constructor(readonly labelId: string) { }
+export interface EditLabelAction extends Action {
+    kind: typeof EditLabelAction.KIND
+    labelId: string
+}
+export namespace EditLabelAction {
+    export const KIND = 'EditLabel';
+
+    export function create(labelId: string): EditLabelAction {
+        return {
+            kind: KIND,
+            labelId
+        };
+    }
 }
 
 export function isEditLabelAction(element?: any): element is EditLabelAction {
@@ -99,7 +108,7 @@ export class EditLabelMouseListener extends MouseListener {
     doubleClick(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
         const editableLabel = getEditableLabel(target);
         if (editableLabel) {
-            return [new EditLabelAction(editableLabel.id)];
+            return [EditLabelAction.create(editableLabel.id)];
         }
         return [];
     }
@@ -112,7 +121,7 @@ export class EditLabelKeyListener extends KeyListener {
                 .filter(e => isSelectable(e) && e.selected)).map(getEditableLabel)
                 .filter((e): e is EditableLabel & SModelElement => e !== undefined);
             if (editableLabels.length === 1) {
-                return [new EditLabelAction(editableLabels[0].id)];
+                return [EditLabelAction.create(editableLabels[0].id)];
             }
         }
         return [];

--- a/packages/sprotty/src/features/edit/edit-routing.ts
+++ b/packages/sprotty/src/features/edit/edit-routing.ts
@@ -15,21 +15,29 @@
  ********************************************************************************/
 
 import { inject, injectable } from "inversify";
-import { Action } from "../../base/actions/action";
+import { Action } from "sprotty-protocol/lib/actions";
+import { Point } from "sprotty-protocol/lib/utils/geometry";
 import { Command, CommandExecutionContext, CommandReturn } from "../../base/commands/command";
 import { SModelElement, SModelRoot, SParentElement } from '../../base/model/smodel';
 import { TYPES } from "../../base/types";
-import { Point } from "../../utils/geometry";
 import { SRoutableElement, SRoutingHandle } from "../routing/model";
 import { EdgeRouterRegistry } from "../routing/routing";
 import { canEditRouting } from './model';
 
-export class SwitchEditModeAction implements Action {
-    static readonly KIND: string = "switchEditMode";
-    kind = SwitchEditModeAction.KIND;
+export interface SwitchEditModeAction extends Action {
+    kind: typeof SwitchEditModeAction.KIND;
+    elementsToActivate: string[]
+    elementsToDeactivate: string[]
+}
+export namespace SwitchEditModeAction {
+    export const KIND = "switchEditMode";
 
-    constructor(public readonly elementsToActivate: string[] = [],
-                public readonly elementsToDeactivate: string[] = []) {
+    export function create(options: { elementsToActivate?: string[], elementsToDeactivate?: string[] }): SwitchEditModeAction {
+        return {
+            kind: KIND,
+            elementsToActivate: options.elementsToActivate ?? [],
+            elementsToDeactivate: options.elementsToDeactivate ?? []
+        };
     }
 }
 

--- a/packages/sprotty/src/features/edit/model.ts
+++ b/packages/sprotty/src/features/edit/model.ts
@@ -14,10 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Dimension, Point } from 'sprotty-protocol/lib/utils/geometry';
 import { SModelElement } from '../../base/model/smodel';
 import { SRoutableElement } from '../routing/model';
 import { SModelExtension } from '../../base/model/smodel-extension';
-import { Point, Dimension } from '../../utils/geometry';
 
 export const editFeature = Symbol('editFeature');
 

--- a/packages/sprotty/src/features/edit/reconnect.ts
+++ b/packages/sprotty/src/features/edit/reconnect.ts
@@ -15,19 +15,29 @@
  ********************************************************************************/
 
 import { inject, injectable } from "inversify";
-import { Action } from "../../base/actions/action";
+import { Action } from "sprotty-protocol/lib/actions";
 import { Command, CommandExecutionContext, CommandReturn } from "../../base/commands/command";
 import { TYPES } from "../../base/types";
 import { SRoutableElement } from "../routing/model";
 import { EdgeMemento, EdgeRouterRegistry } from "../routing/routing";
 
-export class ReconnectAction implements Action {
-    static readonly KIND = 'reconnect';
-    readonly kind =  ReconnectAction.KIND;
+export interface ReconnectAction extends Action {
+    kind: typeof ReconnectAction.KIND
+    routableId: string
+    newSourceId?: string
+    newTargetId?: string
+}
+export namespace ReconnectAction {
+    export const KIND = 'reconnect';
 
-    constructor(readonly routableId: string,
-                readonly newSourceId?: string,
-                readonly newTargetId?: string) {}
+    export function create(options: { routableId: string, newSourceId?: string, newTargetId?: string }): ReconnectAction {
+        return {
+            kind: KIND,
+            routableId: options.routableId,
+            newSourceId: options.newSourceId,
+            newTargetId: options.newTargetId
+        };
+    }
 }
 
 @injectable()

--- a/packages/sprotty/src/features/expand/expand.ts
+++ b/packages/sprotty/src/features/expand/expand.ts
@@ -14,18 +14,20 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Action } from '../../base/actions/action';
+import { injectable } from 'inversify';
+import { Action } from 'sprotty-protocol/lib/actions';
 import { SButton } from '../button/model';
 import { findParentByFeature } from '../../base/model/smodel-utils';
 import { isExpandable } from './model';
 import { IButtonHandler } from '../button/button-handler';
-import { injectable } from 'inversify';
 
 /**
  * Sent from the client to the model source to recalculate a diagram when elements
  * are collapsed/expanded by the client.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
-export class CollapseExpandAction {
+export class CollapseExpandAction implements Action {
     static KIND = 'collapseExpand';
     kind = CollapseExpandAction.KIND;
 
@@ -36,8 +38,10 @@ export class CollapseExpandAction {
 
 /**
  * Programmatic action for expanding or collapsing all elements.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
-export class CollapseExpandAllAction {
+export class CollapseExpandAllAction implements Action {
     static KIND = 'collapseExpandAll';
     kind = CollapseExpandAllAction.KIND;
 

--- a/packages/sprotty/src/features/export/export.spec.ts
+++ b/packages/sprotty/src/features/export/export.spec.ts
@@ -47,7 +47,7 @@ describe('ExportSvgCommand', () => {
 
     const myNode = model.children[0] as SNode;
 
-    const cmd = new ExportSvgCommand(new RequestExportSvgAction());
+    const cmd = new ExportSvgCommand(RequestExportSvgAction.create());
 
     const context: CommandExecutionContext = {
         root: model,

--- a/packages/sprotty/src/features/export/export.ts
+++ b/packages/sprotty/src/features/export/export.ts
@@ -16,10 +16,10 @@
 
 import { injectable, inject } from "inversify";
 import { VNode } from 'snabbdom';
+import { Action, generateRequestId, RequestAction } from "sprotty-protocol/lib/actions";
 import { CommandExecutionContext, HiddenCommand, CommandResult } from '../../base/commands/command';
 import { IVNodePostprocessor } from '../../base/views/vnode-postprocessor';
 import { isSelectable } from '../select/model';
-import { Action, RequestAction, generateRequestId } from '../../base/actions/action';
 import { SModelElement, SModelRoot } from '../../base/model/smodel';
 import { KeyListener } from '../../base/views/key-tool';
 import { matchesKeystroke } from '../../utils/keyboard';
@@ -33,21 +33,23 @@ import { TYPES } from '../../base/types';
 export class ExportSvgKeyListener extends KeyListener {
     keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
         if (matchesKeystroke(event, 'KeyE', 'ctrlCmd', 'shift'))
-            return [ new RequestExportSvgAction() ];
+            return [ RequestExportSvgAction.create() ];
         else
             return [];
     }
 }
 
-export class RequestExportSvgAction implements RequestAction<ExportSvgAction> {
-    static readonly KIND = 'requestExportSvg';
-    readonly kind = RequestExportSvgAction.KIND;
+export interface RequestExportSvgAction extends RequestAction<ExportSvgAction> {
+    kind: typeof RequestExportSvgAction.KIND
+}
+export namespace RequestExportSvgAction {
+    export const KIND = 'requestExportSvg';
 
-    constructor(public readonly requestId: string = '') {}
-
-    /** Factory function to dispatch a request with the `IActionDispatcher` */
-    static create(): RequestAction<ExportSvgAction> {
-        return new RequestExportSvgAction(generateRequestId());
+    export function create(): RequestExportSvgAction {
+        return {
+            kind: KIND,
+            requestId: generateRequestId()
+        };
     }
 }
 

--- a/packages/sprotty/src/features/hover/hover.spec.ts
+++ b/packages/sprotty/src/features/hover/hover.spec.ts
@@ -18,9 +18,9 @@ import "reflect-metadata";
 import "mocha";
 import { expect } from "chai";
 import { Container } from "inversify";
+import { Action } from 'sprotty-protocol/lib/actions';
 import { TYPES } from "../../base/types";
 import { SChildElement, SModelElement, SModelRoot } from "../../base/model/smodel";
-import { Action } from "../../base/actions/action";
 import { HoverFeedbackAction, HoverMouseListener } from "./hover";
 import { Hoverable, hoverFeedbackFeature, popupFeature } from "./model";
 import defaultModule from "../../base/di.config";
@@ -93,7 +93,7 @@ describe('hover', () => {
             const mouseOverResult: (Action | Promise<Action>)[] = hoverListener.mouseOver(target, event);
 
             expect(mouseOverResult).to.have.lengthOf(1);
-            expect(mouseOverResult[0]).to.be.an.instanceof(HoverFeedbackAction);
+            expect((mouseOverResult[0] as Action).kind).to.equal(HoverFeedbackAction.KIND);
         });
         it('resets the hover feedback on hovering over another element', () => {
             const target = new HoverableTarget("1");
@@ -102,8 +102,8 @@ describe('hover', () => {
             const mouseOverResult: (Action | Promise<Action>)[] = hoverListener.mouseOver(anotherTarget, event);
 
             expect(mouseOverResult).to.have.lengthOf(2);
-            expect(mouseOverResult[0]).to.be.an.instanceof(HoverFeedbackAction);
-            expect(mouseOverResult[1]).to.be.an.instanceof(HoverFeedbackAction);
+            expect((mouseOverResult[0] as Action).kind).to.equal(HoverFeedbackAction.KIND);
+            expect((mouseOverResult[1] as Action).kind).to.equal(HoverFeedbackAction.KIND);
 
             const action1 = mouseOverResult[0] as HoverFeedbackAction;
             const action2 = mouseOverResult[1] as HoverFeedbackAction;

--- a/packages/sprotty/src/features/move/model.ts
+++ b/packages/sprotty/src/features/move/model.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Point } from "../../utils/geometry";
+import { Point } from "sprotty-protocol/lib/utils/geometry";
 import { SModelElement } from "../../base/model/smodel";
 import { SModelExtension } from "../../base/model/smodel-extension";
 

--- a/packages/sprotty/src/features/move/move.spec.ts
+++ b/packages/sprotty/src/features/move/move.spec.ts
@@ -88,7 +88,7 @@ describe('move', () => {
     ];
 
     // create the action
-    const moveAction = new MoveAction(moves, /* no animate */ false);
+    const moveAction = MoveAction.create(moves, { animate: false });
 
     // create the command
     const cmd = new MoveCommand(moveAction);

--- a/packages/sprotty/src/features/move/snap.ts
+++ b/packages/sprotty/src/features/move/snap.ts
@@ -15,8 +15,8 @@
  ********************************************************************************/
 
 import { injectable } from "inversify";
+import { Point } from "sprotty-protocol/lib/utils/geometry";
 import { SModelElement } from "../../base/model/smodel";
-import { Point } from "../../utils/geometry";
 import { isBoundsAware } from "../bounds/model";
 
 /**

--- a/packages/sprotty/src/features/open/open.ts
+++ b/packages/sprotty/src/features/open/open.ts
@@ -14,23 +14,32 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Action } from 'sprotty-protocol/lib/actions';
 import { MouseListener } from '../../base/views/mouse-tool';
-import { Action } from '../../base/actions/action';
 import { SModelElement } from '../../base/model/smodel';
 import { findParentByFeature } from '../../base/model/smodel-utils';
 import { isOpenable } from './model';
 
-export class OpenAction {
-    static KIND = 'open';
-    kind = OpenAction.KIND;
-    constructor(public readonly elementId: string) {}
+export interface OpenAction extends Action {
+    kind: typeof OpenAction.KIND
+    elementId: string
+}
+export namespace OpenAction {
+    export const KIND = 'open';
+
+    export function create(elementId: string): OpenAction {
+        return {
+            kind: KIND,
+            elementId
+        };
+    }
 }
 
 export class OpenMouseListener extends MouseListener {
     doubleClick(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
         const openableTarget = findParentByFeature(target, isOpenable);
         if (openableTarget !== undefined) {
-            return [ new OpenAction(openableTarget.id) ];
+            return [ OpenAction.create(openableTarget.id) ];
         }
         return [];
     }

--- a/packages/sprotty/src/features/projection/model.ts
+++ b/packages/sprotty/src/features/projection/model.ts
@@ -14,12 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Viewport } from 'sprotty-protocol/lib/model';
+import { Bounds, Dimension } from 'sprotty-protocol/lib/utils/geometry';
+import { hasOwnProperty } from 'sprotty-protocol/lib/utils/object';
 import { SChildElement, SModelRoot, SParentElement } from '../../base/model/smodel';
 import { SModelExtension } from '../../base/model/smodel-extension';
-import { Bounds, isValidDimension } from '../../utils/geometry';
-import { hasOwnProperty } from '../../utils/object';
 import { BoundsAware, isBoundsAware } from '../bounds/model';
-import { Viewport } from '../viewport/model';
 
 /**
  * Model elements implementing this interface can be displayed on a projection bar.
@@ -100,7 +100,7 @@ export function getModelBounds(model: SModelRoot & Viewport): Bounds | undefined
     let maxY = -MAX_COORD;
 
     const bounds = isBoundsAware(model) ? model.bounds : undefined;
-    if (bounds && isValidDimension(bounds)) {
+    if (bounds && Dimension.isValid(bounds)) {
         // Get the bounds directly from the model if it returns a valid size
         minX = bounds.x;
         minY = bounds.y;

--- a/packages/sprotty/src/features/projection/views.tsx
+++ b/packages/sprotty/src/features/projection/views.tsx
@@ -19,7 +19,7 @@ import { html } from '../../lib/jsx';
 
 import { injectable } from 'inversify';
 import { VNode, VNodeStyle, h } from 'snabbdom';
-import { Bounds } from '../../utils/geometry';
+import { Bounds } from 'sprotty-protocol/lib/utils/geometry';
 import { IView, IViewArgs, RenderingContext } from '../../base/views/view';
 import { setClass } from '../../base/views/vnode-utils';
 import { ViewportRootElement } from '../viewport/viewport-root';

--- a/packages/sprotty/src/features/routing/abstract-edge-router.ts
+++ b/packages/sprotty/src/features/routing/abstract-edge-router.ts
@@ -15,9 +15,9 @@
  ********************************************************************************/
 
 import { inject, injectable } from "inversify";
+import { Bounds, Point } from "sprotty-protocol/lib/utils/geometry";
 import { SModelElement, SParentElement } from "../../base/model/smodel";
 import { translateBounds, translatePoint } from "../../base/model/smodel-utils";
-import { Bounds, euclideanDistance, linear, Point } from "../../utils/geometry";
 import { ResolvedHandleMove } from "../move/move";
 import { RoutingHandleKind, SDanglingAnchor, SRoutingHandle, edgeInProgressID, edgeInProgressTargetHandleID } from "./model";
 import { AnchorComputerRegistry, IAnchorComputer } from "./anchor";
@@ -53,10 +53,10 @@ export class DefaultAnchors {
     }
 
     getNearestSide(point: Point): Side {
-        const leftDistance = euclideanDistance(point, this.left);
-        const rightDistance = euclideanDistance(point, this.right);
-        const topDistance = euclideanDistance(point, this.top);
-        const bottomDistance = euclideanDistance(point, this.bottom);
+        const leftDistance = Point.euclideanDistance(point, this.left);
+        const rightDistance = Point.euclideanDistance(point, this.right);
+        const topDistance = Point.euclideanDistance(point, this.top);
+        const bottomDistance = Point.euclideanDistance(point, this.bottom);
         let currentNearestSide = Side.LEFT;
         let currentMinDist = leftDistance;
         if (rightDistance < currentMinDist) {
@@ -93,7 +93,7 @@ export abstract class AbstractEdgeRouter implements IEdgeRouter {
         if (!segments)
             return undefined;
         const { segmentStart, segmentEnd, lambda } = segments;
-        return linear(segmentStart, segmentEnd, lambda);
+        return Point.linear(segmentStart, segmentEnd, lambda);
     }
 
     derivativeAt(edge: SRoutableElement, t: number): Point | undefined {
@@ -116,7 +116,7 @@ export abstract class AbstractEdgeRouter implements IEdgeRouter {
         const segmentLengths: number[] = [];
         let totalLength = 0;
         for (let i = 0; i < routedPoints.length - 1; ++i) {
-            segmentLengths[i] = euclideanDistance(routedPoints[i], routedPoints[i + 1]);
+            segmentLengths[i] = Point.euclideanDistance(routedPoints[i], routedPoints[i + 1]);
             totalLength += segmentLengths[i];
         }
         let currentLenght = 0;

--- a/packages/sprotty/src/features/routing/anchor.ts
+++ b/packages/sprotty/src/features/routing/anchor.ts
@@ -15,8 +15,8 @@
  ********************************************************************************/
 
 import { injectable, multiInject } from "inversify";
+import { Point } from "sprotty-protocol/lib/utils/geometry";
 import { TYPES } from "../../base/types";
-import { Point } from "../../utils/geometry";
 import { InstanceRegistry } from "../../utils/registry";
 import { SConnectableElement } from "./model";
 

--- a/packages/sprotty/src/features/routing/bezier-edge-router.ts
+++ b/packages/sprotty/src/features/routing/bezier-edge-router.ts
@@ -15,14 +15,14 @@
  ********************************************************************************/
 
 import { inject, injectable, optional } from 'inversify';
+import { Action } from 'sprotty-protocol/lib/actions';
+import { centerOfLine, Point } from 'sprotty-protocol/lib/utils/geometry';
 import { ResolvedHandleMove } from '../move/move';
-import { centerOfLine, Point } from '../../utils/geometry';
 import { SDanglingAnchor, SRoutableElement, SRoutingHandle } from './model';
 import { SModelElement } from '../../base/model/smodel';
 import { EdgeRouterRegistry, RoutedPoint } from './routing';
 import { AbstractEdgeRouter, LinearRouteOptions } from './abstract-edge-router';
 import { MouseListener } from '../../base/views/mouse-tool';
-import { Action } from '../../base/actions/action';
 import { Command, CommandExecutionContext, CommandReturn } from '../../base/commands/command';
 import { TYPES } from "../../base/types";
 import { SEdge } from '../../graph/sgraph';

--- a/packages/sprotty/src/features/routing/manhattan-anchors.ts
+++ b/packages/sprotty/src/features/routing/manhattan-anchors.ts
@@ -14,7 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { center, Point, Bounds, Line, PointToPointLine, intersection, subtract } from "../../utils/geometry";
+import { Bounds, Point } from "sprotty-protocol/lib/utils/geometry";
+import { Line, PointToPointLine, intersection } from "../../utils/geometry";
 import { RECTANGULAR_ANCHOR_KIND, IAnchorComputer, DIAMOND_ANCHOR_KIND, ELLIPTIC_ANCHOR_KIND } from "./anchor";
 import { ManhattanEdgeRouter } from "./manhattan-edge-router";
 import { SConnectableElement } from "./model";
@@ -52,7 +53,7 @@ export class ManhattanRectangularAnchor implements IAnchorComputer {
             else
             return { x: bounds.x + bounds.width, y: refPoint.y };
         }
-        return center(bounds);
+        return Bounds.center(bounds);
     }
 }
 
@@ -76,7 +77,7 @@ export class ManhattanDiamondAnchor implements IAnchorComputer {
             width: b.width + 2 * offset,
             height: b.height + 2 * offset
         };
-        const c = center(bounds);
+        const c = Bounds.center(bounds);
 
         let outline: Line | undefined = undefined;
         let refLine: Line | undefined = undefined;
@@ -136,8 +137,8 @@ export class ManhattanEllipticAnchor implements IAnchorComputer {
             width: b.width + 2 * offset,
             height: b.height + 2 * offset
         };
-        const c = center(bounds);
-        const refRelative = subtract(refPoint, c);
+        const c = Bounds.center(bounds);
+        const refRelative = Point.subtract(refPoint, c);
         let x = c.x;
         let y = c.y;
         if (refPoint.x >= bounds.x && bounds.x + bounds.width >= refPoint.x) {

--- a/packages/sprotty/src/features/routing/manhattan-edge-router.ts
+++ b/packages/sprotty/src/features/routing/manhattan-edge-router.ts
@@ -14,8 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { almostEquals, Bounds, Point } from "sprotty-protocol/lib/utils/geometry";
 import { translatePoint } from "../../base/model/smodel-utils";
-import { almostEquals, center, includes, linear, Point, manhattanDistance } from "../../utils/geometry";
 import { ResolvedHandleMove } from "../move/move";
 import { DefaultAnchors, AbstractEdgeRouter, LinearRouteOptions, Side } from "./abstract-edge-router";
 import { SRoutableElement, RoutingHandleKind, SRoutingHandle } from "./model";
@@ -46,10 +46,10 @@ export class ManhattanEdgeRouter extends AbstractEdgeRouter {
             return [];
         const routedCorners = this.createRoutedCorners(edge);
         const sourceRefPoint = routedCorners[0]
-            || translatePoint(center(edge.target.bounds), edge.target.parent, edge.parent);
+            || translatePoint(Bounds.center(edge.target.bounds), edge.target.parent, edge.parent);
         const sourceAnchor = this.getTranslatedAnchor(edge.source, sourceRefPoint, edge.parent, edge, edge.sourceAnchorCorrection);
         const targetRefPoint = routedCorners[routedCorners.length - 1]
-            || translatePoint(center(edge.source.bounds), edge.source.parent, edge.parent);
+            || translatePoint(Bounds.center(edge.source.bounds), edge.source.parent, edge.parent);
         const targetAnchor = this.getTranslatedAnchor(edge.target, targetRefPoint, edge.parent, edge, edge.targetAnchorCorrection);
         if (!sourceAnchor || !targetAnchor)
             return [];
@@ -94,7 +94,7 @@ export class ManhattanEdgeRouter extends AbstractEdgeRouter {
         if (fraction !== undefined) {
             const { start, end } = this.findRouteSegment(edge, route, handle.pointIndex);
             if (start !== undefined && end !== undefined)
-                return linear(start, end, fraction);
+                return Point.linear(start, end, fraction);
         }
         return undefined;
     }
@@ -182,7 +182,7 @@ export class ManhattanEdgeRouter extends AbstractEdgeRouter {
             return;
         // delete leading RPs inside the bounds of the source
         for (let i = 0; i < routingPoints.length; ++i)
-            if (includes(sourceAnchors.bounds, routingPoints[i])) {
+            if (Bounds.includes(sourceAnchors.bounds, routingPoints[i])) {
                 routingPoints.splice(0, 1);
                 if (updateHandles) {
                     this.removeHandle(edge, -1);
@@ -192,7 +192,7 @@ export class ManhattanEdgeRouter extends AbstractEdgeRouter {
             }
         // delete trailing RPs inside the bounds of the target
         for (let i = routingPoints.length - 1; i >= 0; --i)
-            if (includes(targetAnchors.bounds, routingPoints[i])) {
+            if (Bounds.includes(targetAnchors.bounds, routingPoints[i])) {
                 routingPoints.splice(i, 1);
                 if (updateHandles) {
                     this.removeHandle(edge, i);
@@ -203,7 +203,7 @@ export class ManhattanEdgeRouter extends AbstractEdgeRouter {
         if (routingPoints.length >= 2) {
             const options = this.getOptions(edge);
             for (let i = routingPoints.length - 2; i >= 0; --i) {
-                if (manhattanDistance(routingPoints[i], routingPoints[i + 1]) < options.minimalPointDistance) {
+                if (Point.manhattanDistance(routingPoints[i], routingPoints[i + 1]) < options.minimalPointDistance) {
                     routingPoints.splice(i, 2);
                     --i;
                     if (updateHandles) {
@@ -474,7 +474,7 @@ export class ManhattanEdgeRouter extends AbstractEdgeRouter {
         // priority NN >> EE >> NE >> NW >> SE >> SW
         sourcePoint = sourceAnchors.get(Side.TOP);
         targetPoint = targetAnchors.get(Side.TOP);
-        if (!includes(targetAnchors.bounds, sourcePoint) && !includes(sourceAnchors.bounds, targetPoint)) {
+        if (!Bounds.includes(targetAnchors.bounds, sourcePoint) && !Bounds.includes(sourceAnchors.bounds, targetPoint)) {
             if ((sourcePoint.y - targetPoint.y) < 0) {
                 if (Math.abs(sourcePoint.x - targetPoint.x) > ((sourceAnchors.bounds.width + options.standardDistance) / 2))
                     return { source: Side.TOP, target: Side.TOP };
@@ -486,7 +486,7 @@ export class ManhattanEdgeRouter extends AbstractEdgeRouter {
 
         sourcePoint = sourceAnchors.get(Side.RIGHT);
         targetPoint = targetAnchors.get(Side.RIGHT);
-        if (!includes(targetAnchors.bounds, sourcePoint) && !includes(sourceAnchors.bounds, targetPoint)) {
+        if (!Bounds.includes(targetAnchors.bounds, sourcePoint) && !Bounds.includes(sourceAnchors.bounds, targetPoint)) {
             if ((sourcePoint.x - targetPoint.x) > 0) {
                 if (Math.abs(sourcePoint.y - targetPoint.y) > ((sourceAnchors.bounds.height + options.standardDistance) / 2))
                     return { source: Side.RIGHT, target: Side.RIGHT };
@@ -497,21 +497,21 @@ export class ManhattanEdgeRouter extends AbstractEdgeRouter {
         // Secondly, judge NE NW is available
         sourcePoint = sourceAnchors.get(Side.TOP);
         targetPoint = targetAnchors.get(Side.RIGHT);
-        if (!includes(targetAnchors.bounds, sourcePoint) && !includes(sourceAnchors.bounds, targetPoint))
+        if (!Bounds.includes(targetAnchors.bounds, sourcePoint) && !Bounds.includes(sourceAnchors.bounds, targetPoint))
             return { source: Side.TOP, target: Side.RIGHT };
 
         targetPoint = targetAnchors.get(Side.LEFT);
-        if (!includes(targetAnchors.bounds, sourcePoint) && !includes(sourceAnchors.bounds, targetPoint))
+        if (!Bounds.includes(targetAnchors.bounds, sourcePoint) && !Bounds.includes(sourceAnchors.bounds, targetPoint))
             return { source: Side.TOP, target: Side.LEFT };
 
         // Finally, judge SE SW is available
         sourcePoint = sourceAnchors.get(Side.BOTTOM);
         targetPoint = targetAnchors.get(Side.RIGHT);
-        if (!includes(targetAnchors.bounds, sourcePoint) && !includes(sourceAnchors.bounds, targetPoint))
+        if (!Bounds.includes(targetAnchors.bounds, sourcePoint) && !Bounds.includes(sourceAnchors.bounds, targetPoint))
             return { source: Side.BOTTOM, target: Side.RIGHT };
 
         targetPoint = targetAnchors.get(Side.LEFT);
-        if (!includes(targetAnchors.bounds, sourcePoint) && !includes(sourceAnchors.bounds, targetPoint))
+        if (!Bounds.includes(targetAnchors.bounds, sourcePoint) && !Bounds.includes(sourceAnchors.bounds, targetPoint))
             return { source: Side.BOTTOM, target: Side.LEFT };
 
         // Only to return to the

--- a/packages/sprotty/src/features/routing/model.ts
+++ b/packages/sprotty/src/features/routing/model.ts
@@ -14,10 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Bounds, Point } from 'sprotty-protocol/lib/utils/geometry';
 import { SChildElement, SModelElement } from '../../base/model/smodel';
 import { SModelExtension } from '../../base/model/smodel-extension';
 import { SEdge, SGraphIndex } from '../../graph/sgraph';
-import { Point, Bounds, combine, EMPTY_BOUNDS } from '../../utils/geometry';
 import { FluentIterable } from '../../utils/iterable';
 import { SShapeElement } from '../bounds/model';
 import { deletableFeature } from '../edit/delete';
@@ -43,12 +43,12 @@ export abstract class SRoutableElement extends SChildElement {
 
     get bounds(): Bounds {
         // this should also work for splines, which have the convex hull property
-        return this.routingPoints.reduce<Bounds>((bounds, routingPoint) => combine(bounds, {
+        return this.routingPoints.reduce<Bounds>((bounds, routingPoint) => Bounds.combine(bounds, {
             x: routingPoint.x,
             y: routingPoint.y,
             width: 0,
             height: 0
-        }), EMPTY_BOUNDS);
+        }), Bounds.EMPTY);
     }
 }
 

--- a/packages/sprotty/src/features/routing/polyline-anchors.ts
+++ b/packages/sprotty/src/features/routing/polyline-anchors.ts
@@ -16,9 +16,10 @@
 
 import { IAnchorComputer, ELLIPTIC_ANCHOR_KIND, RECTANGULAR_ANCHOR_KIND, DIAMOND_ANCHOR_KIND } from "./anchor";
 import { SConnectableElement } from "./model";
-import { Point, center, almostEquals, PointToPointLine, Diamond, intersection, shiftTowards } from "../../utils/geometry";
+import { PointToPointLine, Diamond, intersection } from "../../utils/geometry";
 import { injectable } from "inversify";
 import { PolylineEdgeRouter } from "./polyline-edge-router";
+import { almostEquals, Bounds, Point } from "sprotty-protocol/lib/utils/geometry";
 
 @injectable()
 export class EllipseAnchor implements IAnchorComputer {
@@ -29,7 +30,7 @@ export class EllipseAnchor implements IAnchorComputer {
 
     getAnchor(connectable: SConnectableElement, refPoint: Point, offset: number = 0): Point {
         const bounds = connectable.bounds;
-        const c = center(bounds);
+        const c = Bounds.center(bounds);
         const dx = c.x - refPoint.x;
         const dy = c.y - refPoint.y;
         const distance = Math.sqrt(dx * dx + dy * dy);
@@ -51,7 +52,7 @@ export class RectangleAnchor implements IAnchorComputer {
 
     getAnchor(connectable: SConnectableElement, refPoint: Point, offset: number = 0): Point {
         const bounds = connectable.bounds;
-        const c = center(bounds);
+        const c = Bounds.center(bounds);
         const finder = new NearestPointFinder(c, refPoint);
         if (!almostEquals(c.y, refPoint.y)) {
             const xTop = this.getXIntersection(bounds.y, c, refPoint);
@@ -120,9 +121,9 @@ export class DiamondAnchor implements IAnchorComputer {
 
     getAnchor(connectable: SConnectableElement, refPoint: Point, offset: number): Point {
         const bounds = connectable.bounds;
-        const referenceLine = new PointToPointLine(center(bounds), refPoint);
+        const referenceLine = new PointToPointLine(Bounds.center(bounds), refPoint);
         const closestDiamondSide = new Diamond(bounds).closestSideLine(refPoint);
         const anchorPoint = intersection(closestDiamondSide, referenceLine);
-        return shiftTowards(anchorPoint, refPoint, offset);
+        return Point.shiftTowards(anchorPoint, refPoint, offset);
     }
 }

--- a/packages/sprotty/src/features/routing/polyline-edge-router.ts
+++ b/packages/sprotty/src/features/routing/polyline-edge-router.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { inject, injectable } from "inversify";
-import { angleBetweenPoints, center, centerOfLine, maxDistance, Point } from "../../utils/geometry";
+import { angleBetweenPoints, Bounds, centerOfLine, Point } from "sprotty-protocol/lib/utils/geometry";
 import { SRoutingHandle } from "./model";
 import { ResolvedHandleMove } from "../move/move";
 import { AnchorComputerRegistry } from "./anchor";
@@ -65,10 +65,10 @@ export class PolylineEdgeRouter extends AbstractEdgeRouter {
         const rpCount = routingPoints !== undefined ? routingPoints.length : 0;
         if (rpCount === 0) {
             // Use the target center as start anchor reference
-            const startRef = center(target.bounds);
+            const startRef = Bounds.center(target.bounds);
             sourceAnchor = this.getTranslatedAnchor(source, startRef, target.parent, edge, edge.sourceAnchorCorrection);
             // Use the source center as end anchor reference
-            const endRef = center(source.bounds);
+            const endRef = Bounds.center(source.bounds);
             targetAnchor = this.getTranslatedAnchor(target, endRef, source.parent, edge, edge.targetAnchorCorrection);
         } else {
             // Use the first routing point as start anchor reference
@@ -84,8 +84,8 @@ export class PolylineEdgeRouter extends AbstractEdgeRouter {
         for (let i = 0; i < rpCount; i++) {
             const p = routingPoints[i];
             if (i > 0 && i < rpCount - 1
-                || i === 0 && maxDistance(sourceAnchor, p) >= options.minimalPointDistance + (edge.sourceAnchorCorrection || 0)
-                || i === rpCount - 1 && maxDistance(p, targetAnchor) >= options.minimalPointDistance + (edge.targetAnchorCorrection || 0)) {
+                || i === 0 && Point.maxDistance(sourceAnchor, p) >= options.minimalPointDistance + (edge.sourceAnchorCorrection || 0)
+                || i === rpCount - 1 && Point.maxDistance(p, targetAnchor) >= options.minimalPointDistance + (edge.targetAnchorCorrection || 0)) {
                 result.push({ kind: 'linear', x: p.x, y: p.y, pointIndex: i });
             }
         }

--- a/packages/sprotty/src/features/routing/routing.ts
+++ b/packages/sprotty/src/features/routing/routing.ts
@@ -15,10 +15,10 @@
  ********************************************************************************/
 
 import { injectable, multiInject, optional } from "inversify";
+import { Point } from "sprotty-protocol/lib/utils/geometry";
 import { SParentElement } from "../../base/model/smodel";
 import { TYPES } from "../../base/types";
 import { findArgValue, IViewArgs } from "../../base/views/view";
-import { Point } from "../../utils/geometry";
 import { InstanceRegistry } from "../../utils/registry";
 import { ResolvedHandleMove } from "../move/move";
 import { SRoutingHandle } from "../routing/model";

--- a/packages/sprotty/src/features/routing/views.ts
+++ b/packages/sprotty/src/features/routing/views.ts
@@ -16,7 +16,7 @@
 
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
-import { Point } from '../../utils/geometry';
+import { Point } from 'sprotty-protocol/lib/utils/geometry';
 import { IViewArgs, IView, RenderingContext } from '../../base/views/view';
 import { SRoutableElement, getAbsoluteRouteBounds } from './model';
 

--- a/packages/sprotty/src/features/undo-redo/undo-redo.ts
+++ b/packages/sprotty/src/features/undo-redo/undo-redo.ts
@@ -14,28 +14,44 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Action } from "sprotty-protocol/lib/actions";
 import { matchesKeystroke } from "../../utils/keyboard";
-import { Action } from "../../base/actions/action";
 import { KeyListener } from "../../base/views/key-tool";
 import { SModelElement } from "../../base/model/smodel";
 import { isMac } from "../../utils/browser";
 
-export class UndoAction implements Action {
-    static readonly KIND = 'undo';
-    kind = UndoAction.KIND;
+export interface UndoAction extends Action {
+    kind: typeof UndoAction.KIND;
+}
+export namespace UndoAction {
+    export const KIND = 'undo';
+
+    export function create(): UndoAction {
+        return {
+            kind: KIND
+        };
+    }
 }
 
-export class RedoAction implements Action {
-    static readonly KIND = 'redo';
-    kind = RedoAction.KIND;
+export interface RedoAction extends Action {
+    kind: typeof RedoAction.KIND;
+}
+export namespace RedoAction {
+    export const KIND = 'redo';
+
+    export function create(): RedoAction {
+        return {
+            kind: KIND
+        };
+    }
 }
 
 export class UndoRedoKeyListener extends KeyListener {
     keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
         if (matchesKeystroke(event, 'KeyZ', 'ctrlCmd'))
-            return [new UndoAction];
+            return [UndoAction.create()];
         if (matchesKeystroke(event, 'KeyZ', 'ctrlCmd', 'shift') || (!isMac() && matchesKeystroke(event, 'KeyY', 'ctrlCmd')))
-            return [new RedoAction];
+            return [RedoAction.create()];
         return [];
     }
 }

--- a/packages/sprotty/src/features/update/model-matching.ts
+++ b/packages/sprotty/src/features/update/model-matching.ts
@@ -14,7 +14,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { SModelRootSchema, SModelElementSchema, SModelRoot, SModelIndex, SModelElement, isParent } from '../../base/model/smodel';
+import { SModelElement as SModelElementSchema, SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
+import { SModelRoot, SModelElement, isParent, IModelIndex } from '../../base/model/smodel';
+import { SModelIndex } from 'sprotty-protocol';
 
 export interface Match {
     left?: SModelElementSchema
@@ -78,11 +80,10 @@ export class ModelMatcher {
     }
 }
 
-export function applyMatches(root: SModelRootSchema, matches: Match[]): void {
-    let index: SModelIndex<SModelElementSchema>;
+export function applyMatches(root: SModelRootSchema, matches: Match[], index?: IModelIndex): void {
     if (root instanceof SModelRoot) {
         index = root.index;
-    } else {
+    } else if (index === undefined) {
         index = new SModelIndex();
         index.add(root);
     }

--- a/packages/sprotty/src/features/update/update-model.ts
+++ b/packages/sprotty/src/features/update/update-model.ts
@@ -15,12 +15,13 @@
  ********************************************************************************/
 
 import { injectable, inject, optional } from "inversify";
-import { isValidDimension, almostEquals } from "../../utils/geometry";
+import { Action } from "sprotty-protocol/lib/actions";
+import { SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
+import { almostEquals, Dimension } from "sprotty-protocol/lib/utils/geometry";
 import { Animation, CompoundAnimation } from '../../base/animations/animation';
 import { CommandExecutionContext, CommandReturn, Command } from '../../base/commands/command';
 import { FadeAnimation, ResolvedElementFade } from '../fade/fade';
-import { Action } from '../../base/actions/action';
-import { SModelRootSchema, SModelRoot, SChildElement, SModelElement, SParentElement } from "../../base/model/smodel";
+import { SModelRoot, SChildElement, SModelElement, SParentElement } from "../../base/model/smodel";
 import { MoveAnimation, ResolvedElementMove, MorphEdgesAnimation } from "../move/move";
 import { Fadeable, isFadeable } from "../fade/model";
 import { isLocateable } from "../move/model";
@@ -38,6 +39,8 @@ import { containsSome } from "../../base/model/smodel-utils";
 /**
  * Sent from the model source to the client in order to update the model. If no model is present yet,
  * this behaves the same as a SetModelAction. The transition from the old model to the new one can be animated.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export class UpdateModelAction implements Action {
     static readonly KIND = 'updateModel';
@@ -105,7 +108,7 @@ export class UpdateModelCommand extends Command {
             else
                 return animationOrRoot;
         } else {
-            if (oldRoot.type === newRoot.type && isValidDimension(oldRoot.canvasBounds))
+            if (oldRoot.type === newRoot.type && Dimension.isValid(oldRoot.canvasBounds))
                 newRoot.canvasBounds = oldRoot.canvasBounds;
             if (isViewport(oldRoot) && isViewport(newRoot)) {
                 newRoot.zoom = oldRoot.zoom;
@@ -222,7 +225,7 @@ export class UpdateModelCommand extends Command {
             }
         }
         if (isSizeable(left) && isSizeable(right)) {
-            if (!isValidDimension(right.bounds)) {
+            if (!Dimension.isValid(right.bounds)) {
                 right.bounds = {
                     x: right.bounds.x,
                     y: right.bounds.y,

--- a/packages/sprotty/src/features/viewport/center-fit.ts
+++ b/packages/sprotty/src/features/viewport/center-fit.ts
@@ -14,17 +14,18 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Bounds, center, combine, isValidDimension } from "../../utils/geometry";
+import { Action } from "sprotty-protocol/lib/actions";
+import { Viewport } from "sprotty-protocol/lib/model";
+import { Bounds, Dimension } from "sprotty-protocol/lib/utils/geometry";
 import { matchesKeystroke } from "../../utils/keyboard";
 import { SChildElement } from '../../base/model/smodel';
-import { Action } from "../../base/actions/action";
 import { Command, CommandExecutionContext, CommandReturn } from "../../base/commands/command";
 import { SModelElement, SModelRoot } from "../../base/model/smodel";
 import { KeyListener } from "../../base/views/key-tool";
 import { isBoundsAware } from "../bounds/model";
 import { isSelectable } from "../select/model";
 import { ViewportAnimation } from "./viewport";
-import { isViewport, Viewport } from "./model";
+import { isViewport } from "./model";
 import { injectable, inject } from "inversify";
 import { TYPES } from "../../base/types";
 
@@ -34,6 +35,8 @@ import { TYPES } from "../../base/types";
  * It also resets the zoom to its default if retainZoom is false.
  * This action can also be sent from the model source to the client in order to perform such a
  * viewport change programmatically.
+ *
+ * @deprecated Use the declaration in `sprotty-protocol` instead.
  */
 export class CenterAction implements Action {
     static readonly KIND = 'center';
@@ -50,6 +53,8 @@ export class CenterAction implements Action {
  * The resulting FitToScreenCommand changes the zoom and scroll settings of the viewport so the model
  * can be shown completely. This action can also be sent from the model source to the client in order
  * to perform such a viewport change programmatically.
+ *
+ * @deprecated Use the declaration in `sprotty-protocol` instead.
  */
 export class FitToScreenAction implements Action {
     static readonly KIND = 'fit';
@@ -103,8 +108,8 @@ export abstract class BoundsAwareViewportCommand extends Command {
                 );
             }
             if (allBounds.length !== 0) {
-                const bounds = allBounds.reduce((b0, b1) => combine(b0, b1));
-                if (isValidDimension(bounds))
+                const bounds = allBounds.reduce((b0, b1) => Bounds.combine(b0, b1));
+                if (Dimension.isValid(bounds))
                     this.newViewport = this.getNewViewport(bounds, model);
             }
         }
@@ -169,11 +174,11 @@ export class CenterCommand extends BoundsAwareViewportCommand {
     }
 
     getNewViewport(bounds: Bounds, model: SModelRoot): Viewport | undefined {
-        if (!isValidDimension(model.canvasBounds)) {
+        if (!Dimension.isValid(model.canvasBounds)) {
             return undefined;
         }
         const zoom = (this.action.retainZoom && isViewport(model)) ? model.zoom : 1;
-        const c = center(bounds);
+        const c = Bounds.center(bounds);
         return {
             scroll: {
                 x: c.x - 0.5 * model.canvasBounds.width / zoom,
@@ -196,10 +201,10 @@ export class FitToScreenCommand extends BoundsAwareViewportCommand {
     }
 
     getNewViewport(bounds: Bounds, model: SModelRoot): Viewport | undefined {
-        if (!isValidDimension(model.canvasBounds)) {
+        if (!Dimension.isValid(model.canvasBounds)) {
             return undefined;
         }
-        const c = center(bounds);
+        const c = Bounds.center(bounds);
         const delta = this.action.padding === undefined
             ? 0
             : 2 *  this.action.padding;

--- a/packages/sprotty/src/features/viewport/model.ts
+++ b/packages/sprotty/src/features/viewport/model.ts
@@ -14,12 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Scrollable, Zoomable } from "sprotty-protocol/lib/model";
 import { SModelElement, SModelRoot } from "../../base/model/smodel";
-import { Scrollable } from "./scroll";
-import { Zoomable } from "./zoom";
 
 export const viewportFeature = Symbol('viewportFeature');
 
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
 export interface Viewport extends Scrollable, Zoomable {
 }
 

--- a/packages/sprotty/src/features/viewport/scroll.ts
+++ b/packages/sprotty/src/features/viewport/scroll.ts
@@ -135,7 +135,7 @@ export class ScrollMouseListener extends MouseListener {
             zoom: viewport.zoom
         };
         this.lastScrollPosition = { x: event.pageX, y: event.pageY };
-        return [SetViewportAction.create(newViewport, { elementId: viewport.id, animate: false })];
+        return [SetViewportAction.create(viewport.id, newViewport, { animate: false })];
     }
 
     protected moveScrollBar(model: SModelRoot & Viewport, event: MouseEvent, scrollbar: HTMLElement, animate: boolean = false): Action[] {
@@ -176,7 +176,7 @@ export class ScrollMouseListener extends MouseListener {
                 y: modelBounds.y + (position / scrollbarRect.height) * modelBounds.height
             };
         }
-        return [SetViewportAction.create({ scroll: newScroll, zoom: model.zoom }, { elementId: model.id, animate })];
+        return [SetViewportAction.create(model.id, { scroll: newScroll, zoom: model.zoom }, { animate })];
     }
 
     protected getScrollbar(event: MouseEvent): HTMLElement | undefined {

--- a/packages/sprotty/src/features/viewport/scroll.ts
+++ b/packages/sprotty/src/features/viewport/scroll.ts
@@ -14,24 +14,29 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Point } from '../../utils/geometry';
+import { Action, CenterAction, SetViewportAction } from 'sprotty-protocol/lib/actions';
+import { Point } from 'sprotty-protocol/lib/utils/geometry';
 import { SModelElement, SModelRoot } from '../../base/model/smodel';
 import { MouseListener } from '../../base/views/mouse-tool';
-import { Action } from '../../base/actions/action';
 import { SModelExtension } from '../../base/model/smodel-extension';
 import { findParentByFeature } from '../../base/model/smodel-utils';
-import { SetViewportAction } from './viewport';
-import { isViewport, Viewport } from './model';
+import { isViewport } from './model';
 import { isMoveable } from '../move/model';
 import { SRoutingHandle } from '../routing/model';
 import { getModelBounds } from '../projection/model';
-import { CenterAction } from './center-fit';
 import { hitsMouseEvent } from '../../utils/browser';
+import { Viewport } from 'sprotty-protocol/lib/model';
 
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
 export interface Scrollable extends SModelExtension {
     scroll: Point
 }
 
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
 export function isScrollable(element: SModelElement | Scrollable): element is Scrollable {
     return 'scroll' in element;
 }
@@ -112,7 +117,7 @@ export class ScrollMouseListener extends MouseListener {
                     elementId = targetElement.id.substring('vertical-projection:'.length);
                 }
                 if (elementId) {
-                    return [new CenterAction([elementId], true, true)];
+                    return [CenterAction.create([elementId], { animate: true, retainZoom: true })];
                 }
             }
         }
@@ -130,7 +135,7 @@ export class ScrollMouseListener extends MouseListener {
             zoom: viewport.zoom
         };
         this.lastScrollPosition = { x: event.pageX, y: event.pageY };
-        return [new SetViewportAction(viewport.id, newViewport, false)];
+        return [SetViewportAction.create(newViewport, { elementId: viewport.id, animate: false })];
     }
 
     protected moveScrollBar(model: SModelRoot & Viewport, event: MouseEvent, scrollbar: HTMLElement, animate: boolean = false): Action[] {
@@ -171,7 +176,7 @@ export class ScrollMouseListener extends MouseListener {
                 y: modelBounds.y + (position / scrollbarRect.height) * modelBounds.height
             };
         }
-        return [new SetViewportAction(model.id, { scroll: newScroll, zoom: model.zoom }, animate)];
+        return [SetViewportAction.create({ scroll: newScroll, zoom: model.zoom }, { elementId: model.id, animate })];
     }
 
     protected getScrollbar(event: MouseEvent): HTMLElement | undefined {

--- a/packages/sprotty/src/features/viewport/viewport-root.ts
+++ b/packages/sprotty/src/features/viewport/viewport-root.ts
@@ -14,9 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Bounds, Point, isBounds, isValidDimension, EMPTY_DIMENSION, Dimension, ORIGIN_POINT } from "../../utils/geometry";
-import { SModelRoot, SModelIndex, SModelElement, SModelRootSchema } from '../../base/model/smodel';
-import { Viewport, viewportFeature } from "./model";
+import { SModelRoot as SModelRootSchema, Viewport } from 'sprotty-protocol/lib/model';
+import { Bounds, Dimension, isBounds, Point } from 'sprotty-protocol/lib/utils/geometry';
+import { SModelRoot, ModelIndexImpl } from '../../base/model/smodel';
+import { viewportFeature } from "./model";
 import { exportFeature } from "../export/model";
 import { BoundsAware } from "../bounds/model";
 
@@ -36,10 +37,10 @@ export class ViewportRootElement extends SModelRoot implements Viewport, BoundsA
 
     scroll: Point = { x: 0, y: 0 };
     zoom: number = 1;
-    position: Point = ORIGIN_POINT;
-    size: Dimension = EMPTY_DIMENSION;
+    position: Point = Point.ORIGIN;
+    size: Dimension = Dimension.EMPTY;
 
-    constructor(index?: SModelIndex<SModelElement>) {
+    constructor(index?: ModelIndexImpl) {
         super(index);
     }
 
@@ -84,7 +85,7 @@ export class ViewportRootElement extends SModelRoot implements Viewport, BoundsA
             width: -1,
             height: -1
         };
-        if (isBounds(point) && isValidDimension(point)) {
+        if (isBounds(point) && Dimension.isValid(point)) {
             result.width = point.width / this.zoom;
             result.height = point.height / this.zoom;
         }

--- a/packages/sprotty/src/features/viewport/zoom.ts
+++ b/packages/sprotty/src/features/viewport/zoom.ts
@@ -14,20 +14,26 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Point } from "../../utils/geometry";
+import { Action, SetViewportAction } from "sprotty-protocol/lib/actions";
+import { Viewport } from "sprotty-protocol/lib/model";
+import { Point } from "sprotty-protocol/lib/utils/geometry";
 import { getWindowScroll } from "../../utils/browser";
 import { SModelElement, SModelRoot } from "../../base/model/smodel";
 import { MouseListener } from "../../base/views/mouse-tool";
-import { Action } from "../../base/actions/action";
 import { SModelExtension } from "../../base/model/smodel-extension";
 import { findParentByFeature } from "../../base/model/smodel-utils";
-import { SetViewportAction } from "./viewport";
-import { isViewport, Viewport } from "./model";
+import { isViewport } from "./model";
 
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
 export interface Zoomable extends SModelExtension {
     zoom: number
 }
 
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
 export function isZoomable(element: SModelElement | Zoomable): element is Zoomable {
     return 'zoom' in element;
 }
@@ -56,7 +62,7 @@ export class ZoomMouseListener extends MouseListener {
                 },
                 zoom: viewport.zoom * newZoom
             };
-            return [new SetViewportAction(viewport.id, newViewport, false)];
+            return [SetViewportAction.create(newViewport, { elementId: viewport.id, animate: false })];
         }
         return [];
     }

--- a/packages/sprotty/src/features/viewport/zoom.ts
+++ b/packages/sprotty/src/features/viewport/zoom.ts
@@ -62,7 +62,7 @@ export class ZoomMouseListener extends MouseListener {
                 },
                 zoom: viewport.zoom * newZoom
             };
-            return [SetViewportAction.create(newViewport, { elementId: viewport.id, animate: false })];
+            return [SetViewportAction.create(viewport.id, newViewport, { animate: false })];
         }
         return [];
     }

--- a/packages/sprotty/src/features/zorder/zorder.spec.ts
+++ b/packages/sprotty/src/features/zorder/zorder.spec.ts
@@ -54,7 +54,7 @@ describe('BringToFrontCommand', () => {
     const lastIndex = initialModel.children.length - 1;
 
     // Create the z-order action
-    const myZOrderAction = new BringToFrontAction(['node1']);
+    const myZOrderAction = BringToFrontAction.create(['node1']);
 
     // Create the z-order command
     const cmd = new BringToFrontCommand(myZOrderAction);

--- a/packages/sprotty/src/features/zorder/zorder.ts
+++ b/packages/sprotty/src/features/zorder/zorder.ts
@@ -15,20 +15,27 @@
  ********************************************************************************/
 
 import { injectable, inject } from "inversify";
+import { Action } from "sprotty-protocol/lib/actions";
 import { TYPES } from "../../base/types";
 import { SModelRoot, SChildElement, SModelElement, SParentElement } from '../../base/model/smodel';
-import { Action } from "../../base/actions/action";
 import { Command, CommandExecutionContext } from "../../base/commands/command";
 import { SRoutableElement, SConnectableElement } from "../routing/model";
 
 /**
  * Action to render the selected elements in front of others by manipulating the z-order.
  */
-export class BringToFrontAction implements Action {
-    static readonly KIND = 'bringToFront';
-    kind = BringToFrontAction.KIND;
+export interface BringToFrontAction extends Action {
+    kind: typeof BringToFrontAction.KIND;
+    elementIDs: string[]
+}
+export namespace BringToFrontAction {
+    export const KIND = 'bringToFront';
 
-    constructor(public readonly elementIDs: string[]) {
+    export function create(elementIDs: string[]): BringToFrontAction {
+        return {
+            kind: KIND,
+            elementIDs
+        };
     }
 }
 

--- a/packages/sprotty/src/graph/sgraph-factory.ts
+++ b/packages/sprotty/src/graph/sgraph-factory.ts
@@ -15,15 +15,14 @@
  ********************************************************************************/
 
 import { injectable } from "inversify";
+import {
+    SCompartment as SCompartmentSchema, SEdge as SEdgeSchema, SGraph as SGraphSchema, SLabel as SLabelSchema,
+    SModelElement as SModelElementSchema, SModelRoot as SModelRootSchema, SNode as SNodeSchema, SPort as SPortSchema
+} from 'sprotty-protocol/lib/model';
 import { SModelFactory, createFeatureSet } from "../base/model/smodel-factory";
-import {
-    SChildElement, SModelElementSchema, SModelRoot, SModelRootSchema, SParentElement
-} from "../base/model/smodel";
+import { SChildElement, SModelRoot, SParentElement } from "../base/model/smodel";
 import { getBasicType } from "../base/model/smodel-utils";
-import {
-    SCompartment, SEdge, SEdgeSchema, SGraph, SGraphSchema, SLabel, SLabelSchema, SNode,
-    SNodeSchema, SPortSchema, SPort, SCompartmentSchema
-} from "./sgraph";
+import { SCompartment, SEdge, SGraph, SLabel, SNode, SPort } from "./sgraph";
 import { SButton, SButtonSchema } from '../features/button/model';
 
 /**

--- a/packages/sprotty/src/graph/sgraph.ts
+++ b/packages/sprotty/src/graph/sgraph.ts
@@ -14,9 +14,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { SChildElement, SModelElement, SModelElementSchema, SModelIndex, SModelRootSchema } from '../base/model/smodel';
-import { Alignable, alignFeature, BoundsAware, boundsFeature, layoutableChildFeature, layoutContainerFeature,
-    ModelLayoutOptions, SShapeElement, SShapeElementSchema } from '../features/bounds/model';
+import {
+    SModelElement as SModelElementSchema, SModelRoot as SModelRootSchema, SShapeElement as SShapeElementSchema
+} from 'sprotty-protocol/lib/model';
+import { Bounds, Point } from 'sprotty-protocol/lib/utils/geometry';
+import { ModelIndexImpl, SChildElement, SModelElement } from '../base/model/smodel';
+import {
+    Alignable, alignFeature, BoundsAware, boundsFeature, layoutableChildFeature, layoutContainerFeature,
+    ModelLayoutOptions, SShapeElement
+} from '../features/bounds/model';
 import { edgeLayoutFeature, EdgePlacement } from '../features/edge-layout/model';
 import { deletableFeature } from '../features/edit/delete';
 import { editFeature } from '../features/edit/model';
@@ -26,11 +32,12 @@ import { moveFeature } from '../features/move/model';
 import { connectableFeature, SConnectableElement, SRoutableElement } from '../features/routing/model';
 import { Selectable, selectFeature } from '../features/select/model';
 import { ViewportRootElement } from '../features/viewport/viewport-root';
-import { Bounds, ORIGIN_POINT, Point } from '../utils/geometry';
 import { FluentIterable, FluentIterableImpl } from '../utils/iterable';
 
 /**
  * Serializable schema for graph-like models.
+ *
+ * @deprecated Use `SGraph` from `sprotty-protocol` instead.
  */
 export interface SGraphSchema extends SModelRootSchema {
     children: SModelElementSchema[]
@@ -53,6 +60,8 @@ export class SGraph extends ViewportRootElement {
 
 /**
  * Serializable schema for SNode.
+ *
+ * @deprecated Use `SNode` from `sprotty-protocol` instead.
  */
 export interface SNodeSchema extends SShapeElementSchema {
     layout?: string
@@ -85,6 +94,8 @@ export class SNode extends SConnectableElement implements Selectable, Fadeable, 
 
 /**
  * Serializable schema for SPort.
+ *
+ * @deprecated Use `SPort` from `sprotty-protocol` instead.
  */
 export interface SPortSchema extends SShapeElementSchema {
     selected?: boolean
@@ -108,6 +119,8 @@ export class SPort extends SConnectableElement implements Selectable, Fadeable, 
 
 /**
  * Serializable schema for SEdge.
+ *
+ * @deprecated Use `SEdge` from `sprotty-protocol` instead.
  */
 export interface SEdgeSchema extends SModelElementSchema {
     sourceId: string
@@ -136,6 +149,8 @@ export class SEdge extends SRoutableElement implements Fadeable, Selectable, Hov
 
 /**
  * Serializable schema for SLabel.
+ *
+ * @deprecated Use `SLabel` from `sprotty-protocol` instead.
  */
 export interface SLabelSchema extends SShapeElementSchema {
     text: string
@@ -151,7 +166,7 @@ export class SLabel extends SShapeElement implements Selectable, Alignable, Fade
 
     text: string;
     selected: boolean = false;
-    alignment: Point = ORIGIN_POINT;
+    alignment: Point = Point.ORIGIN;
     opacity = 1;
     edgePlacement?: EdgePlacement;
 
@@ -159,6 +174,8 @@ export class SLabel extends SShapeElement implements Selectable, Alignable, Fade
 
 /**
  * Serializable schema for SCompartment.
+ *
+ * @deprecated Use `SCompartment` from `sprotty-protocol` instead.
  */
 export interface SCompartmentSchema extends SShapeElementSchema {
     layout?: string
@@ -182,7 +199,7 @@ export class SCompartment extends SShapeElement implements Fadeable {
 /**
  * A specialized model index that tracks outgoing and incoming edges.
  */
-export class SGraphIndex extends SModelIndex<SModelElement> {
+export class SGraphIndex extends ModelIndexImpl {
 
     private outgoing: Map<string, SEdge[]> = new Map;
     private incoming: Map<string, SEdge[]> = new Map;

--- a/packages/sprotty/src/graph/views.tsx
+++ b/packages/sprotty/src/graph/views.tsx
@@ -17,6 +17,7 @@
 /** @jsx svg */
 import { inject, injectable } from 'inversify';
 import { VNode } from "snabbdom";
+import { Point } from 'sprotty-protocol/lib/utils/geometry';
 import { getSubType } from "../base/model/smodel-utils";
 import { IViewArgs, IView, RenderingContext } from "../base/views/view";
 import { setAttr } from '../base/views/vnode-utils';
@@ -27,7 +28,7 @@ import { SRoutableElement, SRoutingHandle } from '../features/routing/model';
 import { EdgeRouterRegistry, RoutedPoint } from '../features/routing/routing';
 import { RoutableView } from '../features/routing/views';
 import { svg } from '../lib/jsx';
-import { Point, PointToPointLine, shiftTowards } from '../utils/geometry';
+import { PointToPointLine } from '../utils/geometry';
 import { SCompartment, SEdge, SGraph, SLabel } from "./sgraph";
 
 /**
@@ -165,8 +166,8 @@ export class JumpingPolylineEdgeView extends PolylineEdgeView {
     }
 
     protected createJumpPath(intersectionPoint: Point, lineSegment: PointToPointLine): string {
-        const anchorBefore = shiftTowards(intersectionPoint, lineSegment.p1, this.jumpOffsetBefore);
-        const anchorAfter = shiftTowards(intersectionPoint, lineSegment.p2, this.jumpOffsetAfter);
+        const anchorBefore = Point.shiftTowards(intersectionPoint, lineSegment.p1, this.jumpOffsetBefore);
+        const anchorAfter = Point.shiftTowards(intersectionPoint, lineSegment.p2, this.jumpOffsetAfter);
         const rotation = lineSegment.p1.x < lineSegment.p2.x ? 1 : 0;
         return ` L ${anchorBefore.x},${anchorBefore.y} A 1,1 0,0 ${rotation} ${anchorAfter.x},${anchorAfter.y}`;
     }
@@ -181,8 +182,8 @@ export class JumpingPolylineEdgeView extends PolylineEdgeView {
             offsetBefore = this.jumpOffsetBefore + this.skipOffsetAfter;
             offsetAfter = -this.skipOffsetBefore;
         }
-        const anchorBefore = shiftTowards(intersectionPoint, lineSegment.p1, offsetBefore);
-        const anchorAfter = shiftTowards(intersectionPoint, lineSegment.p2, offsetAfter);
+        const anchorBefore = Point.shiftTowards(intersectionPoint, lineSegment.p1, offsetBefore);
+        const anchorAfter = Point.shiftTowards(intersectionPoint, lineSegment.p2, offsetAfter);
         return ` L ${anchorBefore.x},${anchorBefore.y} M ${anchorAfter.x},${anchorAfter.y}`;
     }
 
@@ -209,8 +210,8 @@ export class JumpingPolylineEdgeView extends PolylineEdgeView {
     }
 
     protected createSkipPath(intersectionPoint: Point, lineSegment: PointToPointLine): string {
-        const anchorBefore = shiftTowards(intersectionPoint, lineSegment.p1, this.skipOffsetBefore);
-        const anchorAfter = shiftTowards(intersectionPoint, lineSegment.p2, this.skipOffsetAfter);
+        const anchorBefore = Point.shiftTowards(intersectionPoint, lineSegment.p1, this.skipOffsetBefore);
+        const anchorAfter = Point.shiftTowards(intersectionPoint, lineSegment.p2, this.skipOffsetAfter);
         return ` L ${anchorBefore.x},${anchorBefore.y} M ${anchorAfter.x},${anchorAfter.y}`;
     }
 

--- a/packages/sprotty/src/lib/model.ts
+++ b/packages/sprotty/src/lib/model.ts
@@ -14,8 +14,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { SModelRoot, SModelRootSchema, SChildElement, SModelElementSchema } from "../base/model/smodel";
-import { Point, Dimension, ORIGIN_POINT, EMPTY_DIMENSION, Bounds, isValidDimension, EMPTY_BOUNDS } from "../utils/geometry";
+import { SModelElement as SModelElementSchema, SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
+import { Bounds, Dimension, Point } from "sprotty-protocol/lib/utils/geometry";
+import { SModelRoot, SChildElement } from "../base/model/smodel";
 import { BoundsAware, boundsFeature, Alignable, alignFeature, isBoundsAware } from "../features/bounds/model";
 import { Locateable, moveFeature } from "../features/move/model";
 import { Selectable, selectFeature } from "../features/select/model";
@@ -69,6 +70,8 @@ export class RectangularPort extends SPort {
 
 /**
  * Serializable schema for HtmlRoot.
+ *
+ * @deprecated Use `HtmlRoot` from `sprotty-protocol` instead.
  */
 export interface HtmlRootSchema extends SModelRootSchema {
     classes?: string[]
@@ -83,6 +86,8 @@ export class HtmlRoot extends SModelRoot {
 
 /**
  * Serializable schema for PreRenderedElement.
+ *
+ * @deprecated Use `PreRenderedElement` from `sprotty-protocol` instead.
  */
 export interface PreRenderedElementSchema extends SModelElementSchema {
     code: string
@@ -98,6 +103,8 @@ export class PreRenderedElement extends SChildElement {
 
 /**
  * Serializable schema for ShapedPreRenderedElement.
+ *
+ * @deprecated Use `ShapedPreRenderedElement` from `sprotty-protocol` instead.
  */
 export interface ShapedPreRenderedElementSchema extends PreRenderedElementSchema {
     position?: Point
@@ -110,10 +117,10 @@ export interface ShapedPreRenderedElementSchema extends PreRenderedElementSchema
 export class ShapedPreRenderedElement extends PreRenderedElement implements BoundsAware, Locateable, Selectable, Alignable {
     static readonly DEFAULT_FEATURES = [moveFeature, boundsFeature, selectFeature, alignFeature];
 
-    position: Point = ORIGIN_POINT;
-    size: Dimension = EMPTY_DIMENSION;
+    position: Point = Point.ORIGIN;
+    size: Dimension = Dimension.EMPTY;
     selected: boolean = false;
-    alignment: Point = ORIGIN_POINT;
+    alignment: Point = Point.ORIGIN;
 
     get bounds(): Bounds {
         return {
@@ -151,7 +158,7 @@ export class ShapedPreRenderedElement extends PreRenderedElement implements Boun
 export class ForeignObjectElement extends ShapedPreRenderedElement {
     namespace: string;
     get bounds(): Bounds {
-        if (isValidDimension(this.size)) {
+        if (Dimension.isValid(this.size)) {
             return {
                 x: this.position.x,
                 y: this.position.y,
@@ -166,12 +173,14 @@ export class ForeignObjectElement extends ShapedPreRenderedElement {
                 height: this.parent.bounds.height
             };
         }
-        return EMPTY_BOUNDS;
+        return Bounds.EMPTY;
     }
 }
 
 /**
  * Serializable schema for ForeignObjectElement.
+ *
+ * @deprecated Use `ForeignObjectElement` from `sprotty-protocol` instead.
  */
 export interface ForeignObjectElementSchema extends ShapedPreRenderedElementSchema {
     /** The namespace to be assigned to the elements inside of the `foreignObject`. */

--- a/packages/sprotty/src/lib/svg-views.tsx
+++ b/packages/sprotty/src/lib/svg-views.tsx
@@ -18,6 +18,7 @@
 import { svg } from './jsx';
 
 import { VNode } from "snabbdom";
+import { Point } from 'sprotty-protocol/lib/utils/geometry';
 import { IView, IViewArgs, RenderingContext } from "../base/views/view";
 import { SNode, SPort } from "../graph/sgraph";
 import { ViewportRootElement } from "../features/viewport/viewport-root";
@@ -25,7 +26,7 @@ import { SShapeElement } from '../features/bounds/model';
 import { ShapeView } from '../features/bounds/views';
 import { Hoverable } from '../features/hover/model';
 import { Selectable } from '../features/select/model';
-import { Diamond, Point } from '../utils/geometry';
+import { Diamond } from '../utils/geometry';
 import { SModelElement } from '../base/model/smodel';
 import { injectable } from 'inversify';
 

--- a/packages/sprotty/src/model-source/commit-model.ts
+++ b/packages/sprotty/src/model-source/commit-model.ts
@@ -15,9 +15,10 @@
  ********************************************************************************/
 
 import { inject, injectable } from "inversify";
-import { Action } from "../base/actions/action";
+import { Action } from "sprotty-protocol/lib/actions";
+import { SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
 import { CommandExecutionContext, CommandReturn, SystemCommand } from "../base/commands/command";
-import { SModelRoot, SModelRootSchema } from "../base/model/smodel";
+import { SModelRoot } from "../base/model/smodel";
 import { TYPES } from "../base/types";
 import { ModelSource } from "./model-source";
 
@@ -29,13 +30,22 @@ import { ModelSource } from "./model-source";
  * commands finishes, it fires a CommitModelAction to write the final changes back to
  * the model source.
  */
-export class CommitModelAction implements Action {
-    readonly kind = CommitModelCommand.KIND;
+export interface CommitModelAction extends Action {
+    kind: typeof CommitModelAction.KIND;
+}
+export namespace CommitModelAction {
+    export const KIND = 'commitModel';
+
+    export function create(): CommitModelAction {
+        return {
+            kind: KIND
+        };
+    }
 }
 
 @injectable()
 export class CommitModelCommand extends SystemCommand {
-    static readonly KIND = 'commitModel';
+    static readonly KIND = CommitModelAction.KIND;
 
     @inject(TYPES.ModelSource) modelSource: ModelSource;
 

--- a/packages/sprotty/src/model-source/diagram-server.ts
+++ b/packages/sprotty/src/model-source/diagram-server.ts
@@ -16,30 +16,36 @@
 
 import { saveAs } from 'file-saver';
 import { inject, injectable } from "inversify";
-import { Action } from "../base/actions/action";
+import {
+    Action, CollapseExpandAction, CollapseExpandAllAction, ComputedBoundsAction, RequestModelAction,
+    RequestPopupModelAction, SetModelAction, UpdateModelAction
+} from 'sprotty-protocol/lib/actions';
+import { SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
+import { hasOwnProperty } from 'sprotty-protocol/lib/utils/object';
 import { ActionHandlerRegistry } from "../base/actions/action-handler";
 import { ICommand } from "../base/commands/command";
-import { SetModelAction, SetModelCommand, RequestModelAction } from "../base/features/set-model";
-import { SModelRootSchema } from "../base/model/smodel";
+import { SetModelCommand } from "../base/features/set-model";
 import { TYPES } from "../base/types";
-import { ComputedBoundsAction, RequestBoundsCommand } from '../features/bounds/bounds-manipulation';
-import { CollapseExpandAction, CollapseExpandAllAction } from '../features/expand/expand';
+import { RequestBoundsCommand } from '../features/bounds/bounds-manipulation';
 import { ExportSvgAction } from '../features/export/svg-exporter';
-import { RequestPopupModelAction } from "../features/hover/hover";
 import { OpenAction } from '../features/open/open';
-import { UpdateModelAction, UpdateModelCommand } from "../features/update/update-model";
+import { UpdateModelCommand } from "../features/update/update-model";
 import { ILogger } from "../utils/logging";
-import { hasOwnProperty } from '../utils/object';
 import { ComputedBoundsApplicator, ModelSource } from "./model-source";
 
 /**
  * Wrapper for actions when transferring them between client and server via a DiagramServer.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export interface ActionMessage {
     clientId: string
     action: Action
 }
 
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
 export function isActionMessage(object: unknown): object is ActionMessage {
     return hasOwnProperty(object, 'action');
 }
@@ -64,7 +70,7 @@ const receivedFromServerProperty = '__receivedFromServer';
  * external model source.
  */
 @injectable()
-export abstract class DiagramServer extends ModelSource {
+export abstract class DiagramServerProxy extends ModelSource {
 
     @inject(TYPES.ILogger) protected logger: ILogger;
     @inject(ComputedBoundsApplicator) protected readonly computedBoundsApplicator: ComputedBoundsApplicator;
@@ -189,9 +195,9 @@ export abstract class DiagramServer extends ModelSource {
             const root = this.currentRoot;
             this.computedBoundsApplicator.apply(root, action);
             if (root.type === this.lastSubmittedModelType) {
-                this.actionDispatcher.dispatch(new UpdateModelAction(root));
+                this.actionDispatcher.dispatch(UpdateModelAction.create(root));
             } else {
-                this.actionDispatcher.dispatch(new SetModelAction(root));
+                this.actionDispatcher.dispatch(SetModelAction.create(root));
             }
             this.lastSubmittedModelType = root.type;
             return false;
@@ -214,3 +220,8 @@ export abstract class DiagramServer extends ModelSource {
         return previousRoot;
     }
 }
+
+/**
+ * @deprecated Use `DiagramServerProxy` instead.
+ */
+export const DiagramServer = DiagramServerProxy;

--- a/packages/sprotty/src/model-source/model-source.ts
+++ b/packages/sprotty/src/model-source/model-source.ts
@@ -15,17 +15,16 @@
  ********************************************************************************/
 
 import { inject, injectable } from "inversify";
-import { Action } from "../base/actions/action";
+import { Action, ComputedBoundsAction, RequestModelAction } from "sprotty-protocol/lib/actions";
+import { SModelElement as SModelElementSchema, SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
+import { Dimension, Point } from 'sprotty-protocol/lib/utils/geometry';
+import { SModelIndex } from "sprotty-protocol/lib/utils/model-utils";
 import { IActionDispatcher } from "../base/actions/action-dispatcher";
 import { ActionHandlerRegistry, IActionHandler, IActionHandlerInitializer } from "../base/actions/action-handler";
 import { ICommand } from "../base/commands/command";
-import { RequestModelAction } from "../base/features/set-model";
 import { TYPES } from "../base/types";
 import { ViewerOptions } from "../base/views/viewer-options";
 import { ExportSvgAction } from '../features/export/svg-exporter';
-import { SModelRootSchema, SModelIndex, SModelElementSchema } from "../base/model/smodel";
-import { ComputedBoundsAction } from "../features/bounds/bounds-manipulation";
-import { Point, Dimension } from "../utils/geometry";
 
 /**
  * A model source is serving the model to the event cycle. It represents
@@ -76,7 +75,7 @@ export abstract class ModelSource implements IActionHandler, IActionHandlerIniti
 
 @injectable()
 export class ComputedBoundsApplicator {
-    apply(root: SModelRootSchema, action: ComputedBoundsAction): SModelIndex<SModelElementSchema> {
+    apply(root: SModelRootSchema, action: ComputedBoundsAction): SModelIndex {
         const index = new SModelIndex();
         index.add(root);
         for (const b of action.bounds) {

--- a/packages/sprotty/src/model-source/websocket.ts
+++ b/packages/sprotty/src/model-source/websocket.ts
@@ -15,14 +15,14 @@
  ********************************************************************************/
 
 import { injectable } from "inversify";
-import { DiagramServer, ActionMessage } from "./diagram-server";
+import { ActionMessage } from "sprotty-protocol/lib/actions";
+import { DiagramServerProxy } from "./diagram-server";
 
 /**
- * An external ModelSource that connects to the model provider using a
- * websocket.
+ * An external ModelSource that connects to the model provider using a websocket.
  */
 @injectable()
-export class WebSocketDiagramServer extends DiagramServer {
+export class WebSocketDiagramServerProxy extends DiagramServerProxy {
 
     protected webSocket?: WebSocket;
 
@@ -51,3 +51,8 @@ export class WebSocketDiagramServer extends DiagramServer {
         }
     }
 }
+
+/**
+ * @deprecated Use `WebSocketDiagramServerProxy` instead;
+ */
+export const WebSocketDiagramServer = WebSocketDiagramServerProxy;

--- a/packages/sprotty/src/utils/async.ts
+++ b/packages/sprotty/src/utils/async.ts
@@ -17,6 +17,8 @@
 /**
  * Simple implementation of the deferred pattern.
  * An object that exposes a promise and functions to resolve and reject it.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export class Deferred<T> {
     resolve: (value?: T | PromiseLike<T>) => void;

--- a/packages/sprotty/src/utils/browser.ts
+++ b/packages/sprotty/src/utils/browser.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Point, ORIGIN_POINT } from "./geometry";
+import { Point } from 'sprotty-protocol';
 
 /**
  * Returns whether the mouse or keyboard event includes the CMD key
@@ -48,7 +48,7 @@ export function isCrossSite(url: string): boolean {
  */
 export function getWindowScroll(): Point {
     if (typeof window === 'undefined') {
-        return ORIGIN_POINT;
+        return Point.ORIGIN;
     }
     return {
         x: window.pageXOffset,

--- a/packages/sprotty/src/utils/geometry.spec.ts
+++ b/packages/sprotty/src/utils/geometry.spec.ts
@@ -16,83 +16,36 @@
 
 import "mocha";
 import { expect } from "chai";
-import { almostEquals, euclideanDistance, manhattanDistance, Bounds, combine, includes, ORIGIN_POINT, angleBetweenPoints, PointToPointLine } from "./geometry";
+import { almostEquals } from 'sprotty-protocol/lib/utils/geometry';
+import { PointToPointLine } from "./geometry";
 
-describe('geometry', () => {
-    describe('euclideanDistance', () => {
-        it('works as expected', () => {
-            expect(euclideanDistance({x: 0, y: 0}, {x: 3, y: 4})).to.equal(5);
+describe('PointToPointLine', () => {
+    describe('angle', () => {
+        it('computes a 45° angle correctly', () => {
+            expect(almostEquals(new PointToPointLine({ x: 0, y: 0 }, { x: 1, y: 1 }).angle, Math.PI / 4)).to.be.true;
         });
-    });
-
-    describe('manhattanDistance', () => {
-        it('works as expected', () => {
-            expect(manhattanDistance({x: 0, y: 0}, {x: 3, y: 4})).to.equal(7);
-        });
-    });
-
-    describe('almostEquals', () => {
-        it('returns false for clearly different values', () => {
-            expect(almostEquals(3, 17)).to.be.false;
-        });
-        it('returns true for almost equal values', () => {
-            expect(almostEquals(3.12895, 3.12893)).to.be.true;
-        });
-    });
-
-    describe('combine', () => {
-        it('includes all corner points of the input bounds', () => {
-            const b0: Bounds = { x: 2, y: 2, width: 4, height: 6 };
-            const b1: Bounds = { x: 5, y: 3, width: 5, height: 10 };
-            const b2 = combine(b0, b1);
-            expect(includes(b2, b0)).to.be.true;
-            expect(includes(b2, b1)).to.be.true;
-            expect(includes(b2, { x: b0.x + b0.width, y: b0.y + b0.height })).to.be.true;
-            expect(includes(b2, { x: b1.x + b1.width, y: b1.y + b1.height })).to.be.true;
-            expect(includes(b2, ORIGIN_POINT)).to.be.false;
-            expect(includes(b2, { x: 100, y: 100 })).to.be.false;
-        });
-    });
-
-    describe('angleBetweenPoints', () => {
         it('computes a 90° angle correctly', () => {
-            expect(angleBetweenPoints({ x: 2, y: 0 }, { x: 0, y: 3 })).to.equal(Math.PI / 2);
-            expect(angleBetweenPoints({ x: 2, y: 0 }, { x: 0, y: -3 })).to.equal(Math.PI / 2);
+            expect(almostEquals(new PointToPointLine({ x: 0, y: 0 }, { x: 0, y: 1 }).angle, Math.PI / 2)).to.be.true;
+            expect(almostEquals(new PointToPointLine({ x: 0, y: 0 }, { x: 0, y: -1 }).angle, -Math.PI / 2)).to.be.true;
         });
         it('computes a 180° angle correctly', () => {
-            expect(angleBetweenPoints({ x: 2, y: 0 }, { x: -3, y: 0 })).to.equal(Math.PI);
-            expect(angleBetweenPoints({ x: 0, y: 2 }, { x: 0, y: -3 })).to.equal(Math.PI);
+            expect(almostEquals(new PointToPointLine({ x: 0, y: 0 }, { x: 1, y: 0 }).angle, 0)).to.be.true;
+            expect(almostEquals(new PointToPointLine({ x: 0, y: 0 }, { x: -1, y: 0 }).angle, -Math.PI)).to.be.true;
         });
     });
-
-    describe('PointToPointLine', () => {
-        describe('angle', () => {
-            it('computes a 45° angle correctly', () => {
-                expect(almostEquals(new PointToPointLine({ x: 0, y: 0 }, { x: 1, y: 1 }).angle, Math.PI / 4)).to.be.true;
-            });
-            it('computes a 90° angle correctly', () => {
-                expect(almostEquals(new PointToPointLine({ x: 0, y: 0 }, { x: 0, y: 1 }).angle, Math.PI / 2)).to.be.true;
-                expect(almostEquals(new PointToPointLine({ x: 0, y: 0 }, { x: 0, y: -1 }).angle, -Math.PI / 2)).to.be.true;
-            });
-            it('computes a 180° angle correctly', () => {
-                expect(almostEquals(new PointToPointLine({ x: 0, y: 0 }, { x: 1, y: 0 }).angle, 0)).to.be.true;
-                expect(almostEquals(new PointToPointLine({ x: 0, y: 0 }, { x: -1, y: 0 }).angle, -Math.PI)).to.be.true;
-            });
+    describe('intersection', () => {
+        it('finds intersection of crossing lines', () => {
+            const lineA = new PointToPointLine({ x: 0, y: 0 }, { x: 1, y: 1 });
+            const lineB = new PointToPointLine({ x: 1, y: 0 }, { x: 0, y: 1 });
+            const intersection = lineA.intersection(lineB);
+            expect(intersection!.x).to.equal(0.5);
+            expect(intersection!.y).to.equal(0.5);
         });
-        describe('intersection', () => {
-            it('finds intersection of crossing lines', () => {
-                const lineA = new PointToPointLine({ x: 0, y: 0 }, { x: 1, y: 1 });
-                const lineB = new PointToPointLine({ x: 1, y: 0 }, { x: 0, y: 1 });
-                const intersection = lineA.intersection(lineB);
-                expect(intersection!.x).to.equal(0.5);
-                expect(intersection!.y).to.equal(0.5);
-            });
-            it('returns `undefined` for parallel lines', () => {
-                const lineA = new PointToPointLine({ x: 0, y: 0 }, { x: 1, y: 0 });
-                const lineB = new PointToPointLine({ x: 0, y: 1 }, { x: 1, y: 1 });
-                const intersection = lineA.intersection(lineB);
-                expect(intersection).to.be.undefined;
-            });
+        it('returns `undefined` for parallel lines', () => {
+            const lineA = new PointToPointLine({ x: 0, y: 0 }, { x: 1, y: 0 });
+            const lineB = new PointToPointLine({ x: 0, y: 1 }, { x: 1, y: 1 });
+            const intersection = lineA.intersection(lineB);
+            expect(intersection).to.be.undefined;
         });
     });
 });

--- a/packages/sprotty/src/utils/geometry.ts
+++ b/packages/sprotty/src/utils/geometry.ts
@@ -16,6 +16,8 @@
 
 /**
  * A Point is composed of the (x,y) coordinates of an object.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export interface Point {
     readonly x: number
@@ -24,6 +26,8 @@ export interface Point {
 
 /**
  * (x,y) coordinates of the origin.
+ *
+ * @deprecated Use `Point.ORIGIN` from `sprotty-protocol` instead.
  */
 export const ORIGIN_POINT: Point = Object.freeze({
     x: 0,
@@ -35,6 +39,8 @@ export const ORIGIN_POINT: Point = Object.freeze({
  * @param {Point} p1 - First point
  * @param {Point} p2 - Second point
  * @returns {Point} The sum of the two points
+ *
+ * @deprecated Use `Point.add` from `sprotty-protocol` instead.
  */
 export function add(p1: Point, p2: Point): Point {
     return {
@@ -48,6 +54,8 @@ export function add(p1: Point, p2: Point): Point {
  * @param {Point} p1 - First point
  * @param {Point} p2 - Second point
  * @returns {Point} The difference of the two points
+ *
+ * @deprecated Use `Point.subtract` from `sprotty-protocol` instead.
  */
 export function subtract(p1: Point, p2: Point): Point {
     return {
@@ -61,6 +69,8 @@ export function subtract(p1: Point, p2: Point): Point {
  * @param {Point} point1 a point
  * @param {Point} point2 another point
  * @returns {boolean} `true` if `point1` has exactly the same `x` and `y` values as `point2`, `false` otherwise.
+ *
+ * @deprecated Use `Point.equals` from `sprotty-protocol` instead.
  */
 export function pointEquals(point1: Point, point2: Point): boolean {
     return point1.x === point2.x && point1.y === point2.y;
@@ -68,6 +78,8 @@ export function pointEquals(point1: Point, point2: Point): boolean {
 
 /**
  * The Dimension of an object is composed of its width and height.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export interface Dimension {
     readonly width: number
@@ -76,6 +88,8 @@ export interface Dimension {
 
 /**
  * A dimension with both width and height set to a negative value, which is considered as undefined.
+ *
+ * @deprecated Use `Dimension.EMPTY` from `sprotty-protocol` instead.
  */
 export const EMPTY_DIMENSION: Dimension = Object.freeze({
     width: -1,
@@ -86,6 +100,8 @@ export const EMPTY_DIMENSION: Dimension = Object.freeze({
  * Checks whether the given dimention is valid, i.e. the width and height are non-zero.
  * @param {Dimension} b - Dimension object
  * @returns {boolean}
+ *
+ * @deprecated Use `Dimension.isValid` from `sprotty-protocol` instead.
  */
 export function isValidDimension(d: Dimension): boolean {
     return d.width >= 0 && d.height >= 0;
@@ -93,10 +109,15 @@ export function isValidDimension(d: Dimension): boolean {
 
 /**
  * The bounds are the position (x, y) and dimension (width, height) of an object.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export interface Bounds extends Point, Dimension {
 }
 
+/**
+ * @deprecated Use `Bounds.EMPTY` from `sprotty-protocol` instead.
+ */
 export const EMPTY_BOUNDS: Bounds = Object.freeze({
     x: 0,
     y: 0,
@@ -104,6 +125,9 @@ export const EMPTY_BOUNDS: Bounds = Object.freeze({
     height: -1
 });
 
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
 export function isBounds(element: any): element is Bounds {
     return 'x' in element
         && 'y' in element
@@ -117,6 +141,8 @@ export function isBounds(element: any): element is Bounds {
  * @param {Bounds} b0 - First bounds object
  * @param {Bounds} b1 - Second bounds object
  * @returns {Bounds} The combined bounds
+ *
+ * @deprecated Use `Bounds.combine` from `sprotty-protocol` instead.
  */
 export function combine(b0: Bounds, b1: Bounds): Bounds {
     if (!isValidDimension(b0))
@@ -137,6 +163,8 @@ export function combine(b0: Bounds, b1: Bounds): Bounds {
  * @param {Bounds} b - Bounds object
  * @param {Point} p - Vector by which to translate the bounds
  * @returns {Bounds} The translated bounds
+ *
+ * @deprecated Use `Bounds.translate` from `sprotty-protocol` instead.
  */
 export function translate(b: Bounds, p: Point): Bounds {
     return {
@@ -151,6 +179,8 @@ export function translate(b: Bounds, p: Point): Bounds {
  * Returns the center point of the bounds of an object
  * @param {Bounds} b - Bounds object
  * @returns {Point} the center point
+ *
+ * @deprecated Use `Bounds.center` from `sprotty-protocol` instead.
  */
 export function center(b: Bounds): Point {
     return {
@@ -159,6 +189,9 @@ export function center(b: Bounds): Point {
     };
 }
 
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
 export function centerOfLine(s: Point, e: Point): Point {
     const b: Bounds = {
         x: s.x > e.x ? e.x : s.x,
@@ -171,6 +204,8 @@ export function centerOfLine(s: Point, e: Point): Point {
 
 /**
  * Checks whether the point p is included in the bounds b.
+ *
+ * @deprecated Use `Bounds.includes` from `sprotty-protocol` instead.
  */
 export function includes(b: Bounds, p: Point): boolean {
     return p.x >= b.x && p.x <= b.x + b.width && p.y >= b.y && p.y <= b.y + b.height;
@@ -199,6 +234,8 @@ export type Orientation = 'north' | 'south' | 'east' | 'west';
  * @param {Point} a - First point
  * @param {Point} b - Second point
  * @returns {number} The Eucledian distance
+ *
+ * @deprecated Use `Point.euclideanDistance` from `sprotty-protocol` instead.
  */
 export function euclideanDistance(a: Point, b: Point): number {
     const dx = b.x - a.x;
@@ -212,6 +249,8 @@ export function euclideanDistance(a: Point, b: Point): number {
  * @param {Point} a - First point
  * @param {Point} b - Second point
  * @returns {number} The Manhattan distance
+ *
+ * @deprecated Use `Point.manhattanDistance` from `sprotty-protocol` instead.
  */
 export function manhattanDistance(a: Point, b: Point): number {
     return Math.abs(b.x - a.x) + Math.abs(b.y - a.y);
@@ -222,6 +261,8 @@ export function manhattanDistance(a: Point, b: Point): number {
  * @param {Point} a - First point
  * @param {Point} b - Second point
  * @returns {number} The maximum distance
+ *
+ * @deprecated Use `Point.maxDistance` from `sprotty-protocol` instead.
  */
 export function maxDistance(a: Point, b: Point): number {
     return Math.max(Math.abs(b.x - a.x), Math.abs(b.y - a.y));
@@ -231,6 +272,8 @@ export function maxDistance(a: Point, b: Point): number {
  * Computes the angle in radians of the given point to the x-axis of the coordinate system.
  * The result is in the range [-pi, pi].
  * @param {Point} p - A point in the Eucledian plane
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export function angleOfPoint(p: Point): number {
     return Math.atan2(p.y, p.x);
@@ -241,6 +284,8 @@ export function angleOfPoint(p: Point): number {
  * The result is in the range [0, pi]. Returns NaN if the points are equal.
  * @param {Point} a - First point
  * @param {Point} b - Second point
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export function angleBetweenPoints(a: Point, b: Point): number {
     const lengthProduct = Math.sqrt((a.x * a.x + a.y * a.y) * (b.x * b.x + b.y * b.y));
@@ -255,6 +300,8 @@ export function angleBetweenPoints(a: Point, b: Point): number {
  * @param {Point} point - Point to shift
  * @param {Point} refPoint - Point to shift towards
  * @param {Point} distance - Distance to shift
+ *
+ * @deprecated Use `Point.shiftTowards` from `sprotty-protocol` instead.
  */
 export function shiftTowards(point: Point, refPoint: Point, distance: number): Point {
     const diff = subtract(refPoint, point);
@@ -267,6 +314,8 @@ export function shiftTowards(point: Point, refPoint: Point, distance: number): P
  * Computes the normalized vector from the vector given in `point`; that is, computing its unit vector.
  * @param {Point} point - Point representing the vector to be normalized
  * @returns {Point} The normalized point
+ *
+ * @deprecated Use `Point.normalize` from `sprotty-protocol` instead.
  */
 export function normalize(point: Point): Point {
     const mag = magnitude(point);
@@ -283,6 +332,8 @@ export function normalize(point: Point): Point {
  * Computes the magnitude of the vector given in `point`.
  * @param {Point} point - Point representing the vector to compute the magnitude for
  * @returns {number} The magnitude or also known as length of the `point`
+ *
+ * @deprecated Use `Point.magnitude` from `sprotty-protocol` instead.
  */
 export function magnitude(point: Point): number {
     return Math.sqrt(Math.pow(point.x, 2) + Math.pow(point.y, 2));
@@ -292,6 +343,8 @@ export function magnitude(point: Point): number {
  * Converts from radians to degrees
  * @param {number} a - A value in radians
  * @returns {number} The converted value
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export function toDegrees(a: number): number {
     return a * 180 / Math.PI;
@@ -301,6 +354,8 @@ export function toDegrees(a: number): number {
  * Converts from degrees to radians
  * @param {number} a - A value in degrees
  * @returns {number} The converted value
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export function toRadians(a: number): number {
     return a * Math.PI / 180;
@@ -311,6 +366,8 @@ export function toRadians(a: number): number {
  * @param {number} a - First number
  * @param {number} b - Second number
  * @returns {boolean} True if the two numbers are almost equal
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export function almostEquals(a: number, b: number): boolean {
     return Math.abs(a - b) < 1e-3;
@@ -319,9 +376,8 @@ export function almostEquals(a: number, b: number): boolean {
 /**
  * Calculates a linear combination of p0 and p1 using lambda, i.e.
  *   (1-lambda) * p0 + lambda * p1
- * @param p0
- * @param p1
- * @param lambda
+ *
+ * @deprecated Use `Point.linear` from `sprotty-protocol` instead.
  */
 export function linear(p0: Point, p1: Point, lambda: number): Point {
     return {

--- a/packages/sprotty/src/utils/json.ts
+++ b/packages/sprotty/src/utils/json.ts
@@ -14,12 +14,24 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
 export type JsonAny =  JsonPrimitive | JsonMap | JsonArray | null;
 
-export type JsonPrimitive = string | number | boolean;
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
+ export type JsonPrimitive = string | number | boolean;
 
-export interface JsonMap {
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
+ export interface JsonMap {
     [key: string]: JsonAny;
 }
 
-export interface JsonArray extends Array<JsonAny> {}
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
+ export type JsonArray = Array<JsonAny>;

--- a/packages/sprotty/src/utils/object.ts
+++ b/packages/sprotty/src/utils/object.ts
@@ -14,11 +14,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
- export function isObject(data: unknown): data is Record<PropertyKey, unknown> {
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
+export function isObject(data: unknown): data is Record<PropertyKey, unknown> {
     return typeof data === 'object' && data !== null;
 }
 
-export type TypeOf<T> =
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
+ export type TypeOf<T> =
     T extends number ? 'number'
     : T extends string ? 'string'
     : T extends boolean ? 'boolean'
@@ -28,7 +34,10 @@ export type TypeOf<T> =
     : T extends object ? 'object'
     : 'undefined';
 
-export function hasOwnProperty<K extends PropertyKey, T>(arg: unknown, key: K, type?: TypeOf<T> | ((v: unknown) => v is T)): arg is Record<K, T> {
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
+ export function hasOwnProperty<K extends PropertyKey, T>(arg: unknown, key: K, type?: TypeOf<T> | ((v: unknown) => v is T)): arg is Record<K, T> {
     if (!(isObject(arg) && Object.prototype.hasOwnProperty.call(arg, key))) {
         return false;
     }
@@ -41,6 +50,9 @@ export function hasOwnProperty<K extends PropertyKey, T>(arg: unknown, key: K, t
     return true;
 }
 
-export function safeAssign<T>(target: T, partial: Partial<T>): T {
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
+ export function safeAssign<T>(target: T, partial: Partial<T>): T {
     return Object.assign(target, partial);
 }


### PR DESCRIPTION
Closes #233, closes #243. This is a large change, and I certainly don't expect anyone to review it line-by-line, but any testing with existing applications would be appreciated.

I created a new package `sprotty-protocol` and *copied* the following aspects from `sprotty`. Where possible, the original declarations have been kept and marked `@deprecated`.

 * Many action declarations (now `actions.ts`)
 * Model element schema (now `model.ts`)
 * Most of `utils/geometry.ts`
 * `utils/async.ts`
 * `utils/json.ts`
 * `utils/object.ts`

### Actions

As discussed in #233, I refactored the action classes into interfaces with accompanying namespaces. This supports the notion of actions being lightweight serializable data structures that must not have any attached behavior. This is a breaking change, but only in the way how actions are created: instead of calling a constructor, you call the declared `create` function.

I left those actions that are used only within the client in the `sprotty` package, and also those where I wasn't sure. Feel free to move (i.e. copy and mark `@deprecated`) more action definitions to `sprotty-protocol` if you need them in a Node.js based server. This is something we can still do later without breaking user code: we would remove deprecated code only when we increase the major version.

### Model Elements

I copied all model element schema interfaces to `sprotty-protocol`, but removed the `Schema` suffix (e.g. `SNode` instead of `SNodeSchema`) because

 * it's shorter,
 * it's more consistent with our existing server code in Java,
 * the name "schema" is a bit misleading,
 * we use only the external model in the diagram server, but not the internal model.

Now there's a name conflict between the external model (schema) defined in `sprotty-protocol` and the internal model defined in `sprotty`. Possible options:

 * Keep it as it is now; in case you need to import both the internal and external model in one file, you can resolve the conflict at the import declaration (this should rarely be necessary in user code).
 * Add a suffix to internal model elements, e.g. `SNodeImpl`.
 * Change the prefix of internal model elements, e.g. `InternalNode`.

What do you think?

### Model Index

I split the `SModelIndex` in two classes:

 * `SModelIndex` in `sprotty-protocol` for indexing external models (only on demand)
 * `ModelIndexImpl` in `sprotty` for indexing internal models (attached to the root element)

### Diagram Server

I added a `DiagramServer` class to `sprotty-protocol` for implementing Node.js based diagram servers. This is similar to the diagram server in our Java code base. I renamed the previous `DiagramServer` in `sprotty` to `DiagramServerProxy`.
