### PR TITLE
Edge label positioning

### DIFF
--- a/packages/sprotty-elk/src/elk-layout.spec.ts
+++ b/packages/sprotty-elk/src/elk-layout.spec.ts
@@ -18,8 +18,54 @@ import 'reflect-metadata';
 import { expect, describe, it } from 'vitest';
 import { Container } from 'inversify';
 import ElkConstructor from 'elkjs/lib/elk.bundled';
-import { SCompartment, SEdge, SGraph, SNode, SPort } from 'sprotty-protocol/lib/model';
-import { ElkFactory, ElkLayoutEngine, ILayoutPreprocessor, elkLayoutModule } from './inversify';
+import { LayoutOptions } from 'elkjs/lib/elk-api';
+import { SCompartment, SEdge, SGraph, SLabel, SNode, SPort } from 'sprotty-protocol/lib/model';
+import { Point } from 'sprotty-protocol/lib/utils/geometry';
+import { DefaultLayoutConfigurator, ElkFactory, ElkLayoutEngine, ILayoutConfigurator, ILayoutPreprocessor, elkLayoutModule } from './inversify';
+
+/**
+ * A layout configurator that enables cross-hierarchy edge routing, so an edge can connect a
+ * deeply-nested node to a node inside another container. Used by the nested-nodes test below.
+ */
+class NestedLayoutConfigurator extends DefaultLayoutConfigurator {
+    protected override graphOptions(): LayoutOptions {
+        return {
+            'org.eclipse.elk.algorithm': 'org.eclipse.elk.layered',
+            'org.eclipse.elk.direction': 'RIGHT',
+            'org.eclipse.elk.hierarchyHandling': 'INCLUDE_CHILDREN',
+            'org.eclipse.elk.spacing.nodeNode': '80',
+            'org.eclipse.elk.spacing.edgeNode': '20'
+        };
+    }
+    protected override nodeOptions(): LayoutOptions {
+        return {
+            'org.eclipse.elk.nodeSize.constraints': 'NODE_LABELS MINIMUM_SIZE',
+            'org.eclipse.elk.nodeSize.minimum': '(40, 40)',
+            'org.eclipse.elk.nodeLabels.placement': 'INSIDE H_CENTER V_TOP',
+            'org.eclipse.elk.padding': '[top=30,left=25,bottom=25,right=25]'
+        };
+    }
+}
+
+/** x of the point half-way along the polyline (by arc length) — i.e. `pointAt(0.5)`. */
+function arcLengthMidpointX(points: Point[]): number {
+    const seg: number[] = [];
+    let total = 0;
+    for (let i = 1; i < points.length; i++) {
+        const d = Math.hypot(points[i].x - points[i - 1].x, points[i].y - points[i - 1].y);
+        seg.push(d);
+        total += d;
+    }
+    let target = total / 2;
+    for (let i = 0; i < seg.length; i++) {
+        if (target <= seg[i]) {
+            const t = seg[i] === 0 ? 0 : target / seg[i];
+            return points[i].x + t * (points[i + 1].x - points[i].x);
+        }
+        target -= seg[i];
+    }
+    return points[points.length - 1].x;
+}
 
 describe('ElkLayoutEngine', () => {
     function createContainer() {
@@ -173,6 +219,129 @@ describe('ElkLayoutEngine', () => {
                 }
             ]
         });
+    });
+
+    it('assigns an absolute position to an edge label (issue #514)', async () => {
+        // Reproduces the minimal scenario from https://github.com/eclipse-sprotty/sprotty/issues/514:
+        // two nodes with ports, one edge, and a `label:edge` child with no `edgePlacement`.
+        // ELK is responsible for positioning that label; the engine-agnostic fix in
+        // EdgeLayoutPostprocessor only kicks in when the label carries such a non-origin position.
+        const graph: SGraph = {
+            type: 'graph',
+            id: 'graph',
+            children: [
+                <SNode> {
+                    type: 'node',
+                    id: 'node0',
+                    size: { width: 30, height: 30 },
+                    children: [
+                        <SPort> { type: 'port', id: 'port0', size: { width: 8, height: 8 } }
+                    ]
+                },
+                <SNode> {
+                    type: 'node',
+                    id: 'node1',
+                    size: { width: 30, height: 30 },
+                    children: [
+                        <SPort> { type: 'port', id: 'port1', size: { width: 8, height: 8 } }
+                    ]
+                },
+                <SEdge> {
+                    type: 'edge',
+                    id: 'edge0',
+                    sourceId: 'port0',
+                    targetId: 'port1',
+                    children: [
+                        <SLabel> {
+                            type: 'label:edge',
+                            id: 'edge0_label',
+                            text: 'port0-->port1',
+                            size: { width: 40, height: 12 }
+                        }
+                    ]
+                }
+            ]
+        };
+
+        const container = createContainer();
+        const elkEngine = container.get(ElkLayoutEngine);
+        const result = await elkEngine.layout(graph);
+
+        const edge = (result as SGraph).children.find(c => c.id === 'edge0') as SEdge;
+        const label = edge.children!.find(c => c.id === 'edge0_label') as SLabel;
+
+        // ELK must give the label a real, absolute position (not the origin sentinel).
+        // This is precisely the trigger that makes the postprocessor honor the engine position.
+        expect(label.position).to.not.be.undefined;
+        expect(label.position!.x !== 0 || label.position!.y !== 0).to.equal(true);
+        expect(Number.isFinite(label.position!.x)).to.equal(true);
+        expect(Number.isFinite(label.position!.y)).to.equal(true);
+    });
+
+    it('places a nested edge label in the free space between the outer nodes, not at the edge midpoint (issue #514)', async () => {
+        // Reproduces the nested-nodes facet (issue #514, first/second images):
+        // node "A" is nested deep inside a wide container "outerA" (which also holds the chain
+        // A -> mid -> mid2); it connects to "B" inside "outerB". Because "outerA" is much wider
+        // than the gap between the containers, the edge's geometric midpoint falls on top of
+        // "outerA" — but ELK places the label center in the middle of the *free space* between
+        // the two outer nodes. This locks in that behavior, which the engine-agnostic fix relies
+        // on (it projects the label center onto the edge, keeping it in the gap).
+        const withLabel = (id: string, text: string, w: number, h: number, lw: number, children: any[] = []): SNode => (<SNode>{
+            type: 'node', id, size: { width: w, height: h },
+            children: [<SLabel>{ type: 'label:node', id: `${id}_label`, text, size: { width: lw, height: 12 } }, ...children]
+        });
+
+        const graph: SGraph = {
+            type: 'graph',
+            id: 'graph',
+            children: [
+                withLabel('outerA', 'Outer A', 60, 60, 50, [
+                    withLabel('innerA', 'A', 40, 40, 10),
+                    withLabel('midA', 'mid', 40, 40, 20),
+                    withLabel('mid2A', 'mid2', 40, 40, 24),
+                    <SEdge>{ type: 'edge', id: 'ia_ma', sourceId: 'innerA', targetId: 'midA' },
+                    <SEdge>{ type: 'edge', id: 'ma_m2a', sourceId: 'midA', targetId: 'mid2A' }
+                ]),
+                withLabel('outerB', 'Outer B', 60, 60, 50, [
+                    withLabel('innerB', 'B', 40, 40, 10)
+                ]),
+                <SEdge>{
+                    type: 'edge',
+                    id: 'edge0',
+                    sourceId: 'innerA',
+                    targetId: 'innerB',
+                    children: [
+                        <SLabel>{ type: 'label:edge', id: 'edge0_label', text: 'A -> B', size: { width: 40, height: 12 } }
+                    ]
+                }
+            ]
+        };
+
+        const container = new Container();
+        container.load(elkLayoutModule);
+        container.bind(ElkFactory).toConstantValue(() => new ElkConstructor({ algorithms: ['layered'] }));
+        container.rebind(ILayoutConfigurator).to(NestedLayoutConfigurator).inSingletonScope();
+        const elkEngine = container.get(ElkLayoutEngine);
+        const result = await elkEngine.layout(graph) as SGraph;
+
+        const outerA = result.children!.find(c => c.id === 'outerA') as SNode;
+        const outerB = result.children!.find(c => c.id === 'outerB') as SNode;
+        const edge = result.children!.find(c => c.id === 'edge0') as SEdge;
+        const label = edge.children!.find(c => c.id === 'edge0_label') as SLabel;
+
+        // outerA, outerB and the edge (with its label) are all direct children of the root graph,
+        // so their positions share the same coordinate system.
+        const outerARight = outerA.position!.x + outerA.size!.width;
+        const outerBLeft = outerB.position!.x;
+        const labelCenterX = label.position!.x + label.size!.width / 2;
+        const midpointX = arcLengthMidpointX(edge.routingPoints!);
+
+        // The label center sits in the free gap between the two outer nodes ...
+        expect(labelCenterX).to.be.greaterThan(outerARight);
+        expect(labelCenterX).to.be.lessThan(outerBLeft);
+        // ... and clearly not at the edge's geometric midpoint, which is pulled left over outerA.
+        expect(midpointX).to.be.lessThan(labelCenterX);
+        expect(midpointX).to.be.lessThan(outerARight);
     });
 
     it('considers compartments for padding', async () => {

--- a/packages/sprotty/src/features/edge-layout/edge-layout.spec.tsx
+++ b/packages/sprotty/src/features/edge-layout/edge-layout.spec.tsx
@@ -1,0 +1,193 @@
+/********************************************************************************
+ * Copyright (c) 2024 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/** @jsx svg */
+import { svg } from '../../lib/jsx';
+
+import 'reflect-metadata';
+import { expect, describe, it } from 'vitest';
+import { VNode } from 'snabbdom';
+import { Bounds, Point, toDegrees } from 'sprotty-protocol/lib/utils/geometry';
+import { createFeatureSet } from '../../base/model/smodel-factory';
+import { SEdgeImpl, SGraphImpl, SLabelImpl } from '../../graph/sgraph';
+import { moveFeature } from '../move/model';
+import { EdgeLayoutPostprocessor } from './edge-layout';
+
+/**
+ * A minimal stand-in for an edge router. The real routers are covered by their own specs;
+ * here we stub the geometry so the tests exercise only the postprocessor's decision logic
+ * (branch selection + transform assembly), with fully predictable numbers.
+ */
+interface FakeRouterOverrides {
+    pointAt?: () => Point;
+    derivativeAt?: () => Point;
+    findOrthogonalIntersection?: (edge: unknown, point: Point) => { point: Point, derivative: Point } | undefined;
+}
+
+function fakeRouter(overrides: FakeRouterOverrides = {}) {
+    return {
+        kind: 'polyline',
+        // default: the edge midpoint is (100, 50) and the edge runs horizontally
+        pointAt: overrides.pointAt ?? (() => ({ x: 100, y: 50 })),
+        derivativeAt: overrides.derivativeAt ?? (() => ({ x: 1, y: 0 })),
+        // default projection keeps the x of the queried point and snaps y to the edge line (50)
+        findOrthogonalIntersection: overrides.findOrthogonalIntersection
+            ?? ((_edge: unknown, p: Point) => ({ point: { x: p.x, y: 50 }, derivative: { x: 1, y: 0 } }))
+    };
+}
+
+function createPostprocessor(router: ReturnType<typeof fakeRouter>): EdgeLayoutPostprocessor {
+    const pp = new EdgeLayoutPostprocessor();
+    (pp as any).edgeRouterRegistry = { get: () => router };
+    (pp as any).logger = { error: () => { /* silence */ } };
+    return pp;
+}
+
+interface LabelOptions {
+    edgePlacement?: any;
+    moveable?: boolean;
+}
+
+function createLabel(bounds: Bounds, opts: LabelOptions = {}): SLabelImpl {
+    // A root is needed so add() can register elements in the model index.
+    const graph = new SGraphImpl();
+    graph.id = 'graph';
+    const edge = new SEdgeImpl();
+    edge.id = 'edge0';
+    graph.add(edge);
+
+    const label = new SLabelImpl();
+    label.id = 'edge0_label';
+    label.features = createFeatureSet(
+        SLabelImpl.DEFAULT_FEATURES,
+        opts.moveable ? { enable: [moveFeature] } : undefined
+    );
+    label.bounds = bounds;
+    if (opts.edgePlacement) {
+        label.edgePlacement = opts.edgePlacement;
+    } else {
+        // Guarantee `'edgePlacement' in label` is false regardless of class-field emit,
+        // so checkEdgePlacement() is deterministic across tsc/esbuild.
+        delete (label as any).edgePlacement;
+    }
+    edge.add(label);
+    return label;
+}
+
+function decorateTransform(label: SLabelImpl, router: ReturnType<typeof fakeRouter>): string {
+    const vnode = <g /> as any as VNode;
+    createPostprocessor(router).decorate(vnode, label);
+    return (vnode.data?.attrs?.transform as string ?? '').trim();
+}
+
+describe('EdgeLayoutPostprocessor', () => {
+
+    describe('no explicit edgePlacement, not moveable', () => {
+
+        it('places a label whose position is the origin at the point on the edge (default midpoint)', () => {
+            // position (0,0) => "unpositioned" => fall back to the previous behaviour.
+            const label = createLabel({ x: 0, y: 0, width: 80, height: 16 });
+            const transform = decorateTransform(label, fakeRouter());
+            expect(transform).to.equal('translate(100, 50)');
+        });
+
+        it('honors an engine-assigned absolute position by projecting the label center onto the edge (#514)', () => {
+            // center = (90 + 40, 40 + 8) = (130, 48); projected onto the edge => (130, 50).
+            const label = createLabel({ x: 90, y: 40, width: 80, height: 16 });
+            const transform = decorateTransform(label, fakeRouter());
+            expect(transform).to.equal('translate(130, 50) rotate(0) translate(-40, 7)');
+        });
+
+        it('rotates the label according to the edge direction at the projected point', () => {
+            // A diagonal edge derivative (1,1) => a 45° tangent.
+            const router = fakeRouter({
+                findOrthogonalIntersection: () => ({ point: { x: 130, y: 50 }, derivative: { x: 1, y: 1 } })
+            });
+            const label = createLabel({ x: 90, y: 40, width: 80, height: 16 });
+            const angle = toDegrees(Math.atan2(1, 1));
+            const transform = decorateTransform(label, router);
+            expect(transform).to.equal(`translate(130, 50) rotate(${angle}) translate(-40, 7)`);
+        });
+
+        it('anchors the label at the projected position in the free space, not the geometric edge midpoint (nested nodes, #514)', () => {
+            // Mirrors the nested-nodes case: the geometric midpoint (pointAt) is pulled left,
+            // "over" the outer node, while the engine placed the label center further along, in
+            // the free space between the outer nodes. The fix must anchor at the projection of
+            // the label center, NOT at the midpoint.
+            const router = fakeRouter({
+                pointAt: () => ({ x: 170, y: 100 }), // geometric midpoint, "over Outer A"
+                findOrthogonalIntersection: (_edge: unknown, p: Point) => ({ point: { x: p.x, y: 103 }, derivative: { x: 1, y: 0 } })
+            });
+            // center = (211 + 20, 90 + 8) = (231, 98); projected onto the edge => (231, 103).
+            const label = createLabel({ x: 211, y: 90, width: 40, height: 16 });
+            const transform = decorateTransform(label, router);
+            expect(transform).to.equal('translate(231, 103) rotate(0) translate(-20, 7)');
+            // Explicitly: anchored in the free space (231), not at the geometric midpoint (170).
+            expect(transform).to.contain('translate(231, 103)');
+            expect(transform).to.not.contain('170');
+        });
+
+        it('does NOT project when only the size is set but the position is the origin', () => {
+            // Guards the sentinel: the trigger tests the corner (position), not the center.
+            // If the projection path were taken, this fake would throw.
+            const router = fakeRouter({
+                findOrthogonalIntersection: () => { throw new Error('should not project an unpositioned label'); }
+            });
+            const label = createLabel({ x: 0, y: 0, width: 80, height: 16 });
+            const transform = decorateTransform(label, router);
+            expect(transform).to.equal('translate(100, 50)');
+        });
+    });
+
+    describe('no explicit edgePlacement, moveable', () => {
+
+        it('keeps the freely-movable behavior (point on edge + bounds offset), without projection', () => {
+            const router = fakeRouter({
+                findOrthogonalIntersection: () => { throw new Error('moveable labels must not be projected'); }
+            });
+            const label = createLabel({ x: 90, y: 40, width: 80, height: 16 }, { moveable: true });
+            const transform = decorateTransform(label, router);
+            // (100 + 90, 50 + 40)
+            expect(transform).to.equal('translate(190, 90)');
+        });
+    });
+
+    describe('explicit edgePlacement (behavior must be unchanged by the refactor)', () => {
+
+        const placement = (moveMode: 'none' | 'free' | 'edge') =>
+            ({ position: 0.5, side: 'top', offset: 7, rotate: true, moveMode });
+
+        it('moveMode "none": positions at the point on the edge and applies rotation/alignment', () => {
+            const label = createLabel({ x: 90, y: 40, width: 80, height: 16 }, { edgePlacement: placement('none') });
+            const transform = decorateTransform(label, fakeRouter());
+            expect(transform).to.equal('translate(100, 50) rotate(0) translate(-40, 7)');
+        });
+
+        it('moveMode "free": adds the bounds offset to the point on the edge, then rotation/alignment', () => {
+            const label = createLabel({ x: 90, y: 40, width: 80, height: 16 }, { edgePlacement: placement('free') });
+            const transform = decorateTransform(label, fakeRouter());
+            // (100 + 90, 50 + 40)
+            expect(transform).to.equal('translate(190, 90) rotate(0) translate(-40, 7)');
+        });
+
+        it('moveMode "edge": snaps to the orthogonal intersection on the edge, then rotation/alignment', () => {
+            const label = createLabel({ x: 90, y: 40, width: 80, height: 16 }, { edgePlacement: placement('edge') });
+            // findOrthogonalIntersection is called with (pointOnEdge + bounds) = (190, 90) => x kept, y snapped to 50.
+            const transform = decorateTransform(label, fakeRouter());
+            expect(transform).to.equal('translate(190, 50) rotate(0) translate(-40, 7)');
+        });
+    });
+});

--- a/packages/sprotty/src/features/edge-layout/edge-layout.ts
+++ b/packages/sprotty/src/features/edge-layout/edge-layout.ts
@@ -79,34 +79,29 @@ export class EdgeLayoutPostprocessor implements IVNodePostprocessor {
                                 this.logger.error({}, 'No moveMode set for edge label. Skipping edge placement.');
                                 break;
                         }
-                        if (derivativeOnEdge) {
-                            const angle = toDegrees(Math.atan2(derivativeOnEdge.y, derivativeOnEdge.x));
-                            if (placement.rotate) {
-                                let flippedAngle = angle;
-                                // Flip angle if it exceeds 90 degrees
-                                if (Math.abs(angle) > 90) {
-                                    if (angle < 0)
-                                        flippedAngle += 180;
-                                    else if (angle > 0)
-                                        flippedAngle -= 180;
-                                }
-                                transform += ` rotate(${flippedAngle})`;
-                                // Get rotated alignment based on flipped angle
-                                const alignment = this.getRotatedAlignment(element, placement, flippedAngle !== angle);
-                                transform += ` translate(${alignment.x}, ${alignment.y})`;
-                            } else {
-                                // Get alignment based on angle
-                                const alignment = this.getAlignment(element, placement, angle);
-                                transform += ` translate(${alignment.x}, ${alignment.y})`;
-                            }
-                        }
+
+                        transform += this.applyRotationAndAlignment(derivativeOnEdge, placement, element);
                     } else {
                         // if the element is moveable and no placement is specified, the label is freely movable (i.e. moveMode = 'free').
                         // Otherwise it is fixed to its position (i.e. moveMode = 'none').
                         if (isMoveable(element)) {
-                            transform += `translate(${(pointOnEdge?.x ?? 0) + actualBounds.x}, ${(pointOnEdge?.y ?? 0) + actualBounds.y})`;;
+                            transform += ` translate(${(pointOnEdge?.x ?? 0) + actualBounds.x}, ${(pointOnEdge?.y ?? 0) + actualBounds.y})`;;
                         } else {
-                            transform += `translate(${pointOnEdge.x}, ${pointOnEdge.y})`;
+                            const hasAbsolutePosition = actualBounds.x !== 0 || actualBounds.y !== 0;
+                            if (hasAbsolutePosition) {
+                                const center = {
+                                    x: actualBounds.x + actualBounds.width / 2,
+                                    y: actualBounds.y + actualBounds.height / 2
+                                };
+                                const orthogonal = router.findOrthogonalIntersection(edge, center);
+                                if (orthogonal) {
+                                    transform += ` translate(${orthogonal.point.x}, ${orthogonal.point.y})`;
+                                    derivativeOnEdge = orthogonal.derivative;
+                                }
+                                transform += this.applyRotationAndAlignment(derivativeOnEdge, placement, element);
+                            } else {
+                                transform += ` translate(${pointOnEdge.x}, ${pointOnEdge.y})`;
+                            }
                         }
                     }
                 }
