### PR TITLE
API improvements

### DIFF
--- a/packages/sprotty-protocol/src/actions.ts
+++ b/packages/sprotty-protocol/src/actions.ts
@@ -313,6 +313,28 @@ export interface ElementAndAlignment {
 }
 
 /**
+ * Transport logging data to be stored elsewhere.
+ */
+export interface LoggingAction extends Action {
+    kind: typeof LoggingAction.KIND;
+    severity: string
+    time: string
+    caller: string
+    message: string
+    params: string[]
+}
+export namespace LoggingAction {
+    export const KIND = 'logging';
+
+    export function create(options: { severity: string, time: string, caller: string, message: string, params: string[] }): LoggingAction {
+        return {
+            kind: KIND,
+            ...options
+        };
+    }
+}
+
+/**
  * Triggered when the user changes the selection, e.g. by clicking on a selectable element. The resulting
  * SelectCommand changes the `selected` state accordingly, so the elements can be rendered differently.
  * This action is also forwarded to the diagram server, if present, so it may react on the selection change.
@@ -502,6 +524,185 @@ export namespace SetViewportAction {
             elementId,
             newViewport,
             animate: options.animate ?? true
+        };
+    }
+}
+
+/**
+ * Action to render the selected elements in front of others by manipulating the z-order.
+ */
+ export interface BringToFrontAction extends Action {
+    kind: typeof BringToFrontAction.KIND;
+    elementIDs: string[]
+}
+export namespace BringToFrontAction {
+    export const KIND = 'bringToFront';
+
+    export function create(elementIDs: string[]): BringToFrontAction {
+        return {
+            kind: KIND,
+            elementIDs
+        };
+    }
+}
+
+/**
+ * Undo the previous operation on the stack of operations.
+ */
+export interface UndoAction extends Action {
+    kind: typeof UndoAction.KIND;
+}
+export namespace UndoAction {
+    export const KIND = 'undo';
+
+    export function create(): UndoAction {
+        return {
+            kind: KIND
+        };
+    }
+}
+
+/**
+ * Redo a previously undone operation.
+ */
+export interface RedoAction extends Action {
+    kind: typeof RedoAction.KIND;
+}
+export namespace RedoAction {
+    export const KIND = 'redo';
+
+    export function create(): RedoAction {
+        return {
+            kind: KIND
+        };
+    }
+}
+
+/**
+ * Move an arbitrary set of elements to new positions.
+ */
+export interface MoveAction extends Action {
+    kind: typeof MoveAction.KIND
+    moves: ElementMove[]
+    animate: boolean
+    finished: boolean
+}
+export namespace MoveAction {
+    export const KIND = 'move';
+
+    export function create(moves: ElementMove[], options: { animate?: boolean, finished?: boolean } = {}): MoveAction {
+        return {
+            kind: KIND,
+            moves,
+            animate: options.animate ?? true,
+            finished: options.finished ?? false
+        };
+    }
+}
+
+export interface ElementMove {
+    elementId: string
+    elementType?: string
+    fromPosition?: Point
+    toPosition: Point
+}
+
+/**
+ * Triggered when the user puts the mouse pointer over an element.
+ */
+export interface HoverFeedbackAction extends Action {
+    kind: typeof HoverFeedbackAction.KIND
+    mouseoverElement: string
+    mouseIsOver: boolean
+}
+export namespace HoverFeedbackAction {
+    export const KIND = 'hoverFeedback';
+
+    export function create(options: { mouseoverElement: string, mouseIsOver: boolean }): HoverFeedbackAction {
+        return {
+            kind: KIND,
+            mouseoverElement: options.mouseoverElement,
+            mouseIsOver: options.mouseIsOver
+        };
+    }
+}
+
+/**
+ * Create an element with the given schema and add it to the diagram.
+ */
+export interface CreateElementAction extends Action {
+    kind: typeof CreateElementAction.KIND
+    containerId: string
+    elementSchema: SModelElement
+}
+export namespace CreateElementAction {
+    export const KIND = 'createElement';
+
+    export function create(elementSchema: SModelElement, options: { containerId: string }): CreateElementAction {
+        return {
+            kind: KIND,
+            elementSchema,
+            containerId: options.containerId
+        };
+    }
+}
+
+/**
+ * Delete a set of elements identified by their IDs.
+ */
+export interface DeleteElementAction extends Action {
+    kind: typeof DeleteElementAction.KIND
+    elementIds: string[]
+}
+export namespace DeleteElementAction {
+    export const KIND = 'delete';
+
+    export function create(elementIds: string[]): DeleteElementAction {
+        return {
+            kind: KIND,
+            elementIds
+        };
+    }
+}
+
+/**
+ * Apply a text change to a label element.
+ */
+export interface ApplyLabelEditAction extends Action {
+    kind: typeof ApplyLabelEditAction.KIND;
+    labelId: string,
+    text: string
+}
+export namespace ApplyLabelEditAction {
+    export const KIND = 'applyLabelEdit';
+
+    export function create(labelId: string, text: string): ApplyLabelEditAction {
+        return {
+            kind: KIND,
+            labelId,
+            text
+        };
+    }
+}
+
+/**
+ * Change the source or target node of a routable element (edge of a graph).
+ */
+export interface ReconnectAction extends Action {
+    kind: typeof ReconnectAction.KIND
+    routableId: string
+    newSourceId?: string
+    newTargetId?: string
+}
+export namespace ReconnectAction {
+    export const KIND = 'reconnect';
+
+    export function create(options: { routableId: string, newSourceId?: string, newTargetId?: string }): ReconnectAction {
+        return {
+            kind: KIND,
+            routableId: options.routableId,
+            newSourceId: options.newSourceId,
+            newTargetId: options.newTargetId
         };
     }
 }

