### PR TITLE
Fixed edge layout when there are no routing points yet

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,9 @@
 ports:
   - port: 8080
+    name: Examples Server
+  - port: 5008
+    name: ELK Server
+    onOpen: ignore
 
 tasks:
   - init: |

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,6 @@
             "name": "Mocha: Test Current File",
             "type": "node",
             "request": "launch",
-            "protocol": "inspector",
             "cwd": "${workspaceRoot}",
             "program": "${workspaceRoot}/node_modules/.bin/_mocha",
             "args": [
@@ -26,7 +25,6 @@
             "name": "Mocha: Test All",
             "type": "node",
             "request": "launch",
-            "protocol": "inspector",
             "cwd": "${workspaceRoot}",
             "program": "${workspaceRoot}/node_modules/.bin/_mocha",
             "args": [
@@ -48,7 +46,7 @@
         },
         {
             "name": "Examples Server",
-            "type": "pwa-node",
+            "type": "node",
             "request": "launch",
             "runtimeExecutable": "node",
             "runtimeArgs": [

--- a/packages/sprotty-elk/src/node/layout-data.ts
+++ b/packages/sprotty-elk/src/node/layout-data.ts
@@ -115,23 +115,32 @@ function applyShapeLayout(dataElem: ShapeLayoutElement, shape: ElkShape): void {
 }
 
 function applyEdgeLayout(dataElem: EdgeLayoutElement, edge: ElkExtendedEdge): void {
+    const { route } = dataElem;
     if (edge.sections && edge.sections.length > 0) {
         const section = edge.sections[0];
-        if (dataElem.route.length >= 1) {
-            section.startPoint = dataElem.route[0];
+        if (route.length >= 1) {
+            section.startPoint = route[0];
         }
-        section.bendPoints = dataElem.route.slice(1, -1);
-        if (dataElem.route.length >= 2) {
-            section.endPoint = dataElem.route[dataElem.route.length - 1];
+        section.bendPoints = route.slice(1, -1);
+        if (route.length >= 2) {
+            section.endPoint = route[route.length - 1];
         }
     } else if (isPrimitiveEdge(edge)) {
-        if (dataElem.route.length >= 1) {
-            edge.sourcePoint = dataElem.route[0];
+        if (route.length >= 1) {
+            edge.sourcePoint = route[0];
         }
-        edge.bendPoints = dataElem.route.slice(1, -1);
-        if (dataElem.route.length >= 2) {
-            edge.targetPoint = dataElem.route[dataElem.route.length - 1];
+        edge.bendPoints = route.slice(1, -1);
+        if (route.length >= 2) {
+            edge.targetPoint = route[route.length - 1];
         }
+    } else {
+        // No layout present yet: create a new section
+        edge.sections = [{
+            id: `${edge.id}:layout`,
+            startPoint: route[0],
+            bendPoints: route.slice(1, -1),
+            endPoint: route[route.length - 1]
+        }];
     }
 }
 

--- a/packages/sprotty-elk/src/node/stdio-server.ts
+++ b/packages/sprotty-elk/src/node/stdio-server.ts
@@ -84,7 +84,7 @@ export class StdioElkServer implements ELK {
                             // The layout server responded an error
                             reject(response);
                         } else {
-                            applyLayoutData(response, graph);
+                            this.applyLayout(response, graph);
                             resolve(graph);
                         }
                     } catch (err) {
@@ -94,6 +94,10 @@ export class StdioElkServer implements ELK {
             };
             process.stdout.on('data', dataCallback);
         });
+    }
+
+    protected applyLayout(data: LayoutData, graph: ElkNode) {
+        applyLayoutData(data, graph);
     }
 
     protected createProcess(): Promise<ChildProcess> {


### PR DESCRIPTION
When the ELK server is invoked with a graph that does not have any layout information, the edge routes were not applied. This PR fixes that bug.