### PR TITLE
Use more strict inversify version

### DIFF
--- a/packages/sprotty-elk/package.json
+++ b/packages/sprotty-elk/package.json
@@ -42,7 +42,7 @@
     "sprotty-protocol": "~0.11.0"
   },
   "optionalDependencies": {
-    "inversify": "^5.0.1"
+    "inversify": "^5.1.1"
   },
   "devDependencies": {
     "@types/chai": "^4.2.22",

--- a/packages/sprotty/package.json
+++ b/packages/sprotty/package.json
@@ -55,7 +55,7 @@
     "@vscode/codicons": "^0.0.25",
     "autocompleter": "^5.1.0",
     "file-saver": "^2.0.2",
-    "inversify": "^5.0.1",
+    "inversify": "^5.1.1",
     "snabbdom": "^3.0.3",
     "sprotty-protocol": "~0.11.0",
     "tinyqueue": "^2.0.3"


### PR DESCRIPTION
Using ^5.0.1 currently pulls 5.1.1 wich is not compatible with 5.0.1 pulled by the downstream projects. Affect e.g. sprotty-vscode, sprotty-elk