### PR TITLE
Ensure consistent usage of protocol actions

### DIFF
--- a/packages/sprotty-elk/src/elk-layout.ts
+++ b/packages/sprotty-elk/src/elk-layout.ts
@@ -51,7 +51,7 @@ export class ElkLayoutEngine implements IModelLayoutEngine {
         });
     }
 
-    protected getBasicType(smodel:SModelElement): string{
+    protected getBasicType(smodel: SModelElement): string{
         return getBasicType(smodel);
     }
 
@@ -287,7 +287,7 @@ export class DefaultElementFilter implements IElementFilter {
         }
     }
 
-    protected getBasicType(smodel:SModelElement): string{
+    protected getBasicType(smodel: SModelElement): string{
         return getBasicType(smodel);
     }
 
@@ -349,7 +349,7 @@ export class DefaultLayoutConfigurator implements ILayoutConfigurator {
         }
     }
 
-    protected getBasicType(smodel:SModelElement): string{
+    protected getBasicType(smodel: SModelElement): string{
         return getBasicType(smodel);
     }
 

--- a/packages/sprotty-protocol/src/actions.ts
+++ b/packages/sprotty-protocol/src/actions.ts
@@ -298,7 +298,7 @@ export namespace ComputedBoundsAction {
 /**
  * Associates new bounds with a model element, which is referenced via its id.
  */
- export interface ElementAndBounds {
+export interface ElementAndBounds {
     elementId: string
     newPosition?: Point
     newSize: Dimension
@@ -307,7 +307,7 @@ export namespace ComputedBoundsAction {
 /**
  * Associates a new alignment with a model element, which is referenced via its id.
  */
- export interface ElementAndAlignment {
+export interface ElementAndAlignment {
     elementId: string
     newAlignment: Point
 }
@@ -358,7 +358,7 @@ export namespace SelectAllAction {
  * Sent from the client to the model source to recalculate a diagram when elements
  * are collapsed/expanded by the client.
  */
- export interface CollapseExpandAction {
+export interface CollapseExpandAction {
     kind: typeof CollapseExpandAction.KIND
     expandIds: string[]
     collapseIds: string[]
@@ -379,7 +379,7 @@ export namespace CollapseExpandAction {
  * Programmatic action for expanding or collapsing all elements.
  * If `expand` is true, all elements are expanded, otherwise they are collapsed.
  */
- export interface CollapseExpandAllAction {
+export interface CollapseExpandAllAction {
     kind: typeof CollapseExpandAllAction.KIND
     expand: boolean
 }
@@ -400,6 +400,13 @@ export interface OpenAction {
 }
 export namespace OpenAction {
     export const KIND = 'open';
+
+    export function create(elementId: string): OpenAction {
+        return {
+            kind: KIND,
+            elementId
+        };
+    }
 }
 
 /**

--- a/packages/sprotty/src/base/features/set-model.ts
+++ b/packages/sprotty/src/base/features/set-model.ts
@@ -15,7 +15,10 @@
  ********************************************************************************/
 
 import { inject, injectable } from "inversify";
-import { Action, generateRequestId, RequestAction, ResponseAction } from "sprotty-protocol/lib/actions";
+import {
+    Action, generateRequestId, RequestAction, ResponseAction,
+    RequestModelAction as ProtocolRequestModelAction, SetModelAction as ProtocolSetModelAction
+} from "sprotty-protocol/lib/actions";
 import { SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
 import { JsonPrimitive } from "sprotty-protocol/lib/utils/json";
 import { CommandExecutionContext, ResetCommand } from "../commands/command";
@@ -30,12 +33,12 @@ import { InitializeCanvasBoundsCommand } from './initialize-canvas';
  *
  * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
-export class RequestModelAction implements RequestAction<SetModelAction> {
+export class RequestModelAction implements RequestAction<SetModelAction>, ProtocolRequestModelAction {
     static readonly KIND = 'requestModel';
     readonly kind = RequestModelAction.KIND;
 
     constructor(public readonly options?: { [key: string]: JsonPrimitive },
-                public readonly requestId = '') {}
+        public readonly requestId = '') { }
 
     /** Factory function to dispatch a request with the `IActionDispatcher` */
     static create(options?: { [key: string]: JsonPrimitive }): RequestAction<SetModelAction> {
@@ -48,22 +51,22 @@ export class RequestModelAction implements RequestAction<SetModelAction> {
  *
  * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
-export class SetModelAction implements ResponseAction {
+export class SetModelAction implements ResponseAction, ProtocolSetModelAction {
     static readonly KIND = 'setModel';
     readonly kind = SetModelAction.KIND;
 
     constructor(public readonly newRoot: SModelRootSchema,
-                public readonly responseId = '') {}
+        public readonly responseId = '') { }
 }
 
 @injectable()
 export class SetModelCommand extends ResetCommand {
-    static readonly KIND = SetModelAction.KIND;
+    static readonly KIND = ProtocolSetModelAction.KIND;
 
     oldRoot: SModelRoot;
     newRoot: SModelRoot;
 
-    constructor(@inject(TYPES.Action) protected readonly action: SetModelAction) {
+    constructor(@inject(TYPES.Action) protected readonly action: ProtocolSetModelAction) {
         super();
     }
 

--- a/packages/sprotty/src/features/bounds/bounds-manipulation.ts
+++ b/packages/sprotty/src/features/bounds/bounds-manipulation.ts
@@ -15,7 +15,9 @@
  ********************************************************************************/
 
 import { inject, injectable } from "inversify";
-import { Action, generateRequestId, RequestAction, ResponseAction } from 'sprotty-protocol/lib/actions';
+import {
+    Action, generateRequestId, RequestAction, ResponseAction} from 'sprotty-protocol/lib/actions';
+import * as protocol from "sprotty-protocol/lib/actions";
 import { SModelRoot as SModelRootSchema } from 'sprotty-protocol/lib/model';
 import { Bounds, Dimension, Point } from "sprotty-protocol/lib/utils/geometry";
 import { CommandExecutionContext, CommandResult, CommandReturn, HiddenCommand, SystemCommand } from "../../base/commands/command";
@@ -29,8 +31,8 @@ import { Alignable, BoundsAware, isBoundsAware } from './model';
  *
  * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
-export class SetBoundsAction implements Action {
-    static readonly KIND: string  = 'setBounds';
+export class SetBoundsAction implements Action, protocol.SetBoundsAction {
+    static readonly KIND = 'setBounds';
     readonly kind = SetBoundsAction.KIND;
 
     constructor(public readonly bounds: ElementAndBounds[]) {
@@ -45,12 +47,12 @@ export class SetBoundsAction implements Action {
  *
  * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
-export class RequestBoundsAction implements RequestAction<ComputedBoundsAction> {
-    static readonly KIND: string  = 'requestBounds';
+export class RequestBoundsAction implements RequestAction<ComputedBoundsAction>, protocol.RequestBoundsAction {
+    static readonly KIND = 'requestBounds';
     readonly kind = RequestBoundsAction.KIND;
 
     constructor(public readonly newRoot: SModelRootSchema,
-                public readonly requestId: string = '') {}
+        public readonly requestId: string = '') { }
 
     /** Factory function to dispatch a request with the `IActionDispatcher` */
     static create(newRoot: SModelRootSchema): RequestAction<ComputedBoundsAction> {
@@ -67,14 +69,14 @@ export class RequestBoundsAction implements RequestAction<ComputedBoundsAction> 
  *
  * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
-export class ComputedBoundsAction implements ResponseAction {
+export class ComputedBoundsAction implements ResponseAction, protocol.ComputedBoundsAction {
     static readonly KIND = 'computedBounds';
     readonly kind = ComputedBoundsAction.KIND;
 
     constructor(public readonly bounds: ElementAndBounds[],
-                public readonly revision?: number,
-                public readonly alignments?: ElementAndAlignment[],
-                public readonly responseId = '') {}
+        public readonly revision?: number,
+        public readonly alignments?: ElementAndAlignment[],
+        public readonly responseId = '') { }
 }
 
 /**
@@ -82,7 +84,7 @@ export class ComputedBoundsAction implements ResponseAction {
  *
  * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
-export interface ElementAndBounds {
+export interface ElementAndBounds extends protocol.ElementAndBounds {
     elementId: string
     newPosition?: Point
     newSize: Dimension
@@ -93,7 +95,7 @@ export interface ElementAndBounds {
  *
  * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
-export interface ElementAndAlignment {
+export interface ElementAndAlignment extends protocol.ElementAndAlignment{
     elementId: string
     newAlignment: Point
 }
@@ -103,7 +105,7 @@ export interface ElementAndAlignment {
  *
  * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
-export class LayoutAction implements Action {
+export class LayoutAction implements Action, protocol.LayoutAction {
     static readonly KIND = 'layout';
     readonly kind = LayoutAction.KIND;
 
@@ -126,11 +128,11 @@ export interface ResolvedElementAndAlignment {
 
 @injectable()
 export class SetBoundsCommand extends SystemCommand {
-    static readonly KIND: string  = SetBoundsAction.KIND;
+    static readonly KIND: string = protocol.SetBoundsAction.KIND;
 
     protected bounds: ResolvedElementAndBounds[] = [];
 
-    constructor(@inject(TYPES.Action) protected readonly action: SetBoundsAction) {
+    constructor(@inject(TYPES.Action) protected readonly action: protocol.SetBoundsAction) {
         super();
     }
 
@@ -181,9 +183,9 @@ export class SetBoundsCommand extends SystemCommand {
 
 @injectable()
 export class RequestBoundsCommand extends HiddenCommand {
-    static readonly KIND: string  = RequestBoundsAction.KIND;
+    static readonly KIND: string = protocol.RequestBoundsAction.KIND;
 
-    constructor(@inject(TYPES.Action) protected action: RequestBoundsAction) {
+    constructor(@inject(TYPES.Action) protected action: protocol.RequestBoundsAction) {
         super();
     }
 

--- a/packages/sprotty/src/features/edit/edit-label-ui.ts
+++ b/packages/sprotty/src/features/edit/edit-label-ui.ts
@@ -132,7 +132,7 @@ export class EditLabelUI extends AbstractUIExtension {
             }
         }
         this.actionDispatcherProvider()
-            .then((actionDispatcher) => actionDispatcher.dispatchAll([new ApplyLabelEditAction(this.labelId, this.editControl.value), CommitModelAction.create()]))
+            .then((actionDispatcher) => actionDispatcher.dispatchAll([ApplyLabelEditAction.create(this.labelId, this.editControl.value), CommitModelAction.create()]))
             .catch((reason) => this.logger.error(this, 'No action dispatcher available to execute apply label edit action', reason));
         this.hide();
     }

--- a/packages/sprotty/src/features/edit/edit-label.ts
+++ b/packages/sprotty/src/features/edit/edit-label.ts
@@ -45,12 +45,28 @@ export function isEditLabelAction(element?: any): element is EditLabelAction {
     return isAction(element) && element.kind === EditLabelAction.KIND && 'labelId' in element;
 }
 
-export class ApplyLabelEditAction implements Action {
-    static readonly KIND = 'applyLabelEdit';
-    kind = ApplyLabelEditAction.KIND;
-
-    constructor(readonly labelId: string, readonly text: string) { }
+export interface ApplyLabelEditAction extends Action {
+    kind: typeof ApplyLabelEditAction.KIND;
+    labelId: string,
+    text: string
 }
+
+export namespace ApplyLabelEditAction {
+    export const KIND = 'applyLabelEdit';
+
+    export function create(labelId: string, text: string): ApplyLabelEditAction {
+        return {
+            kind: KIND,
+            labelId,
+            text
+        };
+    }
+}
+
+export function isApplyLabelEditAction(element?: any): element is ApplyLabelEditAction {
+    return isAction(element) && element.kind === ApplyLabelEditAction.KIND && 'labelId' in element && 'text' in element;
+}
+
 
 export class ResolvedLabelEdit {
     label: EditableLabel;

--- a/packages/sprotty/src/features/expand/expand.ts
+++ b/packages/sprotty/src/features/expand/expand.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { injectable } from 'inversify';
-import { Action } from 'sprotty-protocol/lib/actions';
+import { Action, CollapseExpandAction as ProtocolCollapseExpandAction, CollapseExpandAllAction as ProtocolCollapseExpandAllAction} from 'sprotty-protocol/lib/actions';
 import { SButton } from '../button/model';
 import { findParentByFeature } from '../../base/model/smodel-utils';
 import { isExpandable } from './model';
@@ -27,9 +27,9 @@ import { IButtonHandler } from '../button/button-handler';
  *
  * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
-export class CollapseExpandAction implements Action {
-    static KIND = 'collapseExpand';
-    kind = CollapseExpandAction.KIND;
+export class CollapseExpandAction implements Action,ProtocolCollapseExpandAction {
+    static readonly KIND = 'collapseExpand';
+    readonly kind = CollapseExpandAction.KIND;
 
     constructor(public readonly expandIds: string[],
                 public readonly collapseIds: string[]) {
@@ -41,9 +41,9 @@ export class CollapseExpandAction implements Action {
  *
  * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
-export class CollapseExpandAllAction implements Action {
-    static KIND = 'collapseExpandAll';
-    kind = CollapseExpandAllAction.KIND;
+export class CollapseExpandAllAction implements Action,ProtocolCollapseExpandAllAction {
+    static readonly KIND = 'collapseExpandAll';
+    readonly kind = CollapseExpandAllAction.KIND;
 
     /**
      * If `expand` is true, all elements are expanded, othewise they are collapsed.
@@ -59,9 +59,10 @@ export class ExpandButtonHandler implements IButtonHandler {
     buttonPressed(button: SButton): Action[] {
         const expandable = findParentByFeature(button, isExpandable);
         if (expandable !== undefined) {
-            return [ new CollapseExpandAction(
-                expandable.expanded ? [] : [ expandable.id ],
-                expandable.expanded ? [ expandable.id ] : []) ];
+            return [ ProtocolCollapseExpandAction.create({
+                expandIds:   expandable.expanded ? [] : [ expandable.id ],
+                collapseIds:  expandable.expanded ? [ expandable.id ] : []
+            })];
         } else {
             return [];
         }

--- a/packages/sprotty/src/features/open/open.ts
+++ b/packages/sprotty/src/features/open/open.ts
@@ -14,26 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Action } from 'sprotty-protocol/lib/actions';
+import { Action, OpenAction } from 'sprotty-protocol/lib/actions';
 import { MouseListener } from '../../base/views/mouse-tool';
 import { SModelElement } from '../../base/model/smodel';
 import { findParentByFeature } from '../../base/model/smodel-utils';
 import { isOpenable } from './model';
 
-export interface OpenAction extends Action {
-    kind: typeof OpenAction.KIND
-    elementId: string
-}
-export namespace OpenAction {
-    export const KIND = 'open';
-
-    export function create(elementId: string): OpenAction {
-        return {
-            kind: KIND,
-            elementId
-        };
-    }
-}
 
 export class OpenMouseListener extends MouseListener {
     doubleClick(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {

--- a/packages/sprotty/src/features/viewport/center-fit.ts
+++ b/packages/sprotty/src/features/viewport/center-fit.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Action } from "sprotty-protocol/lib/actions";
+import { Action, CenterAction as ProtocolCenterAction, FitToScreenAction as ProtocolFitToScreenAction} from "sprotty-protocol/lib/actions";
 import { Viewport } from "sprotty-protocol/lib/model";
 import { Bounds, Dimension } from "sprotty-protocol/lib/utils/geometry";
 import { matchesKeystroke } from "../../utils/keyboard";
@@ -38,7 +38,7 @@ import { TYPES } from "../../base/types";
  *
  * @deprecated Use the declaration in `sprotty-protocol` instead.
  */
-export class CenterAction implements Action {
+export class CenterAction implements Action, ProtocolCenterAction {
     static readonly KIND = 'center';
     readonly kind = CenterAction.KIND;
 
@@ -56,7 +56,7 @@ export class CenterAction implements Action {
  *
  * @deprecated Use the declaration in `sprotty-protocol` instead.
  */
-export class FitToScreenAction implements Action {
+export class FitToScreenAction implements Action, ProtocolFitToScreenAction {
     static readonly KIND = 'fit';
     readonly kind = FitToScreenAction.KIND;
 
@@ -163,9 +163,9 @@ export abstract class BoundsAwareViewportCommand extends Command {
 }
 
 export class CenterCommand extends BoundsAwareViewportCommand {
-    static readonly KIND = CenterAction.KIND;
+    static readonly KIND = ProtocolCenterAction.KIND;
 
-    constructor(@inject(TYPES.Action) protected action: CenterAction) {
+    constructor(@inject(TYPES.Action) protected action: ProtocolCenterAction) {
         super(action.animate);
     }
 
@@ -190,9 +190,9 @@ export class CenterCommand extends BoundsAwareViewportCommand {
 }
 
 export class FitToScreenCommand extends BoundsAwareViewportCommand {
-    static readonly KIND = FitToScreenAction.KIND;
+    static readonly KIND = ProtocolFitToScreenAction.KIND;
 
-    constructor(@inject(TYPES.Action) protected readonly action: FitToScreenAction) {
+    constructor(@inject(TYPES.Action) protected readonly action: ProtocolFitToScreenAction) {
         super(action.animate);
     }
 

--- a/packages/sprotty/src/features/viewport/viewport.ts
+++ b/packages/sprotty/src/features/viewport/viewport.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { injectable, inject } from "inversify";
-import { Action, generateRequestId, RequestAction, ResponseAction } from "sprotty-protocol/lib/actions";
+import { Action, generateRequestId, RequestAction, ResponseAction, SetViewportAction as ProtocolSetViewPortAction} from "sprotty-protocol/lib/actions";
 import { Viewport } from "sprotty-protocol/lib/model";
 import { Bounds, Point } from "sprotty-protocol/lib/utils/geometry";
 import { SModelElement, SModelRoot } from "../../base/model/smodel";
@@ -28,9 +28,9 @@ import { ModelRequestCommand } from "../../base/commands/request-command";
 /**
  * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
-export class SetViewportAction implements Action {
+export class SetViewportAction implements Action, ProtocolSetViewPortAction {
     static readonly KIND = 'viewport';
-    kind = SetViewportAction.KIND;
+    readonly kind = SetViewportAction.KIND;
 
     constructor(public readonly elementId: string,
                 public readonly newViewport: Viewport,
@@ -75,13 +75,13 @@ export namespace ViewportResult {
 
 @injectable()
 export class SetViewportCommand extends MergeableCommand {
-    static readonly KIND = SetViewportAction.KIND;
+    static readonly KIND = ProtocolSetViewPortAction.KIND;
 
     protected element: SModelElement & Viewport;
     protected oldViewport: Viewport;
     protected newViewport: Viewport;
 
-    constructor(@inject(TYPES.Action) protected readonly action: SetViewportAction) {
+    constructor(@inject(TYPES.Action) protected readonly action: ProtocolSetViewPortAction) {
         super();
         this.newViewport = action.newViewport;
     }

--- a/packages/sprotty/src/model-source/diagram-server.ts
+++ b/packages/sprotty/src/model-source/diagram-server.ts
@@ -16,6 +16,7 @@
 
 import { saveAs } from 'file-saver';
 import { inject, injectable } from "inversify";
+import { OpenAction } from 'sprotty-protocol';
 import {
     Action, CollapseExpandAction, CollapseExpandAllAction, ComputedBoundsAction, RequestModelAction,
     RequestPopupModelAction, SetModelAction, UpdateModelAction
@@ -28,7 +29,6 @@ import { SetModelCommand } from "../base/features/set-model";
 import { TYPES } from "../base/types";
 import { RequestBoundsCommand } from '../features/bounds/bounds-manipulation';
 import { ExportSvgAction } from '../features/export/svg-exporter';
-import { OpenAction } from '../features/open/open';
 import { UpdateModelCommand } from "../features/update/update-model";
 import { ILogger } from "../utils/logging";
 import { ComputedBoundsApplicator, ModelSource } from "./model-source";


### PR DESCRIPTION
- Ensures that the new action definitions of `sprotty-protocol` are used consistently over the deprecated class-based definition.
- Ensure that all commands with injected actions use the sprotty-protocol type instead of its deprecated counterpart
- Update deprecated action class definitions so that the also implement the corresponding interface from `sprotty-protocol`. This ensures that the deprecated definitions are compatible on a type level with the new protocol actions. To avoid name clashings the protocol actions are imported with a `Protocol` prefix.
- Also: fix some ESLint warnings

This also fixes problems when extending one of the command classes provided by sprotty.
For instance with the current master state it would not be possible to extend the `UpdateModelCommand` and use
the protocol `UpdateModelAction` as type for the action parameter. (The deprecated variant doesn't allow undefined for the animate property while the new protocol does)
The adopter would be forced to use the deprecated variant to satisfy the typescript compiler.
