### PR TITLE
Implemented client for running ELK layout in a separate process

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,9 +2,9 @@
 	"version": "0.2.0",
 	"configurations": [
         {
+            "name": "Current Test File",
             "type": "node",
             "request": "launch",
-            "name": "Current Test File",
             "protocol": "inspector",
             "cwd": "${workspaceRoot}",
             "program": "${workspaceRoot}/node_modules/.bin/_mocha",
@@ -21,6 +21,26 @@
             "smartStep": true,
             "internalConsoleOptions": "openOnSessionStart",
             "outputCapture": "std"
+        },
+        {
+            "name": "Examples Server",
+            "type": "pwa-node",
+            "request": "launch",
+            "runtimeExecutable": "node",
+            "runtimeArgs": [
+                "${workspaceFolder}/examples/server/server-app"
+            ],
+            "cwd": "${workspaceFolder}/examples",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceFolder}/examples/server/**/*.js",
+                "${workspaceFolder}/packages/sprotty/lib/**/*.js",
+                "${workspaceFolder}/packages/sprotty-protocol/lib/**/*.js",
+                "${workspaceFolder}/packages/sprotty-elk/lib/**/*.js"
+            ]
         }
 	]
 }

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,1 +1,3 @@
 /resources/
+/server/*.js
+/server/*.js.map

--- a/examples/browser-app.ts
+++ b/examples/browser-app.ts
@@ -19,6 +19,7 @@ import "reflect-metadata";
 import runCircleGraph from "./circlegraph/src/standalone";
 import runClassDiagram from "./classdiagram/src/standalone";
 import runRandomGraph from "./random-graph/src/standalone";
+import runRandomGraphDistributed from "./random-graph-distributed/src/standalone";
 import runSvgPreRendered from "./svg/src/standalone";
 import runMulticore from "./multicore/src/multicore";
 
@@ -31,6 +32,8 @@ if (appDiv) {
         runClassDiagram();
     else if (appMode === 'random-graph')
         runRandomGraph();
+    else if (appMode === 'random-graph-distributed')
+        runRandomGraphDistributed();
     else if (appMode === 'svg')
         runSvgPreRendered();
     else if (appMode === 'multicore')

--- a/examples/index.html
+++ b/examples/index.html
@@ -14,19 +14,28 @@
             <a href="https://github.com/eclipse/sprotty">Sprotty</a> is a web-based diagramming framework.
             For information how to use these examples see <a href="https://github.com/eclipse/sprotty/wiki/Using-sprotty">Using Sprotty</a>.
 
-            <h3>Without server</h3>
+            <h3>Without Server</h3>
+            The following examples run completely in the browser and do not require any additional component.
             <ul>
                 <li><a href="circlegraph/circlegraph.html">Circles and lines:</a><br>
                 A basic diagram showing a graph of moveable nodes and edges.</li>
                 <li><a href="classdiagram/class-diagram.html">Class diagram:</a><br>
                 A basic class diagram using node layouts and hovers.</li>
                 <li><a href="random-graph/random-graph.html">Random graph:</a><br>
-                Randomly generated graph with automatic layout.</li>
+                Randomly generated graph with automatic layout running in the browser.</li>
                 <li><a href="svg/svg-prerendered.html">SVG:</a><br>
                 Demonstrates how to use existing SVG figures.</li>
                 <li><a href="multicore/multicore.html">Multicore:</a><br>
                 Shows a multi-core chip. The color of the cores changes with the code they execute.
                 If you zoom in, the communication channels between the cores appear.</li>
+            </ul>
+
+            <h3>With Server</h3>
+            The following example requires to download and run <a href="https://github.com/TypeFox/elk-server">ELK Server</a> in socket mode.
+            The example server connects to the ELK server and uses it as layout engine.
+            <ul>
+                <li><a href="random-graph-distributed/random-graph.html">Random graph:</a><br>
+                Randomly generated graph with automatic layout running in a separate layout server.</li>
             </ul>
         </div>
     </div>

--- a/examples/package.json
+++ b/examples/package.json
@@ -4,12 +4,13 @@
   "private": "true",
   "dependencies": {
     "core-js": "^3.19.1",
-    "http-server": "^14.0.0",
+    "express": "^4.17.3",
     "reflect-metadata": "^0.1.13",
     "sprotty": "0.11.1",
     "sprotty-elk": "0.11.0"
   },
   "devDependencies": {
+    "@types/express": "^4.17.13",
     "@types/webpack-env": "^1.16.3",
     "css-loader": "^6.5.0",
     "file-loader": "^6.2.0",
@@ -22,8 +23,9 @@
   },
   "scripts": {
     "prepare": "yarn run build",
-    "build": "webpack",
-    "watch": "webpack --watch",
-    "start": "http-server ./"
+    "build": "webpack && tsc",
+    "watch:browser": "webpack --watch",
+    "watch:server": "tsc -w",
+    "start": "node ./server/server-app"
   }
 }

--- a/examples/package.json
+++ b/examples/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "prepare": "yarn run build",
     "build": "webpack && tsc",
+    "watch": "yarn run watch:browser",
     "watch:browser": "webpack --watch",
     "watch:server": "tsc -w",
     "start": "node ./server/server-app"

--- a/examples/random-graph-distributed/css/diagram.css
+++ b/examples/random-graph-distributed/css/diagram.css
@@ -1,0 +1,35 @@
+/********************************************************************************
+ * Copyright (c) 2017-2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+.sprotty-node {
+    fill: #cdc;
+    stroke: #152;
+    stroke-width: 2;
+}
+
+.sprotty-node.mouseover {
+    fill: #dfd;
+}
+
+.sprotty-node.selected {
+    stroke-width: 3;
+}
+
+.sprotty-edge {
+    fill: none;
+    stroke: #152;
+    stroke-width: 1;
+}

--- a/examples/random-graph-distributed/css/page.css
+++ b/examples/random-graph-distributed/css/page.css
@@ -1,0 +1,56 @@
+/********************************************************************************
+ * Copyright (c) 2017-2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+ .copyright {
+    margin-top: 10px;
+    text-align: right;
+    font-size: 10px;
+    color: #888;
+}
+
+.description {
+    margin-top: 20px;
+    margin-bottom: 10px;
+    color: #777;
+}
+
+.help {
+    margin-top: 24px;
+    text-align: right;
+    font-size: 16px;
+    color: #777;
+}
+
+svg.sprotty-graph {
+    margin-top: 15px;
+    width: 100%;
+    height: 500px;
+    border-style: solid;
+    border-width: 1px;
+    border-color: #bbb;
+}
+
+.sprotty-popup {
+    background: none;
+    border-radius: 0px;
+    border: none;
+    min-width: 24px;
+}
+
+.sprotty-popup svg {
+    width: 24px;
+    height: 24px;
+}

--- a/examples/random-graph-distributed/random-graph.html
+++ b/examples/random-graph-distributed/random-graph.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Sprotty Mindmap Example</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="css/page.css">
+    <!-- support Microsoft browsers -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dom4/3.0.0/dom4.js">
+</head>
+<body>
+    <div class="container">
+        <div class="row" id="sprotty-app" data-app="random-graph-distributed">
+            <div class="col-md-10">
+                <h1>Sprotty Random Graph Example</h1>
+            </div>
+            <div class="help col-md-2">
+                <a href='https://github.com/eclipse/sprotty/wiki/Using-sprotty'>Help</a>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+                <div id="sprotty" class="sprotty"/>
+            </div>
+            <div class="copyright">
+                &copy; 2022 <a href="https://www.typefox.io/">TypeFox GmbH</a>.
+            </div>
+        </div>
+    </div>
+<script src="../resources/bundle.js"></script>
+</body>
+</html>

--- a/examples/random-graph-distributed/random-graph.html
+++ b/examples/random-graph-distributed/random-graph.html
@@ -26,6 +26,14 @@
             <div class="copyright">
                 &copy; 2022 <a href="https://www.typefox.io/">TypeFox GmbH</a>.
             </div>
+            If no diagram shows up here, you probably haven't started the elk-server yet.
+            Please follow the steps below:
+            <ol>
+                <li>Download and unpack <a href="https://github.com/TypeFox/elk-server/releases" target="_blank">elk-server</a></li>
+                <li>Run the application with the <code>--socket</code> argument:
+                    <pre>elk-server-0.1.0/bin/elk-server --socket</pre></li>
+                <li>Refresh this page</li>
+            </ol>
         </div>
     </div>
 <script src="../resources/bundle.js"></script>

--- a/examples/random-graph-distributed/src/di.config.ts
+++ b/examples/random-graph-distributed/src/di.config.ts
@@ -1,0 +1,51 @@
+/********************************************************************************
+ * Copyright (c) 2017-2022 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Container, ContainerModule } from 'inversify';
+import {
+    TYPES, configureViewerOptions, SGraphView, SLabelView, ConsoleLogger, LogLevel,
+    loadDefaultModules, SNode, SEdge, SLabel, configureModelElement,
+    SGraph, RectangularNodeView, PolylineEdgeView
+} from 'sprotty';
+import { HttpDiagramServerProxy } from './http-model-source';
+
+export default (containerId: string) => {
+    require('sprotty/css/sprotty.css');
+    require('../css/diagram.css');
+
+    const randomGraphModule = new ContainerModule((bind, unbind, isBound, rebind) => {
+        bind(TYPES.ModelSource).to(HttpDiagramServerProxy).inSingletonScope();
+        rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
+        rebind(TYPES.LogLevel).toConstantValue(LogLevel.log);
+
+        const context = { bind, unbind, isBound, rebind };
+        configureModelElement(container, 'graph', SGraph, SGraphView);
+        configureModelElement(container, 'node', SNode, RectangularNodeView);
+        configureModelElement(container, 'edge', SEdge, PolylineEdgeView);
+        configureModelElement(container, 'label', SLabel, SLabelView);
+
+        configureViewerOptions(context, {
+            needsClientLayout: false,
+            needsServerLayout: true,
+            baseDiv: containerId
+        });
+    });
+
+    const container = new Container();
+    loadDefaultModules(container);
+    container.load(randomGraphModule);
+    return container;
+};

--- a/examples/random-graph-distributed/src/http-model-source.ts
+++ b/examples/random-graph-distributed/src/http-model-source.ts
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (c) 2022 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { DiagramServerProxy } from 'sprotty';
+import { ActionMessage } from 'sprotty-protocol';
+
+/**
+ * HTTP based diagram server. This is not as useful as the WebSocket based implementation
+ * because the server cannot send messages on its own.
+ */
+@injectable()
+export class HttpDiagramServerProxy extends DiagramServerProxy {
+
+    protected sendMessage(message: ActionMessage): void {
+        const body = JSON.stringify(message);
+        const headers = { 'Content-Type': 'application/json', 'Accept': 'application/json' };
+        fetch('/random-graph', { method: 'POST', body, headers }).then(async response => {
+            if (response.ok) {
+                try {
+                    const result = await response.json();
+                    if (Array.isArray(result)) {
+                        for (const message of result) {
+                            this.messageReceived(message);
+                        }
+                    }
+                } catch (err) {
+                    this.logger.error(this, 'Failed to parse response:', err);
+                }
+            } else {
+                this.logger.error(this, 'Response was not ok:', response);
+            }
+        }, err => this.logger.error(this, 'Failed to fetch:', err));
+    }
+
+}

