### PR TITLE
Remove codicon.css, document and explain future usage

### DIFF
--- a/examples/classdiagram/src/di.config.ts
+++ b/examples/classdiagram/src/di.config.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-
+import '@vscode/codicons/dist/codicon.css';
 import { Container, ContainerModule } from "inversify";
 import {
     TYPES, configureViewerOptions, SGraphView, SLabelView, SCompartmentView, JumpingPolylineEdgeView,

--- a/examples/package.json
+++ b/examples/package.json
@@ -3,6 +3,7 @@
   "version": "0.12.0",
   "private": "true",
   "dependencies": {
+    "@vscode/codicons": "^0.0.32",
     "core-js": "^3.25.3",
     "express": "^4.18.1",
     "reflect-metadata": "^0.1.13",

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -39,16 +39,6 @@ const config = {
                 test: /\.css$/,
                 exclude: /\.useable\.css$/,
                 use: ['style-loader', 'css-loader']
-            },
-            {
-                test: /\.(ttf)$/,
-                loader: 'file-loader',
-                options: {
-                    name: '[name].[ext]',
-                    outputPath: '',
-                    publicPath: '..',
-                    postTransformPublicPath: (p) => `__webpack_public_path__ + ${p}`,
-                }
             }
         ]
     },

--- a/packages/sprotty/CHANGELOG.md
+++ b/packages/sprotty/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This change log covers only the client part of Sprotty. See also the change logs of [sprotty-server](https://github.com/eclipse/sprotty-server/blob/master/CHANGELOG.md), [sprotty-theia](https://github.com/eclipse/sprotty-theia/blob/master/CHANGELOG.md) and [sprotty-elk](https://github.com/eclipse/sprotty/blob/master//packages/sprotty-elk/CHANGELOG.md).
 
+### v0.13.0 (TBD)
+
+* Remove codicon.css, document and explain future usage [#312](https://github.com/eclipse/sprotty/pull/292/): You now have to manually add the dependency of `@vscode/codicons` to your application and reference it in your di.config, see classdiagram [di.config.ts](../../examples/classdiagram/src/di.config.ts)
+
 ### v0.12.0 (Jun. 2022)
 
 * Aligned dependency to `inversify` ([#292](https://github.com/eclipse/sprotty/pull/292/)): version constraint is now `^5.1.1` in all sprotty packages.

--- a/packages/sprotty/package.json
+++ b/packages/sprotty/package.json
@@ -52,7 +52,6 @@
     "directory": "packages/sprotty"
   },
   "dependencies": {
-    "@vscode/codicons": "^0.0.25",
     "autocompleter": "^5.1.0",
     "file-saver": "^2.0.2",
     "inversify": "^5.1.1",

--- a/packages/sprotty/src/features/command-palette/di.config.ts
+++ b/packages/sprotty/src/features/command-palette/di.config.ts
@@ -13,7 +13,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import '@vscode/codicons/dist/codicon.css';
 import { ContainerModule } from "inversify";
 import { TYPES } from "../../base/types";
 import { CommandPaletteActionProviderRegistry } from "./action-providers";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1546,10 +1546,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@vscode/codicons@^0.0.25":
-  version "0.0.25"
-  resolved "https://registry.yarnpkg.com/@vscode/codicons/-/codicons-0.0.25.tgz#4ebc3e2c9e707ac46aea0becceda79f7738c647c"
-  integrity sha512-uqPhTdADjwoCh5Ufbv0M6TZiiP2mqbfJVB4grhVx1k+YeP03LDMOHBWPsNwGKn4/0S5Mq9o1w1GeftvR031Gzg==
+"@vscode/codicons@^0.0.32":
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/@vscode/codicons/-/codicons-0.0.32.tgz#9e27de90d509c69762b073719ba3bf46c3cd2530"
+  integrity sha512-3lgSTWhAzzWN/EPURoY4ZDBEA80OPmnaknNujA3qnI4Iu7AONWd9xF3iE4L+4prIe8E3TUnLQ4pxoaFTEEZNwg==
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"


### PR DESCRIPTION
- This removes the need to have codicon as depedency to the sprotty core
- Replace rimraf wih shx along the way

This is the proposed solution for #311 