### PR TITLE
Fix edge views that consider intersections

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,8 +11,8 @@
             "args": [
                 "${file}",
                 "--no-timeouts",
-                "--opts",
-                "${workspaceRoot}/configs/mocha.opts"
+                "--config",
+                "${workspaceRoot}/configs/.mocharc.json"
             ],
             "env": {
                 "TS_NODE_PROJECT": "${workspaceRoot}/tsconfig.json"

--- a/examples/random-graph/src/di.config.ts
+++ b/examples/random-graph/src/di.config.ts
@@ -19,7 +19,7 @@ import ElkConstructor from 'elkjs/lib/elk.bundled';
 import {
     TYPES, configureViewerOptions, SGraphView, SLabelView, ConsoleLogger, LogLevel,
     loadDefaultModules, LocalModelSource, SNode, SEdge, SLabel, configureModelElement,
-    SGraph, RectangularNodeView, PolylineEdgeView
+    SGraph, RectangularNodeView, edgeIntersectionModule, PolylineEdgeViewWithGapsOnIntersections
 } from 'sprotty';
 import { ElkFactory, ElkLayoutEngine, elkLayoutModule } from 'sprotty-elk/lib/inversify';
 
@@ -41,7 +41,7 @@ export default (containerId: string) => {
         const context = { bind, unbind, isBound, rebind };
         configureModelElement(container, 'graph', SGraph, SGraphView);
         configureModelElement(container, 'node', SNode, RectangularNodeView);
-        configureModelElement(container, 'edge', SEdge, PolylineEdgeView);
+        configureModelElement(container, 'edge', SEdge, PolylineEdgeViewWithGapsOnIntersections);
         configureModelElement(container, 'label', SLabel, SLabelView);
 
         configureViewerOptions(context, {
@@ -52,6 +52,7 @@ export default (containerId: string) => {
 
     const container = new Container();
     loadDefaultModules(container);
+    container.load(edgeIntersectionModule);
     container.load(elkLayoutModule, randomGraphModule);
     return container;
 };

--- a/packages/sprotty/src/features/edge-intersection/intersection-finder.ts
+++ b/packages/sprotty/src/features/edge-intersection/intersection-finder.ts
@@ -89,8 +89,22 @@ export class IntersectionFinder implements IEdgeRoutePostprocessor {
      */
     find(routing: EdgeRouting): Intersection[] {
         const eventQueue = new TinyQueue<SweepEvent>(undefined, checkWhichEventIsLeft);
-        routing.routes.forEach((route, routeId) => addRoute(routeId, route, eventQueue));
+        routing.routes.forEach((route, routeId) => {
+            if (this.isSupportedRoute(route)) {
+                addRoute(routeId, route, eventQueue);
+            }
+        });
         return runSweep(eventQueue);
+    }
+
+    /**
+     * Specifies whether or not a specific route should be included in this intersection search or not.
+     *
+     * As this intersection finder only supports linear line segments, this method only returns `true`
+     * for routes that only contain routed points, which are either 'source', 'target' or 'linear'.
+     */
+    protected isSupportedRoute(route: RoutedPoint[]): boolean {
+        return route.find(point => point.kind !== 'source' && point.kind !== 'target' && point.kind !== 'linear') === undefined;
     }
 
     protected addToRouting(intersections: Intersection[], routing: EdgeRouting) {

--- a/packages/sprotty/src/features/edge-intersection/intersection-finder.ts
+++ b/packages/sprotty/src/features/edge-intersection/intersection-finder.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021 EclipseSource and others.
+ * Copyright (c) 2021-2022 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -43,8 +43,31 @@ export const BY_X_THEN_Y = (a: Intersection, b: Intersection): number => {
     return a.intersectionPoint.x - b.intersectionPoint.x;
 };
 
+export const BY_DESCENDING_X_THEN_Y = (a: Intersection, b: Intersection): number => {
+    if (a.intersectionPoint.x === b.intersectionPoint.x) {
+        return a.intersectionPoint.y - b.intersectionPoint.y;
+    }
+    return b.intersectionPoint.x - a.intersectionPoint.x;
+};
+
+export const BY_X_THEN_DESCENDING_Y = (a: Intersection, b: Intersection): number => {
+    if (a.intersectionPoint.x === b.intersectionPoint.x) {
+        return b.intersectionPoint.y - a.intersectionPoint.y;
+    }
+    return a.intersectionPoint.x - b.intersectionPoint.x;
+};
+
+export const BY_DESCENDING_X_THEN_DESCENDING_Y = (a: Intersection, b: Intersection): number => {
+    if (a.intersectionPoint.x === b.intersectionPoint.x) {
+        return b.intersectionPoint.y - a.intersectionPoint.y;
+    }
+    return b.intersectionPoint.x - a.intersectionPoint.x;
+};
+
 /**
  * Finds intersections among edges and updates routed points to reflect those intersections.
+ *
+ * This only yields correct intersections among straight line segments and doesn't work with bezier curves.
  */
 @injectable()
 export class IntersectionFinder implements IEdgeRoutePostprocessor {

--- a/packages/sprotty/src/graph/views.tsx
+++ b/packages/sprotty/src/graph/views.tsx
@@ -274,8 +274,12 @@ export class PolylineEdgeViewWithGapsOnIntersections extends JumpingPolylineEdge
     protected skipOffsetBefore = 3;
     protected skipOffsetAfter = 3;
 
-    protected createJumpPath(intersectionPoint: Point, lineSegment: PointToPointLine): string {
-        return "";
+    protected shouldDrawLineJumpOnIntersection(currentLineSegment: PointToPointLine, otherLineSegment: PointToPointLine) {
+        return false;
+    }
+
+    protected shouldDrawLineGapOnIntersection(currentLineSegment: PointToPointLine, otherLineSegment: PointToPointLine) {
+        return Math.abs(currentLineSegment.slopeOrMax) >= Math.abs(otherLineSegment.slopeOrMax);
     }
 
     protected createGapPath(intersectionPoint: Point, lineSegment: PointToPointLine): string {

--- a/packages/sprotty/src/utils/geometry.spec.ts
+++ b/packages/sprotty/src/utils/geometry.spec.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2022 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -46,6 +46,43 @@ describe('PointToPointLine', () => {
             const lineB = new PointToPointLine({ x: 0, y: 1 }, { x: 1, y: 1 });
             const intersection = lineA.intersection(lineB);
             expect(intersection).to.be.undefined;
+        });
+    });
+    describe('direction', () => {
+        // the coordinate system goes from left to right and top to bottom
+        // thus, x increases to the right and y increases downwards
+        // so a line going north is (x:0,y:1) -> (x:0:y0)
+        it('correctly defines line to north', () => {
+            const line = new PointToPointLine({ x: 0, y: 1 }, { x: 0, y: 0 });
+            expect(line.direction).to.equal('north');
+        });
+        it('correctly defines line to north-east', () => {
+            const line = new PointToPointLine({ x: 0, y: 1 }, { x: 1, y: 0 });
+            expect(line.direction).to.equal('north-east');
+        });
+        it('correctly defines line to east', () => {
+            const line = new PointToPointLine({ x: 0, y: 0 }, { x: 1, y: 0 });
+            expect(line.direction).to.equal('east');
+        });
+        it('correctly defines line to south-east', () => {
+            const line = new PointToPointLine({ x: 0, y: 0 }, { x: 1, y: 1 });
+            expect(line.direction).to.equal('south-east');
+        });
+        it('correctly defines line to south', () => {
+            const line = new PointToPointLine({ x: 0, y: 0 }, { x: 0, y: 1 });
+            expect(line.direction).to.equal('south');
+        });
+        it('correctly defines line to south-west', () => {
+            const line = new PointToPointLine({ x: 1, y: 0 }, { x: 0, y: 1 });
+            expect(line.direction).to.equal('south-west');
+        });
+        it('correctly defines line to west', () => {
+            const line = new PointToPointLine({ x: 1, y: 0 }, { x: 0, y: 0 });
+            expect(line.direction).to.equal('west');
+        });
+        it('correctly defines line to north-west', () => {
+            const line = new PointToPointLine({ x: 1, y: 1 }, { x: 0, y: 0 });
+            expect(line.direction).to.equal('north-west');
         });
     });
 });

--- a/packages/sprotty/src/utils/geometry.ts
+++ b/packages/sprotty/src/utils/geometry.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 TypeFox and others.
+ * Copyright (c) 2017-2022 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -388,7 +388,7 @@ export function linear(p0: Point, p1: Point, lambda: number): Point {
 
 /**
  * A diamond or rhombus is a quadrilateral whose four sides all have the same length.
- * It consinsts of four points, a `topPoint`, `rightPoint`, `bottomPoint`, and a `leftPoint`,
+ * It consists of four points, a `topPoint`, `rightPoint`, `bottomPoint`, and a `leftPoint`,
  * which are connected by four lines -- the `topRightSideLight`, `topLeftSideLine`, `bottomRightSideLine`,
  * and the `bottomLeftSideLine`.
  */
@@ -472,6 +472,10 @@ export interface Line {
     readonly c: number
 }
 
+export type CardinalDirection =
+    'north' | 'north-east' | 'east' | 'south-east' |
+    'south' | 'south-west' | 'west' | 'north-west';
+
 /**
  * A line made up from two points.
  */
@@ -515,6 +519,33 @@ export class PointToPointLine implements Line {
             return Number.MAX_SAFE_INTEGER;
         }
         return this.slope;
+    }
+
+    /**
+     * The direction of this line, such as 'north', 'south', or 'south-west'.
+     */
+    get direction(): CardinalDirection {
+        const hDegrees = toDegrees(this.angle);
+        const degrees = hDegrees < 0 ? 360 + hDegrees : hDegrees;
+        // degrees are relative to the x-axis
+        if (degrees === 90) {
+            return 'south';
+        } else if (degrees === 0 || degrees === 360) {
+            return 'east';
+        } else if (degrees === 270) {
+            return 'north';
+        } else if (degrees === 180) {
+            return 'west';
+        } else if (degrees > 0 && degrees < 90) {
+            return 'south-east';
+        } else if (degrees > 90 && degrees < 180) {
+            return 'south-west';
+        } else if (degrees > 180 && degrees < 270) {
+            return 'north-west';
+        } else if (degrees > 270 && degrees < 360) {
+            return 'north-east';
+        }
+        throw new Error(`Cannot determine direction of line (${this.p1.x},${this.p1.y}) to (${this.p2.x},${this.p2.y})`);
     }
 
     /**


### PR DESCRIPTION
Also...
  * Fixes launch config for running single tests
  * Adds line gaps to random-graph example for testing
  * Mention that intersection finder only works for straight segments (#287)

### How to test
I've added line gaps to the random-graph example to simplify verifying whether all intersections are correctly marked.
So I suggest to use that for verifying whether it works now:

https://user-images.githubusercontent.com/588090/167085594-6e062fff-fb10-4d0f-aefd-90e63606f41a.mp4

Fixes #277

Change-Id: I3c72de91188e32fcb296ef81f27c6b03e18c8bd0
Signed-off-by: Philip Langer <planger@eclipsesource.com>