@@ -260,6 +255,33 @@ export class EdgeLayoutPostprocessor implements IVNodePostprocessor {
 
     protected linearFlip(p0: Point, p1: Point, p2: Point, p3: Point, position: number) {
         return position < 0.5 ? Point.linear(p0, p1, 2 * position) : Point.linear(p2, p3, 2 * position - 1);
+    }
+
+    protected applyRotationAndAlignment(derivativeOnEdge: Point | undefined, placement: EdgePlacement, element: EdgeLayoutable & SModelElementImpl & InternalBoundsAware): string  {
+        let transform: string = "";
+        if (!derivativeOnEdge) {
+            return transform;
+        }
+        const angle = toDegrees(Math.atan2(derivativeOnEdge.y, derivativeOnEdge.x));
+        if (placement.rotate) {
+            let flippedAngle = angle;
+            // Flip angle if it exceeds 90 degrees
+            if (Math.abs(angle) > 90) {
+                if (angle < 0)
+                    flippedAngle += 180;
+                else if (angle > 0)
+                    flippedAngle -= 180;
+            }
+            transform += ` rotate(${flippedAngle})`;
+            // Get rotated alignment based on flipped angle
+            const alignment = this.getRotatedAlignment(element, placement, flippedAngle !== angle);
+            transform += ` translate(${alignment.x}, ${alignment.y})`;
+        } else {
+            // Get alignment based on angle
+            const alignment = this.getAlignment(element, placement, angle);
+            transform += ` translate(${alignment.x}, ${alignment.y})`;
+        }
+        return transform;
     }
 
     postUpdate(): void {}


### PR DESCRIPTION
## Summary

Fixes #514: edge labels positioned by a layout engine (e.g. ELK) were being
re-placed at the edge's geometric midpoint at render time, ignoring the
engine's coordinates.

`EdgeLayoutPostprocessor` now honors an engine-assigned position: when a
non-moveable edge label with no explicit `edgePlacement` carries a non-origin
position, its center is projected onto the edge (deriving the anchor and
tangent) and the existing rotation/alignment pipeline is applied. Labels that
were never positioned still fall back to the previous midpoint behavior.

The change is **engine-agnostic** (it reads the label's own model position, with
no dependency on `sprotty-elk`) and preserves rotation and edge-binding, as
requested in the review.

## Changes

- `packages/sprotty/src/features/edge-layout/edge-layout.ts`: project the label
  center onto the edge for engine-positioned labels; extract the shared
  `applyRotationAndAlignment` helper.

## Tests

- Unit tests for `EdgeLayoutPostprocessor` covering the fix, the no-regression
  paths (unpositioned/moveable/explicit `edgePlacement`), the origin sentinel,
  and the nested-nodes "free space" case.
- ELK integration tests asserting the engine assigns a non-origin position to an
  edge label, including a nested-nodes scenario where the label lands in the free
  space between containers rather than at the edge midpoint.
