### PR TITLE
Rework ButtonHandler registration

### DIFF
--- a/packages/sprotty/src/base/types.ts
+++ b/packages/sprotty/src/base/types.ts
@@ -24,7 +24,7 @@ export const TYPES = {
     ActionHandlerRegistryProvider: Symbol('ActionHandlerRegistryProvider'),
     IAnchorComputer: Symbol('IAnchor'),
     AnimationFrameSyncer: Symbol('AnimationFrameSyncer'),
-    IButtonHandler: Symbol('IButtonHandler'),
+    IButtonHandlerRegistration: Symbol('IButtonHandlerRegistration'),
     ICommandPaletteActionProvider: Symbol('ICommandPaletteActionProvider'),
     ICommandPaletteActionProviderRegistry: Symbol('ICommandPaletteActionProviderRegistry'),
     CommandRegistration: Symbol('CommandRegistration'),

--- a/packages/sprotty/src/base/types.ts
+++ b/packages/sprotty/src/base/types.ts
@@ -24,6 +24,8 @@ export const TYPES = {
     ActionHandlerRegistryProvider: Symbol('ActionHandlerRegistryProvider'),
     IAnchorComputer: Symbol('IAnchor'),
     AnimationFrameSyncer: Symbol('AnimationFrameSyncer'),
+    /** @deprecated deprecated since 0.12.0 - please use `configureButtonHandler` */
+    IButtonHandler: Symbol('IButtonHandler'),
     IButtonHandlerRegistration: Symbol('IButtonHandlerRegistration'),
     ICommandPaletteActionProvider: Symbol('ICommandPaletteActionProvider'),
     ICommandPaletteActionProviderRegistry: Symbol('ICommandPaletteActionProviderRegistry'),

--- a/packages/sprotty/src/features/button/button-handler.ts
+++ b/packages/sprotty/src/features/button/button-handler.ts
@@ -25,6 +25,12 @@ export interface IButtonHandler {
     buttonPressed(button: SButton): Action[]
 }
 
+/** @deprecated deprecated since 0.12.0 - please use `configureButtonHandler` */
+export interface IButtonHandlerFactory {
+    TYPE: string
+    new(): IButtonHandler
+}
+
 export interface IButtonHandlerRegistration {
     TYPE: string
     factory: () => IButtonHandler
@@ -33,9 +39,14 @@ export interface IButtonHandlerRegistration {
 @injectable()
 export class ButtonHandlerRegistry extends InstanceRegistry<IButtonHandler> {
 
-    constructor(@multiInject(TYPES.IButtonHandlerRegistration)@optional() buttonHandlerFactories: IButtonHandlerRegistration[]) {
+    constructor(
+        @multiInject(TYPES.IButtonHandlerRegistration)@optional() buttonHandlerRegistrations: IButtonHandlerRegistration[],
+        // deprecated, but keep support for now
+        @multiInject(TYPES.IButtonHandler)@optional() buttonHandlerFactories: IButtonHandlerFactory[]) {
         super();
-        buttonHandlerFactories.forEach(factory => this.register(factory.TYPE, factory.factory()));
+        buttonHandlerRegistrations.forEach(factory => this.register(factory.TYPE, factory.factory()));
+        // deprecated, but keep support for now
+        buttonHandlerFactories.forEach(factory => this.register(factory.TYPE, new factory()));
     }
 }
 

--- a/packages/sprotty/src/features/expand/di.config.ts
+++ b/packages/sprotty/src/features/expand/di.config.ts
@@ -15,11 +15,11 @@
  ********************************************************************************/
 
 import { ContainerModule } from "inversify";
-import { TYPES } from "../../base/types";
+import { configureButtonHandler } from "../button/button-handler";
 import { ExpandButtonHandler } from "./expand";
 
-const expandModule = new ContainerModule(bind => {
-    bind(TYPES.IButtonHandler).toConstructor(ExpandButtonHandler);
+const expandModule = new ContainerModule((bind, _unbind, isBound) => {
+    configureButtonHandler({bind, isBound}, ExpandButtonHandler.TYPE, ExpandButtonHandler);
 });
 
 export default expandModule;


### PR DESCRIPTION
With the current bindings it is not possible to inject into a ButtonHandler.
The registry now recieves a factory instead of a constructor.
Also provide helper method to bin new ButtonHandlers.

Resolves #300

Contributed on behalf of STMicroelectronics