### PR TITLE
Extracted action handler registry from diagram server

### DIFF
--- a/configs/.eslintrc.js
+++ b/configs/.eslintrc.js
@@ -18,37 +18,7 @@ module.exports = {
     ],
     "rules": {
         "@typescript-eslint/indent": "off",
-        "@typescript-eslint/naming-convention": [
-            "warn",
-                {
-                    "selector": 'default',
-                    "format": ['camelCase'],
-                    "leadingUnderscore": 'allow',
-                    "trailingUnderscore": 'allow',
-                },
-                {
-                    "selector": 'variable',
-                    "format": ['camelCase', 'UPPER_CASE'],
-                    "leadingUnderscore": 'allow',
-                    "trailingUnderscore": 'allow',
-                },
-                {
-                    "selector": 'typeLike',
-                    "format": ['PascalCase'],
-                },                
-                {
-                    "selector": "classProperty",
-                    "format": ["camelCase", "UPPER_CASE"]
-                },      
-                {
-                    "selector": "typeProperty",
-                    "format": ["camelCase", "UPPER_CASE"]
-                },
-                {
-                    "selector": "enumMember",
-                    "format": ["camelCase", "UPPER_CASE"]
-                }
-            ],
+        "@typescript-eslint/naming-convention": "off",
         "@typescript-eslint/no-dynamic-delete": "error",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-misused-new": "error",

--- a/packages/sprotty-protocol/CHANGELOG.md
+++ b/packages/sprotty-protocol/CHANGELOG.md
@@ -1,0 +1,8 @@
+## Eclipse Sprotty Change Log (Client-Server Protocol)
+
+This change log covers only the client-server protocol of Sprotty. See also the change log of [sprotty](https://github.com/eclipse/sprotty/blob/master/packages/sprotty/CHANGELOG.md).
+
+### v0.12.0 (?? 2022)
+
+New features:
+ * Added `ServerActionHandlerRegistry` service to register action handlers for all `DiagramServer` instances ([#260](https://github.com/eclipse/sprotty/pull/260)).

--- a/packages/sprotty-protocol/src/action-handler.ts
+++ b/packages/sprotty-protocol/src/action-handler.ts
@@ -1,0 +1,63 @@
+/********************************************************************************
+ * Copyright (c) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Action } from './actions';
+import { DiagramServer } from './diagram-server';
+import { DiagramState } from './diagram-services';
+
+export type ServerActionHandler<A extends Action = Action> = (action: A, state: DiagramState, server: DiagramServer) => Promise<void>;
+
+/**
+ * Use this service to register handlers to specific actions. The `DiagramServer` queries this registry
+ * when an action is received from the client, and falls back to the built-in behavior if no handlers
+ * are found.
+ */
+export class ServerActionHandlerRegistry {
+
+    protected readonly handlers = new Map<string, ServerActionHandler[]>();
+
+    /**
+     * Returns the action handlers for the given action kind, or `undefined` if there are none.
+     */
+    getHandler(kind: string): ServerActionHandler[] | undefined {
+        return this.handlers.get(kind);
+    }
+
+    /**
+     * Add an action handler to be called when an action of the specified kind is received.
+     */
+    onAction<A extends Action>(kind: string, handler: ServerActionHandler<A>) {
+        if (this.handlers.has(kind)) {
+            this.handlers.get(kind)!.push(handler);
+        } else {
+            this.handlers.set(kind, [handler]);
+        }
+    }
+
+    /**
+     * Remove an action handler that was previously added with `onAction`.
+     */
+    removeActionHandler<A extends Action>(kind: string, handler: ServerActionHandler<A>) {
+        const list = this.handlers.get(kind);
+        if (list) {
+            const index = list.indexOf(handler);
+            if (index >= 0) {
+                list.splice(index, 1);
+            }
+        }
+    }
+
+}

--- a/packages/sprotty-protocol/src/diagram-server.ts
+++ b/packages/sprotty-protocol/src/diagram-server.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ServerActionHandlerRegistry } from './action-handler';
+import { ServerActionHandler, ServerActionHandlerRegistry } from './action-handler';
 import {
     Action, isResponseAction, ResponseAction, RequestModelAction, ComputedBoundsAction, LayoutAction, RequestBoundsAction,
     RequestAction, generateRequestId, SetModelAction, UpdateModelAction, RejectAction, isRequestAction
@@ -43,7 +43,7 @@ export class DiagramServer {
 
     protected readonly diagramGenerator: IDiagramGenerator;
     protected readonly layoutEngine?: IModelLayoutEngine;
-    protected readonly actionHandlerRegistry?: ServerActionHandlerRegistry;
+    protected actionHandlerRegistry?: ServerActionHandlerRegistry;
     protected readonly requests = new Map<string, Deferred<ResponseAction>>();
 
     constructor(dispatch: <A extends Action>(action: A) => Promise<void>,
@@ -52,6 +52,25 @@ export class DiagramServer {
         this.diagramGenerator = services.DiagramGenerator;
         this.layoutEngine = services.ModelLayoutEngine;
         this.actionHandlerRegistry = services.ServerActionHandlerRegistry;
+    }
+
+    /**
+     * @deprecated Use the `ServerActionHandlerRegistry` service instead
+     */
+    onAction<A extends Action>(kind: string, handler: ServerActionHandler<A>) {
+        if (!this.actionHandlerRegistry) {
+            this.actionHandlerRegistry = new ServerActionHandlerRegistry();
+        }
+        this.actionHandlerRegistry.onAction(kind, handler);
+    }
+
+    /**
+     * @deprecated Use the `ServerActionHandlerRegistry` service instead
+     */
+    removeActionHandler<A extends Action>(kind: string, handler: ServerActionHandler<A>) {
+        if (this.actionHandlerRegistry) {
+            this.actionHandlerRegistry.removeActionHandler(kind, handler);
+        }
     }
 
     /**

--- a/packages/sprotty-protocol/src/diagram-services.ts
+++ b/packages/sprotty-protocol/src/diagram-services.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { ServerActionHandlerRegistry } from './action-handler';
 import { SModelRoot } from './model';
 import { JsonMap } from './utils/json';
 import { SModelIndex } from './utils/model-utils';
@@ -35,6 +36,7 @@ export interface DiagramState {
 export interface DiagramServices {
     readonly DiagramGenerator: IDiagramGenerator
     readonly ModelLayoutEngine?: IModelLayoutEngine
+    readonly ServerActionHandlerRegistry?: ServerActionHandlerRegistry
 }
 
 /**


### PR DESCRIPTION
In my first draft of the diagram server, I included the option to register action handlers so it's not necessary to subclass `DiagramServer` just to process incoming actions. But `DiagramServer` instances must be created per client diagram, so there can be possibly many such instances in the backend. I think it would be more convenient to register the action handlers in a separate service instead of the `DiagramServer` instances.