### PR TITLE
#261 Setup nightly deployment

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,9 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    extends: ['./configs/.eslintrc.js'],
+    ignorePatterns: ['**/{node_modules,lib}'],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: 'tsconfig.json'
+    }
+};

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
-    "eslint.options": {
-      "configFile": "configs/.eslintrc.js"
-    },
     "eslint.packageManager": "yarn",
     "search.exclude": {
         "**/node_modules": true,

--- a/configs/base.tsconfig.json
+++ b/configs/base.tsconfig.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json.schemastore.org/tsconfig",
     "compilerOptions": {
         "target": "es5",
         "module": "commonjs",

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -55,7 +55,9 @@ const config = {
 
     plugins: [
         new webpack.ProgressPlugin()
-    ]
+    ],
+    ignoreWarnings: [/Failed to parse source map/],
+
 };
 
 module.exports = config;

--- a/lerna.json
+++ b/lerna.json
@@ -1,10 +1,15 @@
 {
-  "version": "independent",
+  "version": "0.11.1",
   "useWorkspaces": true,
   "npmClient": "yarn",
   "command": {
     "run": {
       "stream": true
+    },
+    "publish": {
+      "forcePublish": true,
+      "skipGit": true,
+      "registry": "https://registry.npmjs.org/"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
     "prepare": "lerna run prepare",
     "clean": "lerna run clean",
     "build": "lerna run build",
-    "test": "lerna run test"
+    "test": "lerna run test",
+    "publish:latest": "lerna publish --exact --ignore-scripts --no-verify-access --yes --no-push",
+    "publish:next": "SHA=$(git rev-parse --short HEAD) && lerna publish preminor --exact --canary --preid next.${SHA} --dist-tag next --no-git-reset --no-git-tag-version --no-push --ignore-scripts --yes --no-verify-access"
   },
   "devDependencies": {
     "lerna": "^4.0.0"

--- a/packages/sprotty-elk/package.json
+++ b/packages/sprotty-elk/package.json
@@ -68,10 +68,7 @@
     "build": "tsc -p ./tsconfig.json && yarn run lint",
     "watch": "tsc -w -p ./tsconfig.json",
     "lint": "eslint -c ../../configs/.eslintrc.js \"src/**/!(*.spec.ts*)\"",
-    "test": "jenkins-mocha --config ../../configs/.mocharc.json \"./src/**/*.spec.?(ts|tsx)\"",
-    "prepublishOnly": "yarn run test",
-    "publish:next": "yarn publish --new-version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" --tag next --no-git-tag-version",
-    "publish:latest": "yarn publish --tag latest --no-git-tag-version"
+    "test": "jenkins-mocha --config ../../configs/.mocharc.json \"./src/**/*.spec.?(ts|tsx)\""
   },
   "files": [
     "lib",

--- a/packages/sprotty-protocol/package.json
+++ b/packages/sprotty-protocol/package.json
@@ -49,10 +49,7 @@
     "build": "tsc -p ./tsconfig.json && yarn run lint",
     "watch": "tsc -w -p ./tsconfig.json",
     "lint": "eslint -c ../../configs/.eslintrc.js \"src/**/!(*.spec.ts*)\"",
-    "test": "mocha --config ../../configs/.mocharc.json \"./src/**/*.spec.?(ts|tsx)\"",
-    "prepublishOnly": "yarn run test",
-    "publish:next": "yarn publish --new-version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" --tag next --no-git-tag-version",
-    "publish:latest": "yarn publish --tag latest --no-git-tag-version"
+    "test": "mocha --config ../../configs/.mocharc.json \"./src/**/*.spec.?(ts|tsx)\""
   },
   "files": [
     "lib",

--- a/packages/sprotty/package.json
+++ b/packages/sprotty/package.json
@@ -90,10 +90,7 @@
     "watch": "tsc -w -p ./tsconfig.json",
     "lint": "eslint -c ../../configs/.eslintrc.js \"src/**/!(*.spec.ts*|test-helper.ts)\"",
     "test:cli": "ts-mocha \"./src/**/*.spec.?(ts|tsx)\"",
-    "test": "jenkins-mocha --config ../../configs/.mocharc.json \"./src/**/*.spec.?(ts|tsx)\"",
-    "prepublishOnly": "yarn run test",
-    "publish:next": "yarn publish --new-version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" --tag next --no-git-tag-version",
-    "publish:latest": "yarn publish --tag latest --no-git-tag-version"
+    "test": "jenkins-mocha --config ../../configs/.mocharc.json \"./src/**/*.spec.?(ts|tsx)\""
   },
   "files": [
     "lib",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "./configs/base.tsconfig.json",
+    "include": [
+        "packages/*/src/**/*.ts",
+      ],
+}


### PR DESCRIPTION
Setup nightly deployment for new mono repo
- Add dedicated scripts for publishing  releases (publish:latest) and nightly snapshots (publish:nightly) using lerna
- Update lerna config
[CI]
- Updated `deploy-sprotty` jenkins job

Additional changes:
- Update eslint config. After the mono-repo switch the config was no longer working with the eslint vscode extension. Added a new root .eslint.rc + tsconfig.json to fix that.
- Ignore warnings related to source map parsing in the example webpack config
- Add schema property to `base.tsconfig.json`

Closes #261