### PR TITLE
Makes it possible to listen to mouse drop events

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
 	"version": "0.2.0",
 	"configurations": [
         {
-            "name": "Current Test File",
+            "name": "Mocha: Test Current File",
             "type": "node",
             "request": "launch",
             "protocol": "inspector",
@@ -14,6 +14,30 @@
                 "--config",
                 "${workspaceRoot}/configs/.mocharc.json"
             ],
+            "env": {
+                "TS_NODE_PROJECT": "${workspaceRoot}/tsconfig.json"
+            },
+            "sourceMaps": true,
+            "smartStep": true,
+            "internalConsoleOptions": "openOnSessionStart",
+            "outputCapture": "std"
+        },
+        {
+            "name": "Mocha: Test All",
+            "type": "node",
+            "request": "launch",
+            "protocol": "inspector",
+            "cwd": "${workspaceRoot}",
+            "program": "${workspaceRoot}/node_modules/.bin/_mocha",
+            "args": [
+                "--recursive",
+                "--no-timeouts",
+                "--exclude",
+                "**/views/view.spec.ts",
+                "--config",
+                "${workspaceRoot}/configs/.mocharc.json"
+            ],
+            "console": "integratedTerminal",
             "env": {
                 "TS_NODE_PROJECT": "${workspaceRoot}/tsconfig.json"
             },

--- a/configs/.mocharc.json
+++ b/configs/.mocharc.json
@@ -6,5 +6,6 @@
     "extension": ["ts", "tsx"],
     "timeout": 10000,
     "reporter": "spec",
-    "colors": true
+    "colors": true,
+    "spec": ["**/*spec.ts", "**/*spec.tsx"]
 }

--- a/examples/circlegraph/circlegraph.html
+++ b/examples/circlegraph/circlegraph.html
@@ -24,16 +24,30 @@
                 <a href='https://github.com/eclipse/sprotty/wiki/Using-sprotty'>Help</a>
             </div>
         </div>
+        <div draggable="true" style="height: 70px; width: 70px;" ondragstart="dragstart(event)">
+            <svg style="height: inherit; width:inherit">
+                <g transform="translate(2, 2)">
+                    <circle class="sprotty-node" r="30" cx="30" cy="30"></circle>
+                    <text x="30" y="37" class="sprotty-text">drag</text>
+                </g>
+            </svg>
+        </div>
         <div class="row">
             <div class="col-md-12">
-                <div id="sprotty" class="sprotty"/>
+                <div id="sprotty" class="sprotty" />
             </div>
             <div class="copyright">
                 &copy; 2017 <a href="https://www.typefox.io/">TypeFox GmbH</a>.
             </div>
         </div>
-        </div>
     </div>
-<script src="../resources/bundle.js"></script>
+
+    <script type="text/javascript">
+        function dragstart(ev) {
+            ev.dataTransfer.setData("text/plain", ev.target.id);
+        }
+    </script>
+    <script src="../resources/bundle.js"></script>
 </body>
+
 </html>

--- a/examples/circlegraph/css/page.css
+++ b/examples/circlegraph/css/page.css
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
- 
+
 .copyright {
     margin-top: 10px;
     text-align: right;
@@ -28,7 +28,7 @@
     color: #888;
 }
 
-svg {
+svg.sprotty-graph {
     margin-top: 15px;
     width: 100%;
     height: 500px;

--- a/packages/sprotty/src/base/views/mouse-tool.ts
+++ b/packages/sprotty/src/base/views/mouse-tool.ts
@@ -140,6 +140,8 @@ export class MouseTool implements IVNodePostprocessor {
             on(vnode, 'wheel', this.wheel.bind(this, element));
             on(vnode, 'contextmenu', this.contextMenu.bind(this, element));
             on(vnode, 'dblclick', this.doubleClick.bind(this, element));
+            on(vnode, 'dragover', (event: MouseEvent) => this.handleEvent('dragOver', element, event));
+            on(vnode, 'drop', (event: MouseEvent) => this.handleEvent('drop', element, event));
         }
         vnode = this.mouseListeners.reduce(
             (n: VNode, listener: MouseListener) => listener.decorate(n, element),
@@ -158,7 +160,9 @@ export class PopupMouseTool extends MouseTool {
     }
 }
 
-export type MouseEventKind = 'mouseOver' | 'mouseOut' | 'mouseEnter' | 'mouseLeave' | 'mouseDown' | 'mouseMove' | 'mouseUp' | 'wheel' | 'doubleClick' | 'contextMenu';
+export type MouseEventKind =
+    'mouseOver' | 'mouseOut' | 'mouseEnter' | 'mouseLeave' | 'mouseDown' | 'mouseMove' | 'mouseUp'
+    | 'wheel' | 'doubleClick' | 'contextMenu' | 'dragOver' | 'drop';
 
 @injectable()
 export class MouseListener {
@@ -200,6 +204,14 @@ export class MouseListener {
     }
 
     contextMenu(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+        return [];
+    }
+
+    dragOver(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+        return [];
+    }
+
+    drop(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
         return [];
     }
 

--- a/packages/sprotty/src/graph/views.spec.tsx
+++ b/packages/sprotty/src/graph/views.spec.tsx
@@ -39,7 +39,7 @@ import { SEdge, SGraph, SNode, SPortSchema, SEdgeSchema, SNodeSchema } from "./s
 import graphModule from './di.config';
 import routingModule from '../features/routing/di.config';
 
-const toHTML = require('snabbdom-to-html');
+import toHTML from 'snabbdom-to-html';
 
 describe('graph views', () => {
     class CircleNodeView extends CircularNodeView {


### PR DESCRIPTION
Adds two new even types `dragover` and `drop`. 

Enhanced the Circle example to demonstrate the  drag and drop functionality.

Try it out by dragging the 'drag' circle into the Graph:
 
<img width="428" alt="Bildschirmfoto 2022-08-26 um 15 20 24" src="https://user-images.githubusercontent.com/454322/186913933-2f5fe64b-0fd1-4863-8930-98ff981b2d78.png">


Also added a new launch config to run all the tests.