### PR TITLE
Small optional type fix in circlegraph example

### DIFF
--- a/examples/circlegraph/src/standalone.ts
+++ b/examples/circlegraph/src/standalone.ts
@@ -61,7 +61,7 @@ export default async function runCircleGraph() {
         };
     }
 
-    const container = createContainer((point: Point) => {
+    const container = createContainer((point?: Point) => {
         createNode(point);
     });
     const dispatcher = container.get<IActionDispatcher>(TYPES.IActionDispatcher);


### PR DESCRIPTION
At this point, the point argument must be optional because the `createContainer` function requires it, and the `addNode` event handler actually calls this function later without arguments.