--- a/packages/sprotty/src/base/actions/action-dispatcher.ts
+++ b/packages/sprotty/src/base/actions/action-dispatcher.ts
@@ -14,17 +14,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { inject, injectable } from "inversify";
-import { Action, isAction, isRequestAction, isResponseAction, RejectAction, RequestAction, ResponseAction, SetModelAction } from "sprotty-protocol/lib/actions";
-import { Deferred } from "sprotty-protocol/lib/utils/async";
-import { TYPES } from "../types";
-import { ILogger } from "../../utils/logging";
+import { inject, injectable } from 'inversify';
+import {
+    Action, isAction, isRequestAction, isResponseAction, RedoAction, RejectAction, RequestAction,
+    ResponseAction, SetModelAction, UndoAction
+} from 'sprotty-protocol/lib/actions';
+import { Deferred } from 'sprotty-protocol/lib/utils/async';
+import { TYPES } from '../types';
+import { ILogger } from '../../utils/logging';
 import { EMPTY_ROOT } from '../model/smodel-factory';
-import { ICommandStack } from "../commands/command-stack";
-import { AnimationFrameSyncer } from "../animations/animation-frame-syncer";
-import { RedoAction, UndoAction } from "../../features/undo-redo/undo-redo";
-import { ActionHandlerRegistry } from "./action-handler";
-import { IDiagramLocker } from "./diagram-locker";
+import { ICommandStack } from '../commands/command-stack';
+import { AnimationFrameSyncer } from '../animations/animation-frame-syncer';
+import { ActionHandlerRegistry } from './action-handler';
+import { IDiagramLocker } from './diagram-locker';
 
 export interface IActionDispatcher {
     dispatch(action: Action): Promise<void>

--- a/packages/sprotty/src/features/button/button-handler.ts
+++ b/packages/sprotty/src/features/button/button-handler.ts
@@ -22,7 +22,7 @@ import { SButton } from './model';
 import { isInjectable } from '../../utils/inversify';
 
 export interface IButtonHandler {
-    buttonPressed(button: SButton): Action[]
+    buttonPressed(button: SButton): (Action | Promise<Action>)[]
 }
 
 /** @deprecated deprecated since 0.12.0 - please use `configureButtonHandler` */

--- a/packages/sprotty/src/features/context-menu/menu-providers.ts
+++ b/packages/sprotty/src/features/context-menu/menu-providers.ts
@@ -14,14 +14,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, multiInject, optional } from "inversify";
-import { Point } from "sprotty-protocol/lib/utils/geometry";
-import { MenuItem } from "./context-menu-service";
-import { SModelRoot } from "../../base/model/smodel";
-import { LabeledAction } from "../../base/actions/action";
-import { TYPES } from "../../base/types";
-import { isDeletable, DeleteElementAction } from "../edit/delete";
-import { isSelected } from "../select/model";
+import { injectable, multiInject, optional } from 'inversify';
+import { Point } from 'sprotty-protocol/lib/utils/geometry';
+import { MenuItem } from './context-menu-service';
+import { SModelRoot } from '../../base/model/smodel';
+import { LabeledAction } from '../../base/actions/action';
+import { TYPES } from '../../base/types';
+import { isDeletable } from '../edit/delete';
+import { isSelected } from '../select/model';
+import { DeleteElementAction } from 'sprotty-protocol';
 
 export interface IContextMenuItemProvider {
     getItems(root: Readonly<SModelRoot>, lastMousePosition?: Point): Promise<LabeledAction[]>;
@@ -42,7 +43,7 @@ export class ContextMenuProviderRegistry implements IContextMenuItemProvider {
         const menuItemsWithParentId = menuItems.filter(menuItem => menuItem.parentId);
         for (const menuItem of menuItemsWithParentId) {
             if (menuItem.parentId) {
-                const fragments = menuItem.parentId.split(".");
+                const fragments = menuItem.parentId.split('.');
                 let matchingParent: MenuItem | undefined = undefined;
                 let nextParents = menuItems;
                 for (const fragment of fragments) {
@@ -70,10 +71,10 @@ export class DeleteContextMenuItemProvider implements IContextMenuItemProvider {
         const selectedElements = Array.from(root.index.all().filter(isSelected).filter(isDeletable));
         return Promise.resolve([
             {
-                id: "delete",
-                label: "Delete",
-                sortString: "d",
-                group: "edit",
+                id: 'delete',
+                label: 'Delete',
+                sortString: 'd',
+                group: 'edit',
                 actions: [DeleteElementAction.create(selectedElements.map(e => e.id))],
                 isEnabled: () => selectedElements.length > 0
             }

--- a/packages/sprotty/src/features/edit/create.ts
+++ b/packages/sprotty/src/features/edit/create.ts
@@ -14,15 +14,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { inject, injectable } from "inversify";
-import { Action } from "sprotty-protocol/lib/actions";
+import { inject, injectable } from 'inversify';
+import { Action } from 'sprotty-protocol/lib/actions';
 import { SModelElement as SModelElementSchema } from 'sprotty-protocol/lib/model';
-import { Command, CommandExecutionContext, CommandReturn } from "../../base/commands/command";
-import { SParentElement, SChildElement } from "../../base/model/smodel";
-import { TYPES } from "../../base/types";
+import { Command, CommandExecutionContext, CommandReturn } from '../../base/commands/command';
+import { SParentElement, SChildElement } from '../../base/model/smodel';
+import { TYPES } from '../../base/types';
 
 /**
  * Create an element with the given schema and add it to the diagram.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
  export interface CreateElementAction extends Action {
     kind: typeof CreateElementAction.KIND
@@ -30,7 +32,7 @@ import { TYPES } from "../../base/types";
     elementSchema: SModelElementSchema
 }
 export namespace CreateElementAction {
-    export const KIND = "createElement";
+    export const KIND = 'createElement';
 
     export function create(elementSchema: SModelElementSchema, options: { containerId: string }): CreateElementAction {
         return {

--- a/packages/sprotty/src/features/edit/delete.ts
+++ b/packages/sprotty/src/features/edit/delete.ts
@@ -14,12 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { inject, injectable } from "inversify";
-import { Action } from "sprotty-protocol/lib/actions";
-import { Command, CommandExecutionContext, CommandReturn } from "../../base/commands/command";
-import { SModelElement, SParentElement, SChildElement } from "../../base/model/smodel";
-import { SModelExtension } from "../../base/model/smodel-extension";
-import { TYPES } from "../../base/types";
+import { inject, injectable } from 'inversify';
+import { Action } from 'sprotty-protocol/lib/actions';
+import { Command, CommandExecutionContext, CommandReturn } from '../../base/commands/command';
+import { SModelElement, SParentElement, SChildElement } from '../../base/model/smodel';
+import { SModelExtension } from '../../base/model/smodel-extension';
+import { TYPES } from '../../base/types';
 
 export const deletableFeature = Symbol('deletableFeature');
 
@@ -32,6 +32,8 @@ export function isDeletable<T extends SModelElement>(element: T): element is T &
 
 /**
  * Delete a set of elements identified by their IDs.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
  export interface DeleteElementAction extends Action {
     kind: typeof DeleteElementAction.KIND

--- a/packages/sprotty/src/features/edit/edit-label-ui.ts
+++ b/packages/sprotty/src/features/edit/edit-label-ui.ts
@@ -13,25 +13,24 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { inject, injectable, optional } from "inversify";
-import { Action } from "sprotty-protocol/lib/actions";
-import { IActionDispatcherProvider } from "../../base/actions/action-dispatcher";
-import { IActionHandler } from "../../base/actions/action-handler";
-import { ICommand } from "../../base/commands/command";
-import { SModelElement, SModelRoot } from "../../base/model/smodel";
-import { TYPES } from "../../base/types";
-import { AbstractUIExtension } from "../../base/ui-extensions/ui-extension";
-import { SetUIExtensionVisibilityAction } from "../../base/ui-extensions/ui-extension-registry";
-import { DOMHelper } from "../../base/views/dom-helper";
-import { ViewerOptions } from "../../base/views/viewer-options";
-import { CommitModelAction } from "../../model-source/commit-model";
-import { matchesKeystroke, KeyCode, KeyboardModifier } from "../../utils/keyboard";
-import { getAbsoluteClientBounds } from "../bounds/model";
-import { getZoom } from "../viewport/zoom";
-import {
-    ApplyLabelEditAction, EditLabelValidationResult, IEditLabelValidator, isEditLabelAction, Severity
-} from "./edit-label";
-import { EditableLabel, isEditableLabel } from "./model";
+
+import { inject, injectable, optional } from 'inversify';
+import { Action, ApplyLabelEditAction } from 'sprotty-protocol/lib/actions';
+import { IActionDispatcherProvider } from '../../base/actions/action-dispatcher';
+import { IActionHandler } from '../../base/actions/action-handler';
+import { ICommand } from '../../base/commands/command';
+import { SModelElement, SModelRoot } from '../../base/model/smodel';
+import { TYPES } from '../../base/types';
+import { AbstractUIExtension } from '../../base/ui-extensions/ui-extension';
+import { SetUIExtensionVisibilityAction } from '../../base/ui-extensions/ui-extension-registry';
+import { DOMHelper } from '../../base/views/dom-helper';
+import { ViewerOptions } from '../../base/views/viewer-options';
+import { CommitModelAction } from '../../model-source/commit-model';
+import { matchesKeystroke, KeyCode, KeyboardModifier } from '../../utils/keyboard';
+import { getAbsoluteClientBounds } from '../bounds/model';
+import { getZoom } from '../viewport/zoom';
+import { EditLabelValidationResult, IEditLabelValidator, isEditLabelAction, Severity } from './edit-label';
+import { EditableLabel, isEditableLabel } from './model';
 
 /** Shows a UI extension for editing a label on emitted `EditLabelAction`s. */
 @injectable()
@@ -50,7 +49,7 @@ export interface IEditLabelValidationDecorator {
 
 @injectable()
 export class EditLabelUI extends AbstractUIExtension {
-    static readonly ID = "editLabelUi";
+    static readonly ID = 'editLabelUi';
 
     @inject(TYPES.IActionDispatcherProvider) public actionDispatcherProvider: IActionDispatcherProvider;
     @inject(TYPES.ViewerOptions) protected viewerOptions: ViewerOptions;
@@ -70,7 +69,7 @@ export class EditLabelUI extends AbstractUIExtension {
     protected previousLabelContent?: string;
 
     public id() { return EditLabelUI.ID; }
-    public containerClass() { return "label-edit"; }
+    public containerClass() { return 'label-edit'; }
 
     protected get labelId() { return this.label ? this.label.id : 'unknown'; }
 

--- a/packages/sprotty/src/features/edit/edit-label.ts
+++ b/packages/sprotty/src/features/edit/edit-label.ts
@@ -14,17 +14,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { inject } from "inversify";
-import { Action, isAction } from "sprotty-protocol/lib/actions";
-import { CommandExecutionContext, CommandReturn, Command } from "../../base/commands/command";
-import { SModelElement } from "../../base/model/smodel";
-import { TYPES } from "../../base/types";
-import { MouseListener } from "../../base/views/mouse-tool";
-import { KeyListener } from "../../base/views/key-tool";
-import { matchesKeystroke } from "../../utils/keyboard";
-import { isSelectable } from "../select/model";
-import { toArray } from "../../utils/iterable";
-import { EditableLabel, isEditableLabel, isWithEditableLabel } from "./model";
+import { inject } from 'inversify';
+import { Action, isAction } from 'sprotty-protocol/lib/actions';
+import { CommandExecutionContext, CommandReturn, Command } from '../../base/commands/command';
+import { SModelElement } from '../../base/model/smodel';
+import { TYPES } from '../../base/types';
+import { MouseListener } from '../../base/views/mouse-tool';
+import { KeyListener } from '../../base/views/key-tool';
+import { matchesKeystroke } from '../../utils/keyboard';
+import { isSelectable } from '../select/model';
+import { toArray } from '../../utils/iterable';
+import { EditableLabel, isEditableLabel, isWithEditableLabel } from './model';
 
 export interface EditLabelAction extends Action {
     kind: typeof EditLabelAction.KIND
@@ -45,6 +45,9 @@ export function isEditLabelAction(element?: any): element is EditLabelAction {
     return isAction(element) && element.kind === EditLabelAction.KIND && 'labelId' in element;
 }
 
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
 export interface ApplyLabelEditAction extends Action {
     kind: typeof ApplyLabelEditAction.KIND;
     labelId: string,

--- a/packages/sprotty/src/features/edit/reconnect.ts
+++ b/packages/sprotty/src/features/edit/reconnect.ts
@@ -14,13 +14,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { inject, injectable } from "inversify";
-import { Action } from "sprotty-protocol/lib/actions";
-import { Command, CommandExecutionContext, CommandReturn } from "../../base/commands/command";
-import { TYPES } from "../../base/types";
-import { SRoutableElement } from "../routing/model";
-import { EdgeMemento, EdgeRouterRegistry } from "../routing/routing";
+import { inject, injectable } from 'inversify';
+import { Action } from 'sprotty-protocol/lib/actions';
+import { Command, CommandExecutionContext, CommandReturn } from '../../base/commands/command';
+import { TYPES } from '../../base/types';
+import { SRoutableElement } from '../routing/model';
+import { EdgeMemento, EdgeRouterRegistry } from '../routing/routing';
 
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
 export interface ReconnectAction extends Action {
     kind: typeof ReconnectAction.KIND
     routableId: string

--- a/packages/sprotty/src/features/hover/hover.ts
+++ b/packages/sprotty/src/features/hover/hover.ts
@@ -37,6 +37,8 @@ import { hasPopupFeature, isHoverable } from "./model";
 
 /**
  * Triggered when the user puts the mouse pointer over an element.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export interface HoverFeedbackAction extends Action {
     kind: typeof HoverFeedbackAction.KIND

--- a/packages/sprotty/src/features/undo-redo/undo-redo.ts
+++ b/packages/sprotty/src/features/undo-redo/undo-redo.ts
@@ -14,12 +14,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Action } from "sprotty-protocol/lib/actions";
-import { matchesKeystroke } from "../../utils/keyboard";
-import { KeyListener } from "../../base/views/key-tool";
-import { SModelElement } from "../../base/model/smodel";
-import { isMac } from "../../utils/browser";
+import { Action } from 'sprotty-protocol/lib/actions';
+import { matchesKeystroke } from '../../utils/keyboard';
+import { KeyListener } from '../../base/views/key-tool';
+import { SModelElement } from '../../base/model/smodel';
+import { isMac } from '../../utils/browser';
 
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
 export interface UndoAction extends Action {
     kind: typeof UndoAction.KIND;
 }
@@ -33,6 +36,9 @@ export namespace UndoAction {
     }
 }
 
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
 export interface RedoAction extends Action {
     kind: typeof RedoAction.KIND;
 }

--- a/packages/sprotty/src/features/zorder/zorder.ts
+++ b/packages/sprotty/src/features/zorder/zorder.ts
@@ -14,15 +14,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject } from "inversify";
-import { Action } from "sprotty-protocol/lib/actions";
-import { TYPES } from "../../base/types";
+import { injectable, inject } from 'inversify';
+import { Action } from 'sprotty-protocol/lib/actions';
+import { TYPES } from '../../base/types';
 import { SModelRoot, SChildElement, SModelElement, SParentElement } from '../../base/model/smodel';
-import { Command, CommandExecutionContext } from "../../base/commands/command";
-import { SRoutableElement, SConnectableElement } from "../routing/model";
+import { Command, CommandExecutionContext } from '../../base/commands/command';
+import { SRoutableElement, SConnectableElement } from '../routing/model';
 
 /**
  * Action to render the selected elements in front of others by manipulating the z-order.
+ *
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
  */
 export interface BringToFrontAction extends Action {
     kind: typeof BringToFrontAction.KIND;

--- a/packages/sprotty/src/model-source/logging.ts
+++ b/packages/sprotty/src/model-source/logging.ts
@@ -14,12 +14,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject } from "inversify";
-import { Action } from "sprotty-protocol/lib/actions";
-import { ILogger, LogLevel } from "../utils/logging";
-import { TYPES } from "../base/types";
-import { ModelSource } from "./model-source";
+import { injectable, inject } from 'inversify';
+import { Action } from 'sprotty-protocol/lib/actions';
+import { ILogger, LogLevel } from '../utils/logging';
+import { TYPES } from '../base/types';
+import { ModelSource } from './model-source';
 
+/**
+ * @deprecated Use the declaration from `sprotty-protocol` instead.
+ */
 export interface LoggingAction extends Action {
     kind: typeof LoggingAction.KIND;
     severity: string


### PR DESCRIPTION
### Made SelectMouseListener and MoveMouseListener more extensible

I extracted lots of functionality to protected methods to structure the code better and to enable fine-grained customization. Those two mouse listeners carry a lot of the interaction logic, which is not optimal.

### Moved several more actions to sprotty-protocol

Moving the action definitions to the sprotty-protocol package enables accessing them in Node.js based servers.