### PR TITLE
Use service binding for all Mouse and KeyListeners

### DIFF
--- a/examples/classdiagram/src/di.config.ts
+++ b/examples/classdiagram/src/di.config.ts
@@ -46,7 +46,8 @@ export default (containerId: string) => {
         bind(TYPES.ISnapper).to(CenterGridSnapper);
         bind(TYPES.IEditLabelValidator).to(ClassDiagramLabelValidator);
         bind(TYPES.IEditLabelValidationDecorator).to(ClassDiagramLabelValidationDecorator);
-        bind(TYPES.MouseListener).to(BezierMouseListener);
+        bind(BezierMouseListener).toSelf().inSingletonScope();
+        bind(TYPES.MouseListener).toService(BezierMouseListener);
 
         const context = { bind, unbind, isBound, rebind };
         configureModelElement(context, 'graph', SGraph, SGraphView);

--- a/packages/sprotty/src/base/di.config.ts
+++ b/packages/sprotty/src/base/di.config.ts
@@ -160,7 +160,8 @@ const defaultContainerModule = new ContainerModule((bind, _unbind, isBound) => {
 
     // Tool manager initialization ------------------------------------
     bind(TYPES.IToolManager).to(ToolManager).inSingletonScope();
-    bind(TYPES.KeyListener).to(DefaultToolsEnablingKeyListener);
+    bind(DefaultToolsEnablingKeyListener).toSelf().inSingletonScope();
+    bind(TYPES.KeyListener).toService(DefaultToolsEnablingKeyListener);
     bind(ToolManagerActionHandler).toSelf().inSingletonScope();
     configureActionHandler(context, EnableDefaultToolsAction.KIND, ToolManagerActionHandler);
     configureActionHandler(context, EnableToolsAction.KIND, ToolManagerActionHandler);

--- a/packages/sprotty/src/features/command-palette/di.config.ts
+++ b/packages/sprotty/src/features/command-palette/di.config.ts
@@ -22,7 +22,8 @@ import { CommandPalette, CommandPaletteKeyListener } from "./command-palette";
 const commandPaletteModule = new ContainerModule((bind) => {
     bind(CommandPalette).toSelf().inSingletonScope();
     bind(TYPES.IUIExtension).toService(CommandPalette);
-    bind(TYPES.KeyListener).to(CommandPaletteKeyListener);
+    bind(CommandPaletteKeyListener).toSelf().inSingletonScope();
+    bind(TYPES.KeyListener).toService(CommandPaletteKeyListener);
     bind(CommandPaletteActionProviderRegistry).toSelf().inSingletonScope();
     bind(TYPES.ICommandPaletteActionProviderRegistry).toService(CommandPaletteActionProviderRegistry);
 });

--- a/packages/sprotty/src/features/context-menu/di.config.ts
+++ b/packages/sprotty/src/features/context-menu/di.config.ts
@@ -32,7 +32,8 @@ const contextMenuModule = new ContainerModule(bind => {
             });
         };
     });
-    bind(TYPES.MouseListener).to(ContextMenuMouseListener);
+    bind(ContextMenuMouseListener).toSelf().inSingletonScope();
+    bind(TYPES.MouseListener).toService(ContextMenuMouseListener);
     bind(TYPES.IContextMenuProviderRegistry).to(ContextMenuProviderRegistry);
 });
 

--- a/packages/sprotty/src/features/edit/di.config.ts
+++ b/packages/sprotty/src/features/edit/di.config.ts
@@ -36,8 +36,10 @@ export const edgeEditModule = new ContainerModule((bind, _unbind, isBound) => {
 });
 
 export const labelEditModule = new ContainerModule((bind, _unbind, isBound) => {
-    bind(TYPES.MouseListener).to(EditLabelMouseListener);
-    bind(TYPES.KeyListener).to(EditLabelKeyListener);
+    bind(EditLabelMouseListener).toSelf().inSingletonScope();
+    bind(TYPES.MouseListener).toService(EditLabelMouseListener);
+    bind(EditLabelKeyListener).toSelf().inSingletonScope();
+    bind(TYPES.KeyListener).toService(EditLabelKeyListener);
     configureCommand({ bind, isBound }, ApplyLabelEditCommand);
 });
 

