### PR TITLE
Remove hover feedback for last element

### DIFF
--- a/packages/sprotty/src/features/hover/hover.ts
+++ b/packages/sprotty/src/features/hover/hover.ts
@@ -277,7 +277,7 @@ export class HoverMouseListener extends AbstractHoverMouseListener {
     mouseOut(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
         const result: (Action | Promise<Action>)[] = [];
         if (!this.mouseIsDown) {
-            const elementUnderMouse = document.elementFromPoint(event.x, event.y);
+            const elementUnderMouse = this.getElementFromEventPosition(event);
             if (!this.isSprottyPopup(elementUnderMouse)) {
                 if (this.state.popupOpen) {
                     const popupTarget = findParent(target, hasPopupFeature);
@@ -289,11 +289,18 @@ export class HoverMouseListener extends AbstractHoverMouseListener {
                 const hoverTarget = findParentByFeature(target, isHoverable);
                 if (hoverTarget !== undefined) {
                     result.push(HoverFeedbackAction.create({ mouseoverElement: hoverTarget.id, mouseIsOver: false }));
+                    if (this.lastHoverFeedbackElementId && this.lastHoverFeedbackElementId !== hoverTarget.id) {
+                        result.push(HoverFeedbackAction.create({ mouseoverElement: this.lastHoverFeedbackElementId, mouseIsOver: false }));
+                    }
                     this.lastHoverFeedbackElementId = undefined;
                 }
             }
         }
         return result;
+    }
+
+    protected getElementFromEventPosition(event: MouseEvent) {
+        return document.elementFromPoint(event.x, event.y);
     }
 
     protected isSprottyPopup(element: Element | null): boolean {


### PR DESCRIPTION
Remove the hover feedback from the last hover feedback element also
if the mouse-out event occurs for another element. This is needed e.g.
when an edge is entered with the mouse where the routing handle would
appear on selection and then left via the routing handle.

Fixes https://github.com/eclipse/sprotty/issues/264