--- a/examples/random-graph-distributed/src/standalone.ts
+++ b/examples/random-graph-distributed/src/standalone.ts
@@ -26,5 +26,6 @@ export default function runRandomGraphDistributed() {
         actionDispatcher.dispatch(response);
     }, err => {
         console.error(err);
-    })
+        document.getElementById('sprotty')!.innerText = String(err);
+    });
 }

--- a/examples/random-graph-distributed/src/standalone.ts
+++ b/examples/random-graph-distributed/src/standalone.ts
@@ -1,0 +1,30 @@
+/********************************************************************************
+ * Copyright (c) 2017-2022 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { IActionDispatcher, TYPES } from 'sprotty';
+import { RequestModelAction } from 'sprotty-protocol';
+import createContainer from './di.config';
+
+export default function runRandomGraphDistributed() {
+    const container = createContainer('sprotty');
+
+    const actionDispatcher = container.get<IActionDispatcher>(TYPES.IActionDispatcher);
+    actionDispatcher.request(RequestModelAction.create()).then(response => {
+        actionDispatcher.dispatch(response);
+    }, err => {
+        console.error(err);
+    })
+}

--- a/examples/server/random-graph-generator.ts
+++ b/examples/server/random-graph-generator.ts
@@ -1,0 +1,63 @@
+/********************************************************************************
+ * Copyright (c) 2022 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { GeneratorArguments, IDiagramGenerator, SEdge, SGraph, SLabel, SModelRoot, SNode } from 'sprotty-protocol';
+
+const NODES = 50;
+const EDGES = 100;
+
+export class RandomGraphGenerator implements IDiagramGenerator {
+
+    generate(args: GeneratorArguments): SModelRoot | Promise<SModelRoot> {
+        const graph: SGraph = {
+            type: 'graph',
+            id: 'root',
+            children: []
+        };
+
+        for (let i = 0; i < NODES; i++) {
+            const node: SNode = {
+                type: 'node',
+                id: `node${i}`,
+                size: { width: 28, height: 28 },
+                children: [
+                    <SLabel>{
+                        type: 'label',
+                        id: `node${i}_label`,
+                        text: i.toString(),
+                        size: { width: 18, height: 18 },
+                        position: { x: 5, y: 5 },
+                        alignment: { x: 0, y: 15 }
+                    }
+                ]
+            };
+            graph.children.push(node);
+        }
+
+        for (let i = 0; i < EDGES; i++) {
+            const edge: SEdge = {
+                type: 'edge',
+                id: `edge${i}`,
+                sourceId: `node${Math.floor(Math.random() * NODES)}`,
+                targetId: `node${Math.floor(Math.random() * NODES)}`
+            };
+            graph.children.push(edge);
+        }
+
+        return graph;
+    }
+
+}

--- a/examples/server/server-app.ts
+++ b/examples/server/server-app.ts
@@ -1,0 +1,70 @@
+/********************************************************************************
+ * Copyright (c) 2022 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import express from 'express';
+import * as path from 'path';
+import { ElkFactory, ElkLayoutEngine } from 'sprotty-elk/lib/elk-layout';
+import { SocketElkServer } from 'sprotty-elk/lib/node';
+import { Action, ActionMessage, DiagramServer, DiagramServices } from 'sprotty-protocol';
+import { RandomGraphGenerator } from './random-graph-generator';
+
+const serverApp = express();
+serverApp.use(express.json());
+
+// POST endpoint for fetching random graphs
+// Note: This approach works only for the initial RequestModelAction, but not for further
+// interaction between client and server. Use a WebSocket connection for more complex use cases.
+const elkFactory: ElkFactory = () => new SocketElkServer();
+const services: DiagramServices = {
+    DiagramGenerator: new RandomGraphGenerator(),
+    ModelLayoutEngine: new ElkLayoutEngine(elkFactory)
+}
+serverApp.post('/random-graph', (req, res) => {
+    let responseTimeout: NodeJS.Timeout;
+    try {
+        const incomingMessage = req.body as ActionMessage;
+        let responded = false;
+
+        // Create a diagram server and process the incoming message
+        const diagramServer = new DiagramServer(async (action: Action) => {
+            if (responded) {
+                console.warn('Cannot process additional action:', action);
+            } else {
+                // Send the first outgoing action as response
+                res.json([{ clientId: incomingMessage.clientId, action }]);
+                responded = true;
+            }
+        }, services);
+        diagramServer.accept(incomingMessage.action);
+
+        responseTimeout = setTimeout(() => {
+            if (!responded) {
+                res.json([]);
+                responded = true;
+            }
+        }, 10_000);
+    } catch (err) {
+        console.error(err);
+        res.status(500).send(err);
+        clearTimeout(responseTimeout!);
+    }
+});
+
+serverApp.use(express.static(path.join(__dirname, '..')));
+
+serverApp.listen(8080, () => {
+    console.log('Sprotty examples are available at http://localhost:8080');
+});

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -4,11 +4,13 @@
     "types": [
       "reflect-metadata", "webpack-env"
     ],
-    "outDir": "../out",
     "declaration": false,
     "declarationMap": false
   },
+  "include": [
+    "./server/**/*.ts"
+  ],
   "exclude": [
-    "**/*.spec.ts", "**/*.spec.tsx", "src/utils/test-helper.ts"
+    "**/*.spec.ts", "**/*.spec.tsx"
   ]
 }

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -14,7 +14,7 @@ const config = {
         'core-js/es/promise',
         'core-js/es/string',
         'core-js/es/symbol',
-        './app.ts'
+        './browser-app.ts'
     ],
     output: {
         filename: 'bundle.js',

--- a/packages/sprotty-elk/package.json
+++ b/packages/sprotty-elk/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.22",
     "@types/mocha": "^7.0.2",
+    "@types/node": "16.11.6",
     "@typescript-eslint/eslint-plugin": "^5.3.0",
     "@typescript-eslint/parser": "^5.3.0",
     "chai": "^4.3.4",

--- a/packages/sprotty-elk/src/elk-layout.ts
+++ b/packages/sprotty-elk/src/elk-layout.ts
@@ -31,8 +31,8 @@ export class ElkLayoutEngine implements IModelLayoutEngine {
     protected readonly elk: ELK;
 
     constructor(elkFactory: ElkFactory,
-                protected readonly filter: IElementFilter,
-                protected readonly configurator: ILayoutConfigurator) {
+                protected readonly filter: IElementFilter = new DefaultElementFilter(),
+                protected readonly configurator: ILayoutConfigurator = new DefaultLayoutConfigurator()) {
         this.elk = elkFactory();
     }
 

--- a/packages/sprotty-elk/src/node/index.ts
+++ b/packages/sprotty-elk/src/node/index.ts
@@ -1,0 +1,19 @@
+/********************************************************************************
+ * Copyright (c) 2022 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export * from './layout-data';
+export * from './socket-server';
+export * from './stdio-server';

--- a/packages/sprotty-elk/src/node/layout-data.ts
+++ b/packages/sprotty-elk/src/node/layout-data.ts
@@ -1,0 +1,167 @@
+/********************************************************************************
+ * Copyright (c) 2022 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ElkEdge, ElkExtendedEdge, ElkNode, ElkPrimitiveEdge, ElkShape } from 'elkjs/lib/elk-api';
+import { Dimension, Point } from 'sprotty-protocol';
+
+/**
+ * Data structure received in JSON format from an ELK server.
+ */
+export interface LayoutData {
+    [id: string]: LayoutElement
+}
+
+export type LayoutElement = ShapeLayoutElement | EdgeLayoutElement;
+
+export interface ShapeLayoutElement {
+    position: Point
+    size: Dimension
+}
+
+export function isShapeLayout(element: unknown): element is ShapeLayoutElement {
+    return typeof element === 'object' && element !== null
+        && (element as ShapeLayoutElement).position !== undefined;
+}
+
+export interface EdgeLayoutElement {
+    route: Point[]
+}
+
+export function isEdgeLayout(element: unknown): element is EdgeLayoutElement {
+    return typeof element === 'object' && element !== null
+        && (element as EdgeLayoutElement).route !== undefined;
+}
+
+export function isError(element: unknown): element is Error {
+    return typeof element === 'object' && element !== null
+        && (element as Error).stack !== undefined;
+}
+
+/**
+ * Apply the given layout data received from an ELK server to the original graph.
+ */
+export function applyLayoutData(data: LayoutData, node: ElkNode): void {
+    const dataElem = data[node.id];
+    if (isShapeLayout(dataElem)) {
+        applyShapeLayout(dataElem, node);
+    }
+    if (node.ports) {
+        for (const port of node.ports) {
+            const portDataElem = data[port.id];
+            if (isShapeLayout(portDataElem)) {
+                applyShapeLayout(portDataElem, port);
+            }
+            if (port.labels) {
+                for (const label of port.labels) {
+                    const labelDataElem = data[label.id];
+                    if (isShapeLayout(labelDataElem)) {
+                        applyShapeLayout(labelDataElem, label);
+                    }
+                }
+            }
+        }
+    }
+    if (node.labels) {
+        for (const label of node.labels) {
+            const labelDataElem = data[label.id];
+            if (isShapeLayout(labelDataElem)) {
+                applyShapeLayout(labelDataElem, label);
+            }
+        }
+    }
+    if (node.edges) {
+        for (const edge of node.edges) {
+            const edgeDataElem = data[edge.id];
+            if (isEdgeLayout(edgeDataElem)) {
+                applyEdgeLayout(edgeDataElem, edge);
+            }
+            if (edge.labels) {
+                for (const label of edge.labels) {
+                    const labelDataElem = data[label.id];
+                    if (isShapeLayout(labelDataElem)) {
+                        applyShapeLayout(labelDataElem, label);
+                    }
+                }
+            }
+        }
+    }
+    if (node.children) {
+        for (const child of node.children) {
+            applyLayoutData(data, child);
+        }
+    }
+}
+
+function applyShapeLayout(dataElem: ShapeLayoutElement, shape: ElkShape): void {
+    shape.x = dataElem.position.x;
+    shape.y = dataElem.position.y;
+    if (dataElem.size) {
+        shape.width = dataElem.size.width;
+        shape.height = dataElem.size.height;
+    }
+}
+
+function applyEdgeLayout(dataElem: EdgeLayoutElement, edge: ElkEdge): void {
+    if (isPrimitiveEdge(edge)) {
+        if (dataElem.route.length >= 1) {
+            edge.sourcePoint = dataElem.route[0];
+        }
+        edge.bendPoints = dataElem.route.slice(1, -1);
+        if (dataElem.route.length >= 2) {
+            edge.targetPoint = dataElem.route[dataElem.route.length - 1];
+        }
+    } else if (isExtendedEdge(edge) && edge.sections.length > 0) {
+        const section = edge.sections[0];
+        if (dataElem.route.length >= 1) {
+            section.startPoint = dataElem.route[0];
+        }
+        section.bendPoints = dataElem.route.slice(1, -1);
+        if (dataElem.route.length >= 2) {
+            section.endPoint = dataElem.route[dataElem.route.length - 1];
+        }
+    }
+}
+
+function isPrimitiveEdge(edge: ElkEdge): edge is ElkPrimitiveEdge {
+    return typeof (edge as ElkPrimitiveEdge).source === 'string'
+        && typeof (edge as ElkPrimitiveEdge).target === 'string';
+}
+
+function isExtendedEdge(edge: ElkEdge): edge is ElkExtendedEdge {
+    return Array.isArray((edge as ElkExtendedEdge).sources) && Array.isArray((edge as ElkExtendedEdge).targets);
+}
+
+/**
+ * Utility function that looks for the end of a JSON object in an incoming stream.
+ */
+export function findObjectEnd(chunk: Buffer, state: ParseState): void {
+    for (let i = 0; i < chunk.length; i++) {
+        const ch = chunk[i];
+        // TODO check whether inside a string
+        if (ch === OPEN_BRACE) {
+            state.objLevel++;
+        } else if (ch === CLOSE_BRACE) {
+            state.objLevel--;
+        }
+    }
+}
+
+export interface ParseState {
+    objLevel: number
+}
+
+const OPEN_BRACE = '{'.charCodeAt(0);
+const CLOSE_BRACE = '}'.charCodeAt(0);

--- a/packages/sprotty-elk/src/node/socket-server.ts
+++ b/packages/sprotty-elk/src/node/socket-server.ts
@@ -1,0 +1,30 @@
+/********************************************************************************
+ * Copyright (c) 2022 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ElkLayoutArguments, ElkNode } from 'elkjs/lib/elk-api';
+import { ElkFactory } from '../elk-layout';
+
+export const socketElkServerFactory: ElkFactory = () => {
+    const requestLayout = (graph: ElkNode, args?: ElkLayoutArguments): Promise<ElkNode> => {
+        return null!;
+    }
+    return {
+        layout: requestLayout,
+        knownLayoutAlgorithms: () => Promise.reject('not supported'),
+        knownLayoutOptions: () => Promise.reject('not supported'),
+        knownLayoutCategories: () => Promise.reject('not supported')
+    };
+};

--- a/packages/sprotty-elk/src/node/socket-server.ts
+++ b/packages/sprotty-elk/src/node/socket-server.ts
@@ -23,6 +23,14 @@ import { applyLayoutData, findObjectEnd, isError, LayoutData, ParseState } from 
 const DEFAULT_PORT = 5008;
 const DEFAULT_TIMEOUT = 10_000;
 
+/**
+ * Use this together with the `ElkLayoutEngine` to connect to a Java process via socket:
+ * ```
+ * const elkFactory: ElkFactory = () => new SocketElkServer();
+ * ```
+ * The `elk-server` application can be obtained here:
+ * https://github.com/TypeFox/elk-server
+ */
 export class SocketElkServer implements ELK {
 
     protected socket?: Socket;

--- a/packages/sprotty-elk/src/node/socket-server.ts
+++ b/packages/sprotty-elk/src/node/socket-server.ts
@@ -14,17 +14,95 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ElkLayoutArguments, ElkNode } from 'elkjs/lib/elk-api';
-import { ElkFactory } from '../elk-layout';
+import { Socket } from 'net';
+import {
+    ELK, ElkLayoutAlgorithmDescription, ElkLayoutCategoryDescription, ElkLayoutOptionDescription, ElkNode
+} from 'elkjs/lib/elk-api';
+import { applyLayoutData, findObjectEnd, isError, LayoutData, ParseState } from './layout-data';
 
-export const socketElkServerFactory: ElkFactory = () => {
-    const requestLayout = (graph: ElkNode, args?: ElkLayoutArguments): Promise<ElkNode> => {
-        return null!;
+const DEFAULT_PORT = 5008;
+const DEFAULT_TIMEOUT = 10_000;
+
+export class SocketElkServer implements ELK {
+
+    protected socket?: Socket;
+    protected readonly port: number;
+    protected readonly timeoutDelay: number;
+
+    constructor(options: { port?: number, timeoutDelay?: number } = {}) {
+        const envPort = process.env.SERVER_PORT ? parseInt(process.env.SERVER_PORT, 10) : undefined;
+        this.port = options.port ?? envPort ?? DEFAULT_PORT;
+        this.timeoutDelay = options.timeoutDelay ?? DEFAULT_TIMEOUT;
     }
-    return {
-        layout: requestLayout,
-        knownLayoutAlgorithms: () => Promise.reject('not supported'),
-        knownLayoutOptions: () => Promise.reject('not supported'),
-        knownLayoutCategories: () => Promise.reject('not supported')
-    };
-};
+
+    async layout(graph: ElkNode): Promise<ElkNode> {
+        const socket = await this.createSocket();
+        return new Promise((resolve, reject) => {
+            const timeout = setTimeout(
+                () => reject(new Error(`Timeout of ${this.timeoutDelay} ms elapsed while waiting for layout server.`)),
+                this.timeoutDelay
+            );
+            const closeCallback = () => {
+                clearTimeout(timeout);
+                this.socket = undefined;
+                reject(new Error('The layout server socket was closed.'));
+            };
+            socket.on('close', closeCallback);
+            // Send the input graph to the layout server
+            socket.write(JSON.stringify(graph));
+
+            // Wait for complete result
+            const buffers: Buffer[] = [];
+            const parseState: ParseState = { objLevel: 0 };
+            const dataCallback = (chunk: Buffer) => {
+                buffers.push(chunk);
+                findObjectEnd(chunk, parseState);
+                if (parseState.objLevel === 0) {
+                    clearTimeout(timeout);
+                    socket.removeListener('close', closeCallback);
+                    socket.removeListener('data', dataCallback);
+                    try {
+                        const response = JSON.parse(Buffer.concat(buffers).toString()) as LayoutData | Error;
+                        if (isError(response)) {
+                            // The layout server responded an error
+                            reject(response);
+                        } else {
+                            applyLayoutData(response, graph);
+                            resolve(graph);
+                        }
+                    } catch (err) {
+                        reject(err);
+                    }
+                }
+            };
+            socket.on('data', dataCallback);
+        });
+    }
+
+    protected createSocket(): Promise<Socket> {
+        if (this.socket && !this.socket.destroyed) {
+            return Promise.resolve(this.socket);
+        }
+        return new Promise((resolve, reject) => {
+            const socket = new Socket();
+            socket.on('error', err => {
+                this.socket = undefined;
+                reject(err);
+            });
+            socket.connect(this.port);
+            this.socket = socket;
+            socket.on('ready', () => resolve(socket));
+        });
+    }
+
+    knownLayoutAlgorithms(): Promise<ElkLayoutAlgorithmDescription> {
+        throw new Error('Method not implemented.');
+    }
+    knownLayoutOptions(): Promise<ElkLayoutOptionDescription> {
+        throw new Error('Method not implemented.');
+    }
+    knownLayoutCategories(): Promise<ElkLayoutCategoryDescription> {
+        throw new Error('Method not implemented.');
+    }
+
+}

--- a/packages/sprotty-elk/src/node/stdio-server.ts
+++ b/packages/sprotty-elk/src/node/stdio-server.ts
@@ -1,0 +1,30 @@
+/********************************************************************************
+ * Copyright (c) 2022 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ElkLayoutArguments, ElkNode } from 'elkjs/lib/elk-api';
+import { ElkFactory } from '../elk-layout';
+
+export const stdioElkServerFactory: ElkFactory = () => {
+    const requestLayout = (graph: ElkNode, args?: ElkLayoutArguments): Promise<ElkNode> => {
+        return null!;
+    }
+    return {
+        layout: requestLayout,
+        knownLayoutAlgorithms: () => Promise.reject('not supported'),
+        knownLayoutOptions: () => Promise.reject('not supported'),
+        knownLayoutCategories: () => Promise.reject('not supported')
+    };
+};

--- a/packages/sprotty-elk/src/node/stdio-server.ts
+++ b/packages/sprotty-elk/src/node/stdio-server.ts
@@ -14,17 +14,101 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ElkLayoutArguments, ElkNode } from 'elkjs/lib/elk-api';
-import { ElkFactory } from '../elk-layout';
+import { spawn, ChildProcess } from 'child_process';
+import {
+    ELK, ElkLayoutAlgorithmDescription, ElkLayoutCategoryDescription, ElkLayoutOptionDescription, ElkNode
+} from 'elkjs/lib/elk-api';
+import { applyLayoutData, findObjectEnd, isError, LayoutData, ParseState } from './layout-data';
 
-export const stdioElkServerFactory: ElkFactory = () => {
-    const requestLayout = (graph: ElkNode, args?: ElkLayoutArguments): Promise<ElkNode> => {
-        return null!;
+const DEFAULT_TIMEOUT = 10_000;
+
+export class StdioElkServer implements ELK {
+
+    protected process?: ChildProcess;
+    protected readonly commandPath: string;
+    protected readonly timeoutDelay: number;
+
+    constructor(options: { commandPath: string, timeoutDelay?: number }) {
+        this.commandPath = options.commandPath;
+        this.timeoutDelay = options.timeoutDelay ?? DEFAULT_TIMEOUT;
+        process.on('exit', () => {
+            if (this.process) {
+                this.process.kill();
+            }
+        });
     }
-    return {
-        layout: requestLayout,
-        knownLayoutAlgorithms: () => Promise.reject('not supported'),
-        knownLayoutOptions: () => Promise.reject('not supported'),
-        knownLayoutCategories: () => Promise.reject('not supported')
-    };
-};
+
+    async layout(graph: ElkNode): Promise<ElkNode> {
+        const process = await this.createProcess();
+        return new Promise((resolve, reject) => {
+            const timeout = setTimeout(
+                () => reject(new Error(`Timeout of ${this.timeoutDelay} ms elapsed while waiting for layout server.`)),
+                this.timeoutDelay
+            );
+            const exitCallback = () => {
+                clearTimeout(timeout);
+                this.process = undefined;
+                reject(new Error('The layout server process terminated.'));
+            };
+            process.on('exit', exitCallback);
+            if (!process.stdin || !process.stdout) {
+                reject('The layout server process is not available.');
+                return;
+            }
+            process.stdin.on('error', reject);
+            // Send the input graph to the layout server
+            process.stdin.write(JSON.stringify(graph));
+
+            // Wait for complete result
+            const buffers: Buffer[] = [];
+            const parseState: ParseState = { objLevel: 0 };
+            const dataCallback = (chunk: Buffer) => {
+                buffers.push(chunk);
+                findObjectEnd(chunk, parseState);
+                if (parseState.objLevel === 0) {
+                    clearTimeout(timeout);
+                    process.removeListener('exit', exitCallback);
+                    process.stdout?.removeListener('data', dataCallback);
+                    process.stdin?.removeListener('error', reject);
+                    try {
+                        const response = JSON.parse(Buffer.concat(buffers).toString()) as LayoutData | Error;
+                        if (isError(response)) {
+                            // The layout server responded an error
+                            reject(response);
+                        } else {
+                            applyLayoutData(response, graph);
+                            resolve(graph);
+                        }
+                    } catch (err) {
+                        reject(err);
+                    }
+                }
+            };
+            process.stdout.on('data', dataCallback);
+        });
+    }
+
+    protected createProcess(): Promise<ChildProcess> {
+        if (this.process && !this.process.killed) {
+            return Promise.resolve(this.process);
+        }
+        return new Promise((resolve, reject) => {
+            const process = spawn(this.commandPath, ['--stdio']);
+            process.on('error', reject);
+            process.stderr.on('data', data => console.error(data.toString()));
+            this.process = process;
+            setImmediate(() => resolve(process));
+        });
+    }
+
+    knownLayoutAlgorithms(): Promise<ElkLayoutAlgorithmDescription> {
+        throw new Error('Method not implemented.');
+    }
+    knownLayoutOptions(): Promise<ElkLayoutOptionDescription> {
+        throw new Error('Method not implemented.');
+    }
+    knownLayoutCategories(): Promise<ElkLayoutCategoryDescription> {
+        throw new Error('Method not implemented.');
+    }
+
+}

--- a/packages/sprotty-elk/src/node/stdio-server.ts
+++ b/packages/sprotty-elk/src/node/stdio-server.ts
@@ -22,6 +22,14 @@ import { applyLayoutData, findObjectEnd, isError, LayoutData, ParseState } from 
 
 const DEFAULT_TIMEOUT = 10_000;
 
+/**
+ * Use this together with the `ElkLayoutEngine` to spawn a Java process in the background:
+ * ```
+ * const elkFactory: ElkFactory = () => new StdioElkServer({ commandPath: './elk-server/bin/elk-server' });
+ * ```
+ * The `elk-server` application can be obtained here:
+ * https://github.com/TypeFox/elk-server
+ */
 export class StdioElkServer implements ELK {
 
     protected process?: ChildProcess;

--- a/packages/sprotty-elk/tsconfig.json
+++ b/packages/sprotty-elk/tsconfig.json
@@ -1,7 +1,10 @@
 {
     "extends": "../../configs/base.tsconfig.json",
     "compilerOptions": {
-      "outDir": "lib"
+      "outDir": "lib",
+      "types": [
+        "node"
+      ]
     },
     "include": [
       "src"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1048,10 +1048,25 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
+"@types/body-parser@*":
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"
+  integrity sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
 "@types/chai@^4.2.22":
   version "4.2.22"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.22.tgz#47020d7e4cf19194d43b5202f35f75bd2ad35ce7"
   integrity sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ==
+
+"@types/connect@*":
+  version "3.4.35"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
+  integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/eslint-scope@^3.7.0":
   version "3.7.1"
@@ -1073,6 +1088,25 @@
   version "0.0.50"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
   integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
+
+"@types/express-serve-static-core@^4.17.18":
+  version "4.17.28"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz#c47def9f34ec81dc6328d0b1b5303d1ec98d86b8"
+  integrity sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+
+"@types/express@^4.17.13":
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.13.tgz#a76e2995728999bab51a33fabce1d705a3709034"
+  integrity sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.18"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
 
 "@types/file-saver@^2.0.3":
   version "2.0.3"
@@ -1098,6 +1132,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/mime@^1":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
+  integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
+
 "@types/minimatch@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
@@ -1113,7 +1152,7 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-7.0.2.tgz#b17f16cf933597e10d6d78eae3251e692ce8b0ce"
   integrity sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==
 
-"@types/node@*":
+"@types/node@*", "@types/node@16.11.6":
   version "16.11.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.6.tgz#6bef7a2a0ad684cf6e90fcfe31cecabd9ce0a3ae"
   integrity sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==
@@ -1132,6 +1171,24 @@
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-6.0.2.tgz#99f6b72d82e34cea03a4d8f2ed72114d909c1c61"
   integrity sha512-+hQX+WyJAOne7Fh3zF5CxPemILIbuhNcqHHodzK9caYOLnC8pD5efmPleRnw0z++LfKUC/sVNMwk0Gap+B0baA==
+
+"@types/qs@*":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
+"@types/range-parser@*":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
+  integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
+
+"@types/serve-static@*":
+  version "1.13.10"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
+  integrity sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
+  dependencies:
+    "@types/mime" "^1"
+    "@types/node" "*"
 
 "@types/tough-cookie@*":
   version "4.0.1"
@@ -1384,6 +1441,14 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+accepts@~1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
+  integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
+  dependencies:
+    mime-types "~2.1.34"
+    negotiator "0.6.3"
+
 acorn-globals@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
@@ -1577,6 +1642,11 @@ array-differ@^3.0.0:
   resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-3.0.0.tgz#3cbb3d0f316810eafcc47624734237d6aee4ae6b"
   integrity sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==
 
+array-flatten@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
+  integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
+
 array-ify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
@@ -1619,13 +1689,6 @@ assertion-error@^1.1.0:
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
   integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
-async@^2.6.2:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
-  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
-  dependencies:
-    lodash "^4.17.14"
-
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -1656,13 +1719,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-basic-auth@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
-  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
-  dependencies:
-    safe-buffer "5.1.2"
-
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
@@ -1684,6 +1740,22 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+body-parser@1.19.2:
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.2.tgz#4714ccd9c157d44797b8b5607d72c0b89952f26e"
+  integrity sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==
+  dependencies:
+    bytes "3.1.2"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.2"
+    http-errors "1.8.1"
+    iconv-lite "0.4.24"
+    on-finished "~2.3.0"
+    qs "6.9.7"
+    raw-body "2.4.3"
+    type-is "~1.6.18"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1745,6 +1817,11 @@ byte-size@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/byte-size/-/byte-size-7.0.1.tgz#b1daf3386de7ab9d706b941a748dbfc71130dee3"
   integrity sha512-crQdqyCwhokxwV1UyDzLZanhkugAgft7vt0qbbdt60C6Zf3CAiGmtUCylbtYwrU6loOUw3euGrNtW1J651ot1A==
+
+bytes@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
+  integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
 cacache@^15.0.5, cacache@^15.2.0:
   version "15.3.0"
@@ -1981,11 +2058,6 @@ colorette@^2.0.14:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
   integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
 
-colors@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
-
 columnify@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
@@ -2051,6 +2123,18 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
+
+content-disposition@0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
+  integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
+  dependencies:
+    safe-buffer "5.2.1"
+
+content-type@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
+  integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
 conventional-changelog-angular@^5.0.12:
   version "5.0.13"
@@ -2141,6 +2225,16 @@ convert-source-map@^1.6.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+cookie-signature@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
+  integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
+
+cookie@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
 core-js@^3.19.1:
   version "3.19.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.19.1.tgz#f6f173cae23e73a7d88fa23b6e9da329276c6641"
@@ -2155,11 +2249,6 @@ core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
-
-corser@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/corser/-/corser-2.0.1.tgz#8eda252ecaab5840dcd975ceb90d9370c819ff87"
-  integrity sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=
 
 cosmiconfig@^7.0.0:
   version "7.0.1"
@@ -2267,6 +2356,13 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
+debug@2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
 debug@3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -2280,13 +2376,6 @@ debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
   dependencies:
     ms "2.1.2"
-
-debug@^3.1.1:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
-  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
-  dependencies:
-    ms "^2.1.1"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -2364,7 +2453,7 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-depd@^1.1.2:
+depd@^1.1.2, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
@@ -2373,6 +2462,11 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
+
+destroy@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
+  integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
 detect-indent@^5.0.0:
   version "5.0.0"
@@ -2450,6 +2544,11 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+ee-first@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+  integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+
 electron-to-chromium@^1.3.886:
   version "1.3.887"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.887.tgz#b36aeed12a28aaa19460a467823f5bbe1f3c6f06"
@@ -2474,6 +2573,11 @@ emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
+
+encodeurl@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
+  integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
 encoding@^0.1.12:
   version "0.1.13"
@@ -2568,6 +2672,11 @@ escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
+escape-html@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -2726,7 +2835,12 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-eventemitter3@^4.0.0, eventemitter3@^4.0.4:
+etag@~1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+  integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+
+eventemitter3@^4.0.4:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -2750,6 +2864,42 @@ execa@^5.0.0:
     onetime "^5.1.2"
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
+
+express@^4.17.3:
+  version "4.17.3"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.17.3.tgz#f6c7302194a4fb54271b73a1fe7a06478c8f85a1"
+  integrity sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==
+  dependencies:
+    accepts "~1.3.8"
+    array-flatten "1.1.1"
+    body-parser "1.19.2"
+    content-disposition "0.5.4"
+    content-type "~1.0.4"
+    cookie "0.4.2"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "~1.1.2"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "~1.1.2"
+    fresh "0.5.2"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "~2.3.0"
+    parseurl "~1.3.3"
+    path-to-regexp "0.1.7"
+    proxy-addr "~2.0.7"
+    qs "6.9.7"
+    range-parser "~1.2.1"
+    safe-buffer "5.2.1"
+    send "0.17.2"
+    serve-static "1.14.2"
+    setprototypeof "1.2.0"
+    statuses "~1.5.0"
+    type-is "~1.6.18"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
 
 extend@~3.0.2:
   version "3.0.2"
@@ -2852,6 +3002,19 @@ filter-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
   integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
 
+finalhandler@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
+  integrity sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    on-finished "~2.3.0"
+    parseurl "~1.3.3"
+    statuses "~1.5.0"
+    unpipe "~1.0.0"
+
 find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
@@ -2903,11 +3066,6 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
   integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
 
-follow-redirects@^1.0.0:
-  version "1.14.8"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
-  integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
-
 foreground-child@^1.5.6:
   version "1.5.6"
   resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-1.5.6.tgz#4fd71ad2dfde96789b980a5c0a295937cb2f5ce9"
@@ -2938,6 +3096,16 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+forwarded@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
+  integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
+
+fresh@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+  integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
 fs-extra@^9.1.0:
   version "9.1.0"
@@ -3253,7 +3421,7 @@ hasha@^3.0.0:
   dependencies:
     is-stream "^1.0.1"
 
-he@1.2.0, he@^1.2.0:
+he@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -3287,6 +3455,17 @@ http-cache-semantics@^4.1.0:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
 
+http-errors@1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c"
+  integrity sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.1"
+
 http-proxy-agent@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
@@ -3304,34 +3483,6 @@ http-proxy-agent@^5.0.0:
     "@tootallnate/once" "2"
     agent-base "6"
     debug "4"
-
-http-proxy@^1.18.1:
-  version "1.18.1"
-  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
-  integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
-  dependencies:
-    eventemitter3 "^4.0.0"
-    follow-redirects "^1.0.0"
-    requires-port "^1.0.0"
-
-http-server@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/http-server/-/http-server-14.0.0.tgz#bd214952a60b93ce8ca9bbe8ba181faf7f9821b0"
-  integrity sha512-XTePIXAo5x72bI8SlKFSqsg7UuSHwsOa4+RJIe56YeMUvfTvGDy7TxFkTEhfIRmM/Dnf6x29ut541ythSBZdkQ==
-  dependencies:
-    basic-auth "^2.0.1"
-    colors "^1.4.0"
-    corser "^2.0.1"
-    he "^1.2.0"
-    html-encoding-sniffer "^3.0.0"
-    http-proxy "^1.18.1"
-    mime "^1.6.0"
-    minimist "^1.2.5"
-    opener "^1.5.1"
-    portfinder "^1.0.28"
-    secure-compare "3.0.1"
-    union "~0.5.0"
-    url-join "^4.0.1"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -3362,19 +3513,19 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
+iconv-lite@0.4.24, iconv-lite@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
 iconv-lite@0.6.3, iconv-lite@^0.6.2:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
-
-iconv-lite@^0.4.24:
-  version "0.4.24"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
-  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
 
 icss-utils@^5.0.0, icss-utils@^5.1.0:
   version "5.1.0"
@@ -3437,7 +3588,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3507,6 +3658,11 @@ ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
+
+ipaddr.js@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
+  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -4139,7 +4295,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.7.0:
+lodash@^4.17.15, lodash@^4.17.19, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4246,6 +4402,11 @@ map-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
+media-typer@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+  integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+
 meow@^8.0.0:
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/meow/-/meow-8.1.2.tgz#bcbe45bda0ee1729d350c03cffc8395a36c4e897"
@@ -4262,6 +4423,11 @@ meow@^8.0.0:
     trim-newlines "^3.0.0"
     type-fest "^0.18.0"
     yargs-parser "^20.2.3"
+
+merge-descriptors@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+  integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
 
 merge-source-map@^1.1.0:
   version "1.1.0"
@@ -4280,6 +4446,11 @@ merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
+methods@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+  integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
+
 micromatch@^4.0.0, micromatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
@@ -4293,6 +4464,11 @@ mime-db@1.50.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.50.0.tgz#abd4ac94e98d3c0e185016c67ab45d5fde40c11f"
   integrity sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
 mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.19:
   version "2.1.33"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.33.tgz#1fa12a904472fafd068e48d9e8401f74d3f70edb"
@@ -4300,7 +4476,14 @@ mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.19:
   dependencies:
     mime-db "1.50.0"
 
-mime@^1.6.0:
+mime-types@~2.1.24, mime-types@~2.1.34:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
+mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
@@ -4505,6 +4688,11 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+
 ms@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
@@ -4515,7 +4703,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.0.0, ms@^2.1.1:
+ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -4545,6 +4733,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+negotiator@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
+  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
 negotiator@^0.6.2:
   version "0.6.2"
@@ -4878,6 +5071,13 @@ object.getownpropertydescriptors@^2.0.3:
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
 
+on-finished@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
+  integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
+  dependencies:
+    ee-first "1.1.1"
+
 once@^1.3.0, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -4891,11 +5091,6 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
-
-opener@^1.5.1:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
-  integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -5132,6 +5327,11 @@ parse5@6.0.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
+parseurl@~1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
+  integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -5156,6 +5356,11 @@ path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-to-regexp@0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+  integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
 path-type@^3.0.0:
   version "3.0.0"
@@ -5222,15 +5427,6 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
-
-portfinder@^1.0.28:
-  version "1.0.28"
-  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
-  integrity sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==
-  dependencies:
-    async "^2.6.2"
-    debug "^3.1.1"
-    mkdirp "^0.5.5"
 
 postcss-modules-extract-imports@^3.0.0:
   version "3.0.0"
@@ -5332,6 +5528,14 @@ protocols@^1.1.0, protocols@^1.4.0:
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.8.tgz#48eea2d8f58d9644a4a32caae5d5db290a075ce8"
   integrity sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==
 
+proxy-addr@~2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
+  integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
+  dependencies:
+    forwarded "0.2.0"
+    ipaddr.js "1.9.1"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -5352,7 +5556,12 @@ q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qs@^6.4.0, qs@^6.9.4:
+qs@6.9.7:
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.7.tgz#4610846871485e1e048f44ae3b94033f0e675afe"
+  integrity sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==
+
+qs@^6.9.4:
   version "6.10.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
   integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
@@ -5390,6 +5599,21 @@ randombytes@^2.1.0:
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
     safe-buffer "^5.1.0"
+
+range-parser@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
+  integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
+
+raw-body@2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.3.tgz#8f80305d11c2a0a545c2d9d89d7a0286fcead43c"
+  integrity sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==
+  dependencies:
+    bytes "3.1.2"
+    http-errors "1.8.1"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -5608,11 +5832,6 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
-requires-port@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
-  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
-
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -5698,15 +5917,15 @@ rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
@@ -5729,11 +5948,6 @@ schema-utils@^3.0.0, schema-utils@^3.1.0, schema-utils@^3.1.1:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
-secure-compare@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/secure-compare/-/secure-compare-3.0.1.tgz#f1a0329b308b221fae37b9974f3d578d0ca999e3"
-  integrity sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=
-
 "semver@2 || 3 || 4 || 5", semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
@@ -5751,6 +5965,25 @@ semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semve
   dependencies:
     lru-cache "^6.0.0"
 
+send@0.17.2:
+  version "0.17.2"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.17.2.tgz#926622f76601c41808012c8bf1688fe3906f7820"
+  integrity sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==
+  dependencies:
+    debug "2.6.9"
+    depd "~1.1.2"
+    destroy "~1.0.4"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "0.5.2"
+    http-errors "1.8.1"
+    mime "1.6.0"
+    ms "2.1.3"
+    on-finished "~2.3.0"
+    range-parser "~1.2.1"
+    statuses "~1.5.0"
+
 serialize-javascript@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
@@ -5758,10 +5991,25 @@ serialize-javascript@^6.0.0:
   dependencies:
     randombytes "^2.1.0"
 
+serve-static@1.14.2:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.14.2.tgz#722d6294b1d62626d41b43a013ece4598d292bfa"
+  integrity sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==
+  dependencies:
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    parseurl "~1.3.3"
+    send "0.17.2"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+setprototypeof@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
+  integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
 shallow-clone@^3.0.0:
   version "3.0.1"
@@ -6008,6 +6256,11 @@ ssri@^8.0.0, ssri@^8.0.1:
   integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
   dependencies:
     minipass "^3.1.1"
+
+"statuses@>= 1.5.0 < 2", statuses@~1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+  integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
 strict-uri-encode@^2.0.0:
   version "2.0.0"
@@ -6329,6 +6582,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+toidentifier@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
+  integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
 tough-cookie@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.0.0.tgz#d822234eeca882f991f0f908824ad2622ddbece4"
@@ -6504,6 +6762,14 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type-is@~1.6.18:
+  version "1.6.18"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
+  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.24"
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -6546,13 +6812,6 @@ unbox-primitive@^1.0.1:
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
 
-union@~0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/union/-/union-0.5.0.tgz#b2c11be84f60538537b846edb9ba266ba0090075"
-  integrity sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==
-  dependencies:
-    qs "^6.4.0"
-
 unique-filename@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230"
@@ -6582,6 +6841,11 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
+unpipe@1.0.0, unpipe@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+  integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
+
 upath@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/upath/-/upath-2.0.1.tgz#50c73dea68d6f6b990f51d279ce6081665d61a8b"
@@ -6594,11 +6858,6 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-url-join@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
-  integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
-
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -6610,6 +6869,11 @@ util-promisify@^2.1.0:
   integrity sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
+
+utils-merge@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
+  integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
 uuid@^3.3.2:
   version "3.4.0"
@@ -6635,6 +6899,11 @@ validate-npm-package-name@^3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
+
+vary@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
+  integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
This PR adds two classes `SocketElkServer` and `StdioElkServer` to `sprotty-elk` that enable to run the ELK layout engine in a separate Java process. The Java application is implemented in a new MIT-licensed project [elk-server](https://github.com/TypeFox/elk-server).

## How To Test

1. Download [elk-server](https://github.com/TypeFox/elk-server/releases/tag/v0.1.0)
2. Run the application with the `--socket` argument:
   ```
    elk-server-0.1.0/bin/elk-server --socket
   ```
3. Build and run the examples server (`yarn start`)
4. Open the new "random graph" example in the "With Server" section on http://localhost:8080/

The result should look similar to the previous in-browser "random graph" example.