--- a/packages/sprotty/src/features/export/di.config.ts
+++ b/packages/sprotty/src/features/export/di.config.ts
@@ -21,7 +21,8 @@ import { SvgExporter } from './svg-exporter';
 import { configureCommand } from "../../base/commands/command-registration";
 
 const exportSvgModule = new ContainerModule((bind, _unbind, isBound) => {
-    bind(TYPES.KeyListener).to(ExportSvgKeyListener).inSingletonScope();
+    bind(ExportSvgKeyListener).toSelf().inSingletonScope();
+    bind(TYPES.KeyListener).toService(ExportSvgKeyListener);
     bind(TYPES.HiddenVNodePostprocessor).to(ExportSvgPostprocessor).inSingletonScope();
     configureCommand({ bind, isBound }, ExportSvgCommand);
     bind(TYPES.SvgExporter).to(SvgExporter).inSingletonScope();

--- a/packages/sprotty/src/features/hover/di.config.ts
+++ b/packages/sprotty/src/features/hover/di.config.ts
@@ -29,9 +29,12 @@ import { MoveCommand } from "../move/move";
 
 const hoverModule = new ContainerModule((bind, _unbind, isBound) => {
     bind(TYPES.PopupVNodePostprocessor).to(PopupPositionUpdater).inSingletonScope();
-    bind(TYPES.MouseListener).to(HoverMouseListener);
-    bind(TYPES.PopupMouseListener).to(PopupHoverMouseListener);
-    bind(TYPES.KeyListener).to(HoverKeyListener);
+    bind(HoverMouseListener).toSelf().inSingletonScope();
+    bind(TYPES.MouseListener).toService(HoverMouseListener);
+    bind(PopupHoverMouseListener).toSelf().inSingletonScope();
+    bind(TYPES.PopupMouseListener).toService(PopupHoverMouseListener);
+    bind(HoverKeyListener).toSelf().inSingletonScope();
+    bind(TYPES.KeyListener).toService(HoverKeyListener);
     bind<HoverState>(TYPES.HoverState).toConstantValue({
         mouseOverTimer: undefined,
         mouseOutTimer: undefined,

--- a/packages/sprotty/src/features/move/di.config.ts
+++ b/packages/sprotty/src/features/move/di.config.ts
@@ -20,7 +20,8 @@ import { MoveCommand, MoveMouseListener, LocationPostprocessor } from './move';
 import { configureCommand } from "../../base/commands/command-registration";
 
 const moveModule = new ContainerModule((bind, _unbind, isBound) => {
-    bind(TYPES.MouseListener).to(MoveMouseListener);
+    bind(MoveMouseListener).toSelf().inSingletonScope();
+    bind(TYPES.MouseListener).toService(MoveMouseListener);
     configureCommand({ bind, isBound }, MoveCommand);
     bind(LocationPostprocessor).toSelf().inSingletonScope();
     bind(TYPES.IVNodePostprocessor).toService(LocationPostprocessor);

--- a/packages/sprotty/src/features/open/di.config.ts
+++ b/packages/sprotty/src/features/open/di.config.ts
@@ -19,7 +19,8 @@ import { TYPES } from "../../base/types";
 import { OpenMouseListener } from "./open";
 
 const openModule = new ContainerModule(bind => {
-    bind(TYPES.MouseListener).to(OpenMouseListener);
+    bind(OpenMouseListener).toSelf().inSingletonScope();
+    bind(TYPES.MouseListener).toService(OpenMouseListener);
 });
 
 export default openModule;

--- a/packages/sprotty/src/features/select/di.config.ts
+++ b/packages/sprotty/src/features/select/di.config.ts
@@ -23,8 +23,10 @@ const selectModule = new ContainerModule((bind, _unbind, isBound) => {
     configureCommand({ bind, isBound }, SelectCommand);
     configureCommand({ bind, isBound }, SelectAllCommand);
     configureCommand({ bind, isBound }, GetSelectionCommand);
-    bind(TYPES.KeyListener).to(SelectKeyboardListener);
-    bind(TYPES.MouseListener).to(SelectMouseListener);
+    bind(SelectKeyboardListener).toSelf().inSingletonScope();
+    bind(TYPES.KeyListener).toService(SelectKeyboardListener);
+    bind(SelectMouseListener).toSelf().inSingletonScope();
+    bind(TYPES.MouseListener).toService(SelectMouseListener);
 });
 
 export default selectModule;

--- a/packages/sprotty/src/features/undo-redo/di.config.ts
+++ b/packages/sprotty/src/features/undo-redo/di.config.ts
@@ -19,7 +19,8 @@ import { TYPES } from "../../base/types";
 import { UndoRedoKeyListener } from "./undo-redo";
 
 const undoRedoModule = new ContainerModule(bind => {
-    bind(TYPES.KeyListener).to(UndoRedoKeyListener);
+    bind(UndoRedoKeyListener).toSelf().inSingletonScope();
+    bind(TYPES.KeyListener).toService(UndoRedoKeyListener);
 });
 
 export default undoRedoModule;

--- a/packages/sprotty/src/features/viewport/di.config.ts
+++ b/packages/sprotty/src/features/viewport/di.config.ts
@@ -27,9 +27,12 @@ const viewportModule = new ContainerModule((bind , _unbind, isBound) => {
     configureCommand({ bind, isBound }, FitToScreenCommand);
     configureCommand({ bind, isBound }, SetViewportCommand);
     configureCommand({ bind, isBound }, GetViewportCommand);
-    bind(TYPES.KeyListener).to(CenterKeyboardListener);
-    bind(TYPES.MouseListener).to(ScrollMouseListener);
-    bind(TYPES.MouseListener).to(ZoomMouseListener);
+    bind(CenterKeyboardListener).toSelf().inSingletonScope();
+    bind(TYPES.KeyListener).toService(CenterKeyboardListener);
+    bind(ScrollMouseListener).toSelf().inSingletonScope();
+    bind(ZoomMouseListener).toSelf().inSingletonScope();
+    bind(TYPES.MouseListener).toService(ScrollMouseListener);
+    bind(TYPES.MouseListener).toService(ZoomMouseListener);
 });
 
 export default viewportModule;


### PR DESCRIPTION
Make it simpler to extend existing mouse and key listeners.