### PR TITLE
Avoid sending label edit action if there is no change

### DIFF
--- a/packages/sprotty/src/features/edit/edit-label-ui.ts
+++ b/packages/sprotty/src/features/edit/edit-label-ui.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2020 EclipseSource and others.
+ * Copyright (c) 2019-2022 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -121,6 +121,11 @@ export class EditLabelUI extends AbstractUIExtension {
 
     protected async applyLabelEdit() {
         if (!this.isActive) {
+            return;
+        }
+        if (this.label?.text === this.editControl.value) {
+            // no action necessary
+            this.hide();
             return;
         }
         if (this.blockApplyEditOnInvalidInput) {


### PR DESCRIPTION
This problem was observed in [GLSP](https://github.com/eclipse-glsp/glsp/issues/766) as sending an "empty" operation still makes the editor dirty due to a command being on the command stack.